### PR TITLE
Adapt error message check in backup errors

### DIFF
--- a/lib/view_model/restore_from_backup_view_model.dart
+++ b/lib/view_model/restore_from_backup_view_model.dart
@@ -64,7 +64,7 @@ abstract class RestoreFromBackupViewModelBase with Store {
     } catch (e) {
       var msg = e.toString();
 
-      if (msg == 'Message authentication code (MAC) is invalid') {
+      if (msg.toLowerCase().contains("message authentication code (mac)")) {
         msg = 'Incorrect backup password';
       }
 


### PR DESCRIPTION
there is a new error message thrown in 
`/flutter/.pub-cache/hosted/pub.dartlang.org/cryptography-2.0.5/lib/src/cryptography/mac.dart` which is
`SecretBox has wrong message authentication code (MAC)`
so I changed the condition to be more adaptable and focus on the error itself `message authentication code (MAC)`