### PR TITLE
Fixed the render flex error caused by menu widget title in monero wallet

### DIFF
--- a/lib/src/screens/dashboard/widgets/menu_widget.dart
+++ b/lib/src/screens/dashboard/widgets/menu_widget.dart
@@ -131,9 +131,8 @@ class MenuWidgetState extends State<MenuWidget> {
                               children: <Widget>[
                                 _iconFor(type: widget.dashboardViewModel.type),
                                 SizedBox(width: 12),
-                                Expanded(
+                                SingleChildScrollView(
                                     child: Container(
-                                  height: 42,
                                   child: Column(
                                     crossAxisAlignment:
                                         CrossAxisAlignment.start,


### PR DESCRIPTION
This is a bug I discovered using the app. It was not assigned as a task. This is why it has no branch name like "'CW-number". Approved by our CTO. 

