### PR TITLE
soft keyboard dismisses when generate-name icon is pressed

### DIFF
--- a/lib/src/screens/new_wallet/new_wallet_page.dart
+++ b/lib/src/screens/new_wallet/new_wallet_page.dart
@@ -105,18 +105,50 @@ class _WalletNameFormState extends State<WalletNameForm> {
               padding: EdgeInsets.only(top: 24),
               child: Form(
                 key: _formKey,
-                child: TextFormField(
-                  onChanged: (value) => _walletNewVM.name = value,
-                  controller: _controller,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                      fontSize: 20.0,
-                      fontWeight: FontWeight.w600,
-                      color: Theme.of(context).primaryTextTheme.title.color),
-                  decoration: InputDecoration(
-                    suffixIcon: IconButton(
+                child: Stack(
+                  alignment: Alignment.centerRight,
+                  children: [
+                    TextFormField(
+                      onChanged: (value) => _walletNewVM.name = value,
+                      controller: _controller,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                          fontSize: 20.0,
+                          fontWeight: FontWeight.w600,
+                          color:
+                              Theme.of(context).primaryTextTheme.title.color),
+                      decoration: InputDecoration(
+                        hintStyle: TextStyle(
+                            fontSize: 18.0,
+                            fontWeight: FontWeight.w500,
+                            color: Theme.of(context)
+                                .accentTextTheme
+                                .display3
+                                .color),
+                        hintText: S.of(context).wallet_name,
+                        focusedBorder: UnderlineInputBorder(
+                            borderSide: BorderSide(
+                                color: Theme.of(context)
+                                    .accentTextTheme
+                                    .display3
+                                    .decorationColor,
+                                width: 1.0)),
+                        enabledBorder: UnderlineInputBorder(
+                          borderSide: BorderSide(
+                              color: Theme.of(context)
+                                  .accentTextTheme
+                                  .display3
+                                  .decorationColor,
+                              width: 1.0),
+                        ),
+                      ),
+                      validator: WalletNameValidator(),
+                    ),
+                    IconButton(
                       onPressed: () async {
                         final rName = await generateName();
+                        FocusManager.instance.primaryFocus?.unfocus();
+
                         setState(() {
                           _controller.text = rName;
                           _walletNewVM.name = rName;
@@ -141,29 +173,7 @@ class _WalletNameFormState extends State<WalletNameForm> {
                         ),
                       ),
                     ),
-                    hintStyle: TextStyle(
-                        fontSize: 18.0,
-                        fontWeight: FontWeight.w500,
-                        color:
-                            Theme.of(context).accentTextTheme.display3.color),
-                    hintText: S.of(context).wallet_name,
-                    focusedBorder: UnderlineInputBorder(
-                        borderSide: BorderSide(
-                            color: Theme.of(context)
-                                .accentTextTheme
-                                .display3
-                                .decorationColor,
-                            width: 1.0)),
-                    enabledBorder: UnderlineInputBorder(
-                      borderSide: BorderSide(
-                          color: Theme.of(context)
-                              .accentTextTheme
-                              .display3
-                              .decorationColor,
-                          width: 1.0),
-                    ),
-                  ),
-                  validator: WalletNameValidator(),
+                  ],
                 ),
               ),
             ),

--- a/lib/src/screens/restore/wallet_restore_from_keys_form.dart
+++ b/lib/src/screens/restore/wallet_restore_from_keys_form.dart
@@ -37,13 +37,6 @@ class WalletRestoreFromKeysFromState extends State<WalletRestoreFromKeysFrom> {
   final TextEditingController viewKeyController;
   final TextEditingController spendKeyController;
   final TextEditingController nameTextEditingController;
-  bool buttonPressed;
-
-  @override
-  void initState() {
-    super.initState();
-    buttonPressed = false;
-  }
 
   @override
   void dispose() {

--- a/lib/src/screens/restore/wallet_restore_from_keys_form.dart
+++ b/lib/src/screens/restore/wallet_restore_from_keys_form.dart
@@ -37,6 +37,13 @@ class WalletRestoreFromKeysFromState extends State<WalletRestoreFromKeysFrom> {
   final TextEditingController viewKeyController;
   final TextEditingController spendKeyController;
   final TextEditingController nameTextEditingController;
+  bool buttonPressed;
+
+  @override
+  void initState() {
+    super.initState();
+    buttonPressed = false;
+  }
 
   @override
   void dispose() {
@@ -54,17 +61,19 @@ class WalletRestoreFromKeysFromState extends State<WalletRestoreFromKeysFrom> {
         child: Form(
           key: formKey,
           child: Column(children: <Widget>[
-            BaseTextFormField(
-              controller: nameTextEditingController,
-              hintText: S.of(context).wallet_name,
-              validator: WalletNameValidator(),
-              suffixIcon: Container(
-                width: 12,
-                height: 14,
-                margin: const EdgeInsets.only(bottom: 15, left: 13),
-                child: InkWell(
-                  onTap: () async {
+            Stack(
+              alignment: Alignment.centerRight,
+              children: [
+                BaseTextFormField(
+                  controller: nameTextEditingController,
+                  hintText: S.of(context).wallet_name,
+                  validator: WalletNameValidator(),
+                ),
+                IconButton(
+                  onPressed: () async {
                     final rName = await generateName();
+                    FocusManager.instance.primaryFocus?.unfocus();
+
                     setState(() {
                       nameTextEditingController.text = rName;
                       nameTextEditingController.selection =
@@ -72,18 +81,24 @@ class WalletRestoreFromKeysFromState extends State<WalletRestoreFromKeysFrom> {
                               offset: nameTextEditingController.text.length));
                     });
                   },
-                  child: Container(
-                      padding: EdgeInsets.all(8),
-                      decoration: BoxDecoration(
-                          color: Theme.of(context).hintColor,
-                          borderRadius: BorderRadius.all(Radius.circular(6))),
-                      child: Image.asset('assets/images/refresh_icon.png',
-                          color: Theme.of(context)
-                              .primaryTextTheme
-                              .display1
-                              .decorationColor)),
+                  icon: Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(6.0),
+                      color: Theme.of(context).hintColor,
+                    ),
+                    width: 34,
+                    height: 34,
+                    child: Image.asset(
+                      'assets/images/refresh_icon.png',
+                      color: Theme.of(context)
+                          .primaryTextTheme
+                          .display1
+                          .decorationColor,
+                    ),
+                  ),
                 ),
-              ),
+              ],
             ),
             Container(height: 20),
             BaseTextFormField(

--- a/lib/src/screens/restore/wallet_restore_from_seed_form.dart
+++ b/lib/src/screens/restore/wallet_restore_from_seed_form.dart
@@ -61,36 +61,42 @@ class WalletRestoreFromSeedFormState extends State<WalletRestoreFromSeedForm> {
     return Container(
         padding: EdgeInsets.only(left: 24, right: 24),
         child: Column(children: [
-          BaseTextFormField(
-            controller: nameTextEditingController,
-            hintText: S.of(context).wallet_name,
-            validator: WalletNameValidator(),
-            suffixIcon: Container(
-              width: 12,
-              height: 14,
-              margin: const EdgeInsets.only(bottom: 15, left: 13),
-              child: InkWell(
-                onTap: () async {
-                  final rName = await generateName();
-                  setState(() {
-                    nameTextEditingController.text = rName;
-                    nameTextEditingController.selection =
-                        TextSelection.fromPosition(TextPosition(
-                            offset: nameTextEditingController.text.length));
-                  });
-                },
-                child: Container(
-                    padding: EdgeInsets.all(8),
-                    decoration: BoxDecoration(
-                        color: Theme.of(context).hintColor,
-                        borderRadius: BorderRadius.all(Radius.circular(6))),
-                    child: Image.asset('assets/images/refresh_icon.png',
-                        color: Theme.of(context)
-                            .primaryTextTheme
-                            .display1
-                            .decorationColor)),
+          Stack(
+            alignment: Alignment.centerRight,
+            children: [
+              BaseTextFormField(
+                controller: nameTextEditingController,
+                hintText: S.of(context).wallet_name,
+                validator: WalletNameValidator(),
               ),
-            ),
+              Container(
+                width: 34,
+                height: 34,
+                margin: const EdgeInsets.only(bottom: 15, left: 13),
+                child: InkWell(
+                  onTap: () async {
+                    final rName = await generateName();
+                    FocusManager.instance.primaryFocus?.unfocus();
+                    setState(() {
+                      nameTextEditingController.text = rName;
+                      nameTextEditingController.selection =
+                          TextSelection.fromPosition(TextPosition(
+                              offset: nameTextEditingController.text.length));
+                    });
+                  },
+                  child: Container(
+                      padding: EdgeInsets.all(8),
+                      decoration: BoxDecoration(
+                          color: Theme.of(context).hintColor,
+                          borderRadius: BorderRadius.all(Radius.circular(6))),
+                      child: Image.asset('assets/images/refresh_icon.png',
+                          color: Theme.of(context)
+                              .primaryTextTheme
+                              .display1
+                              .decorationColor)),
+                ),
+              ),
+            ],
           ),
           Container(height: 20),
           SeedWidget(


### PR DESCRIPTION
@mkyq , I have added the dismissable-keyboard property to generate-name button. The keyboard was not getting dismissed completely because the button resided inside the TextFormField and so onPress method of the button also triggered the focus on TextFormField and thus invoked the onTap method on TextFormField. However, I have tackled it using Stack to separate the onTap and onPress triggering each other. 