### PR TITLE
Select sub address or standard address instead of both.

### DIFF
--- a/lib/core/yat_service.dart
+++ b/lib/core/yat_service.dart
@@ -25,23 +25,25 @@ class YatService {
   Future<List<YatRecord>> fetchYatAddress(String emojiId, String ticker) async {
     final formattedTicker = ticker.toUpperCase();
     final formattedEmojiId = emojiId.replaceAll(' ', '');
+    final tag = tags[formattedTicker];
     final uri = Uri.parse(lookupEmojiUrl(formattedEmojiId)).replace(
         queryParameters: <String, dynamic>{
-          "tags": tags[formattedTicker]
+          "tags": tag
         });
-
     final yatRecords = <YatRecord>[];
 
     try {
       final response = await get(uri);
       final resBody = json.decode(response.body) as Map<String, dynamic>;
-
       final results = resBody["result"] as Map<dynamic, dynamic>;
-   
       // Favour a subaddress over a standard address.
-      final yatRecord = results[MONERO_SUB_ADDRESS] ?? results[MONERO_STD_ADDRESS];
+      final yatRecord = (
+        results[MONERO_SUB_ADDRESS] ??
+        results[MONERO_STD_ADDRESS] ??
+        results[tag]) as Map<String, dynamic>;
+
       if (yatRecord != null) {
-        yatRecords.add(YatRecord.fromJson(yatRecord as Map<String, dynamic>))
+        yatRecords.add(YatRecord.fromJson(yatRecord));
       }
 
       return yatRecords;

--- a/lib/core/yat_service.dart
+++ b/lib/core/yat_service.dart
@@ -41,7 +41,7 @@ class YatService {
       // Favour a subaddress over a standard address.
       final yatRecord = results[MONERO_SUB_ADDRESS] ?? results[MONERO_STD_ADDRESS];
       if (yatRecord != null) {
-        yatRecords.add(YatRecord.fromJson(value as Map<String, dynamic>))
+        yatRecords.add(YatRecord.fromJson(yatRecord as Map<String, dynamic>))
       }
 
       return yatRecords;

--- a/lib/core/yat_service.dart
+++ b/lib/core/yat_service.dart
@@ -9,15 +9,17 @@ class YatService {
   static String get apiUrl =>
       YatService.isDevMode ? YatService.apiDevUrl : YatService.apiReleaseUrl;
   static const apiReleaseUrl = "https://a.y.at";
-  static const apiDevUrl = 'https://yat.fyi';
+  static const apiDevUrl = 'https://a.yat.fyi';
 
   static String lookupEmojiUrl(String emojiId) =>
       "$apiUrl/emoji_id/$emojiId/payment";
   
+  static const String MONERO_SUB_ADDRESS = '0x1002';
+  static const String MONERO_STD_ADDRESS = '0x1001';
   static const tags = {
-    'XMR': '0x1001,0x1002',
+    'XMR': "$MONERO_STD_ADDRESS,$MONERO_SUB_ADDRESS",
     'BTC': '0x1003',
-    'LTC': '0x3fff'
+    'LTC': '0x1019'
   };
 
   Future<List<YatRecord>> fetchYatAddress(String emojiId, String ticker) async {
@@ -35,9 +37,12 @@ class YatService {
       final resBody = json.decode(response.body) as Map<String, dynamic>;
 
       final results = resBody["result"] as Map<dynamic, dynamic>;
-      results.forEach((dynamic key, dynamic value) {
-        yatRecords.add(YatRecord.fromJson(value as Map<String, dynamic>));
-      });
+   
+      // Favour a subaddress over a standard address.
+      final yatRecord = results[MONERO_SUB_ADDRESS] ?? results[MONERO_STD_ADDRESS];
+      if (yatRecord != null) {
+        yatRecords.add(YatRecord.fromJson(value as Map<String, dynamic>))
+      }
 
       return yatRecords;
     } catch (_) {

--- a/lib/store/yat/yat_store.dart
+++ b/lib/store/yat/yat_store.dart
@@ -29,7 +29,7 @@ class YatLink {
   static const startFlowUrl = ''; // 'https://www.y03btrk.com/4RQSJ/6JHXF/';
   static const isDevMode = true;
   static const tags = <String, List<String>>{"XMR" : ['0x1001', '0x1002'],
-    "BTC" : ['0x1003'], "LTC" : ['0x3fff']};
+    "BTC" : ['0x1003'], "LTC" : ['0x1019']};
 
   static String get apiUrl => YatLink.isDevMode
       ? YatLink.apiDevUrl


### PR DESCRIPTION
### N.B. I don't actually have flutter installed so I didn't test this.

Just some small fixes here, the api dev url was missing the subdomain `a`.

Instead of showing both the subaddress and the standard address, choose just the sub address and if it's not available use the standard address.
