### PR TITLE
Fix FIO send parsed Address

### DIFF
--- a/cw_haven/lib/haven_wallet.dart
+++ b/cw_haven/lib/haven_wallet.dart
@@ -187,7 +187,9 @@ abstract class HavenWalletBase extends WalletBase<MoneroBalance,
           accountIndex: walletAddresses.account!.id);
     } else {
       final output = outputs.first;
-      final address = output.address;
+      final address = output.isParsedAddress && (output.extractedAddress?.isNotEmpty ?? false)
+          ? output.extractedAddress!
+          : output.address;
       final amount = output.sendAll
           ? null
           : output.cryptoAmount!.replaceAll(',', '.');


### PR DESCRIPTION
Check if the address is parsed then create the transaction with the parsed address not the entered address