### PR TITLE
Fix validation for Beech32 encoded BTC address

### DIFF
--- a/lib/src/stores/address_book/address_book_store.dart
+++ b/lib/src/stores/address_book/address_book_store.dart
@@ -65,7 +65,7 @@ abstract class AddressBookStoreBase with Store {
           isValid = (value.length == 42);
           break;
         case CryptoCurrency.btc:
-          isValid = (value.length == 34)||(value.length == 42);
+          isValid = (value.length == 34)||(value.length == 42)||(value.length == 62);
           break;
         case CryptoCurrency.dash:
           isValid = (value.length == 34);

--- a/lib/src/stores/exchange/exchange_store.dart
+++ b/lib/src/stores/exchange/exchange_store.dart
@@ -289,7 +289,7 @@ abstract class ExchangeStoreBase with Store {
           isValid = (value.length == 42);
           break;
         case CryptoCurrency.btc:
-          isValid = (value.length == 34)||(value.length == 42);
+          isValid = (value.length == 34)||(value.length == 42)||(value.length == 62);
           break;
         case CryptoCurrency.dash:
           isValid = (value.length == 34);

--- a/lib/src/stores/send/send_store.dart
+++ b/lib/src/stores/send/send_store.dart
@@ -188,7 +188,7 @@ abstract class SendStoreBase with Store {
           isValid = (value.length == 42);
           break;
         case CryptoCurrency.btc:
-          isValid = (value.length == 34)||(value.length == 42);
+          isValid = (value.length == 34)||(value.length == 42)||(value.length == 62);
           break;
         case CryptoCurrency.dash:
           isValid = (value.length == 34);

--- a/lib/src/stores/wallet_restoration/wallet_restoration_store.dart
+++ b/lib/src/stores/wallet_restoration/wallet_restoration_store.dart
@@ -137,7 +137,7 @@ abstract class WalleRestorationStoreBase with Store {
           isValid = (value.length == 42);
           break;
         case CryptoCurrency.btc:
-          isValid = (value.length == 34)||(value.length == 42);
+          isValid = (value.length == 34)||(value.length == 42)||(value.length == 62);
           break;
         case CryptoCurrency.dash:
           isValid = (value.length == 34);


### PR DESCRIPTION
Beech32 encoded BTC address may have a length of 62 characters, which is used by several apps, e.g. Bitwala.

For reference see:
https://en.bitcoin.it/wiki/BIP_0173#Segwit_address_format