### PR TITLE
Change Haven default node

### DIFF
--- a/assets/haven_node_list.yml
+++ b/assets/haven_node_list.yml
@@ -1,6 +1,3 @@
 -
-  uri: vault.havenprotocol.org:443
-  login: super
-  password: super
-  useSSL: true
+  uri: nodes.havenprotocol.org:443
   is_default: true

--- a/lib/entities/default_settings_migration.dart
+++ b/lib/entities/default_settings_migration.dart
@@ -22,7 +22,7 @@ import 'package:encrypt/encrypt.dart' as encrypt;
 const newCakeWalletMoneroUri = 'xmr-node.cakewallet.com:18081';
 const cakeWalletBitcoinElectrumUri = 'electrum.cakewallet.com:50002';
 const cakeWalletLitecoinElectrumUri = 'ltc-electrum.cakewallet.com:50002';
-const havenDefaultNodeUri = 'vault.havenprotocol.org:443';
+const havenDefaultNodeUri = 'nodes.havenprotocol.org:443';
 
 Future defaultSettingsMigration(
     {@required int version,


### PR DESCRIPTION
Haven stopped supporting the old node: https://havenprotocol.org/knowledge/running-on-flux/

I edited in the node list and migrations files. Please test :)