### PR TITLE
Changed cake wallet remote nodes addresses and credentials

### DIFF
--- a/assets/node_list.yml
+++ b/assets/node_list.yml
@@ -2,14 +2,10 @@
   uri: xmr-node-uk.cakewallet.com:18081
   is_default: true
 -
-  uri: eu-node.cakewallet.io:18081
-  login: cake
-  password: public_node
+  uri: xmr-node-eu.cakewallet.com:18081
   is_default: false
 -
-  uri: node.cakewallet.io:18081
-  login: cake
-  password: public_node
+  uri: xmr-node-usa-east.cakewallet.com:18081
   is_default: false
 -
   uri: node.moneroworld.com:18089

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -80,7 +80,8 @@ void main() async {
       sharedPreferences: sharedPreferences,
       walletListService: walletListService,
       nodes: nodes,
-      authStore: authenticationStore);
+      authStore: authenticationStore,
+      initialMigrationVersion: 2);
 
   final settingsStore = await SettingsStoreBase.load(
       nodes: nodes,

--- a/lib/src/domain/common/default_settings_migration.dart
+++ b/lib/src/domain/common/default_settings_migration.dart
@@ -19,28 +19,104 @@ Future defaultSettingsMigration(
     return;
   }
 
-  try {
-    switch (version) {
-      case 1:
-        await sharedPreferences.setString(
-            'current_fiat_currency', FiatCurrency.usd.toString());
-        await sharedPreferences.setInt(
-            'current_fee_priority', TransactionPriority.standart.raw);
-        await sharedPreferences.setInt('current_balance_display_mode',
-            BalanceDisplayMode.availableBalance.raw);
-        await sharedPreferences.setInt(
-            'current_default_settings_migration_version', 1);
-        await sharedPreferences.setBool('save_recipient_address', false);
-        await resetToDefault(nodes);
-        await sharedPreferences.setInt('current_node_id', 0);
-        break;
-      default:
-        break;
+  final migrationVersionsLength = version - currentVersion;
+  final migrationVersions = List<int>.generate(
+      migrationVersionsLength, (i) => currentVersion + (i + 1));
+
+  await Future.forEach(migrationVersions, (int version) async {
+    try {
+      switch (version) {
+        case 1:
+          await sharedPreferences.setString(
+              'current_fiat_currency', FiatCurrency.usd.toString());
+          await sharedPreferences.setInt(
+              'current_fee_priority', TransactionPriority.standart.raw);
+          await sharedPreferences.setInt('current_balance_display_mode',
+              BalanceDisplayMode.availableBalance.raw);
+          await sharedPreferences.setBool('save_recipient_address', false);
+          await resetToDefault(nodes);
+          await changeCurrentNodeToDefault(
+              sharedPreferences: sharedPreferences, nodes: nodes);
+
+          break;
+        case 2:
+          await replaceNodesMigration(nodes: nodes);
+          await replaceDefaultNode(
+              sharedPreferences: sharedPreferences, nodes: nodes);
+
+          break;
+        default:
+          break;
+      }
+
+      await sharedPreferences.setInt(
+          'current_default_settings_migration_version', version);
+    } catch (e) {
+      print('Migration error: ${e.toString()}');
     }
-  } catch (e) {
-    print('Migration error: ${e.toString()}');
-  }
+  });
 
   await sharedPreferences.setInt(
       'current_default_settings_migration_version', version);
+}
+
+Future<void> replaceNodesMigration({@required Box<Node> nodes}) async {
+  final replaceNodes = <String, Node>{
+    'eu-node.cakewallet.io:18081':
+        Node(uri: 'xmr-node-eu.cakewallet.com:18081'),
+    'node.cakewallet.io:18081':
+        Node(uri: 'xmr-node-usa-east.cakewallet.com:18081')
+  };
+
+  nodes.values.forEach((Node node) async {
+    final nodeToReplace = replaceNodes[node.uri];
+
+    if (nodeToReplace != null) {
+      node.uri = nodeToReplace.uri;
+      node.login = nodeToReplace.login;
+      node.password = nodeToReplace.password;
+      await node.save();
+    }
+  });
+}
+
+Future<void> changeCurrentNodeToDefault(
+    {@required SharedPreferences sharedPreferences,
+    @required Box<Node> nodes}) async {
+  final timeZone = DateTime.now().timeZoneOffset.inHours;
+  String nodeUri = '';
+
+  if (timeZone >= 1) { // Eurasia
+    nodeUri = 'xmr-node-eu.cakewallet.com:18081';
+  } else if (timeZone <= -4) { // America
+    nodeUri = 'xmr-node-usa-east.cakewallet.com:18081';
+  }
+
+  final node = nodes.values.firstWhere((Node node) => node.uri == nodeUri) ??
+      nodes.values.first;
+  final nodeId = node != null ? node.key as int : 0; // 0 - England
+
+  await sharedPreferences.setInt('current_node_id', nodeId);
+}
+
+Future<void> replaceDefaultNode(
+    {@required SharedPreferences sharedPreferences,
+    @required Box<Node> nodes}) async {
+  const nodesForReplace = <String>[
+    'xmr-node-uk.cakewallet.com:18081',
+    'eu-node.cakewallet.io:18081',
+    'node.cakewallet.io:18081'
+  ];
+  final currentNodeId = sharedPreferences.getInt('current_node_id');
+  final currentNode =
+      nodes.values.firstWhere((Node node) => node.key == currentNodeId);
+  final needToReplace =
+      currentNode == null ? true : nodesForReplace.contains(currentNode.uri);
+
+  if (!needToReplace) {
+    return;
+  }
+
+  await changeCurrentNodeToDefault(
+      sharedPreferences: sharedPreferences, nodes: nodes);
 }

--- a/lib/src/domain/common/node_list.dart
+++ b/lib/src/domain/common/node_list.dart
@@ -5,9 +5,15 @@ import 'package:cake_wallet/src/domain/common/node.dart';
 
 Future<List<Node>> loadDefaultNodes() async {
   final nodesRaw = await rootBundle.loadString('assets/node_list.yml');
-  final nodes = loadYaml(nodesRaw) as List<Map<dynamic, dynamic>>;
-  
-  return nodes.map((raw) => Node.fromMap(raw)).toList();
+  final nodes = loadYaml(nodesRaw) as YamlList;
+
+  return nodes.map((dynamic raw) {
+    if (raw is Map) {
+      return Node.fromMap(raw);
+    }
+
+    return null;
+  }).toList();
 }
 
 Future resetToDefault(Box<Node> nodeSource) async {


### PR DESCRIPTION
Replaced eu-node.cakewallet.io by xmr-node-eu.cakewallet.com and node cakewallet.io by xmr-node-usa-east.cakewallet.com in remote nodes list. Added migration for change current remote node if user use old eu or usa remote node by new addresses. Changed way for set default remote node for initial setup by base on current user time zone.