### PR TITLE
Caching Dependencies in workflow run

### DIFF
--- a/.github/workflows/cache_dependencies.yml
+++ b/.github/workflows/cache_dependencies.yml
@@ -1,0 +1,56 @@
+name: Cache Dependencies
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '8.x'
+
+      - name: Flutter action
+        uses: subosito/flutter-action@v1
+        with:
+          flutter-version: '3.3.x'
+          channel: stable
+
+      - name: Install package dependencies
+        run: sudo apt-get install -y curl unzip automake build-essential file pkg-config git python libtool libtinfo5 cmake clang
+
+      - name: Execute Build and Setup Commands
+        run: |
+          sudo mkdir -p /opt/android
+          sudo chown $USER /opt/android
+          cd /opt/android
+          git clone https://github.com/cake-tech/cake_wallet.git --branch main
+          cd cake_wallet/scripts/android/
+          ./install_ndk.sh
+          source ./app_env.sh cakewallet
+          ./app_config.sh
+
+      - name: Cache Externals
+        id: cache-externals
+        uses: actions/cache@v3
+        with:
+          path: |
+            /opt/android/cake_wallet/cw_haven/android/.cxx
+            /opt/android/cake_wallet/cw_haven/ios/External
+            /opt/android/cake_wallet/cw_monero/android/.cxx
+            /opt/android/cake_wallet/cw_monero/ios/External
+            /opt/android/cake_wallet/cw_shared_external/ios/External
+          key: ${{ hashFiles('/opt/android/cake_wallet/cw_haven/pubspec.yaml', '/opt/android/cake_wallet/cw_monero/pubspec.yaml', '/opt/android/cake_wallet/cw_shared_external/pubspec.yaml') }}
+
+      - if: ${{ steps.cache-externals.outputs.cache-hit != 'true' }}
+        name: Generate Externals
+        run: |
+          cd /opt/android/cake_wallet/scripts/android/
+          source ./app_env.sh cakewallet
+          ./build_all.sh
+          ./copy_monero_deps.sh

--- a/.github/workflows/cache_dependencies.yml
+++ b/.github/workflows/cache_dependencies.yml
@@ -45,7 +45,7 @@ jobs:
             /opt/android/cake_wallet/cw_monero/android/.cxx
             /opt/android/cake_wallet/cw_monero/ios/External
             /opt/android/cake_wallet/cw_shared_external/ios/External
-          key: ${{ hashFiles('/opt/android/cake_wallet/cw_haven/pubspec.yaml', '/opt/android/cake_wallet/cw_monero/pubspec.yaml', '/opt/android/cake_wallet/cw_shared_external/pubspec.yaml') }}
+          key: ${{ hashFiles('/opt/android/cake_wallet/scripts/android/build_monero.sh', '/opt/android/cake_wallet/scripts/android/build_haven.sh') }}
 
       - if: ${{ steps.cache-externals.outputs.cache-hit != 'true' }}
         name: Generate Externals

--- a/.github/workflows/pr_test_build.yml
+++ b/.github/workflows/pr_test_build.yml
@@ -45,7 +45,7 @@ jobs:
             /opt/android/cake_wallet/cw_monero/android/.cxx
             /opt/android/cake_wallet/cw_monero/ios/External
             /opt/android/cake_wallet/cw_shared_external/ios/External
-          key: ${{ hashFiles('/opt/android/cake_wallet/cw_haven/pubspec.yaml', '/opt/android/cake_wallet/cw_monero/pubspec.yaml', '/opt/android/cake_wallet/cw_shared_external/pubspec.yaml') }}
+          key: ${{ hashFiles('/opt/android/cake_wallet/scripts/android/build_monero.sh', '/opt/android/cake_wallet/scripts/android/build_haven.sh') }}
 
       - if: ${{ steps.cache-externals.outputs.cache-hit != 'true' }}
         name: Generate Externals

--- a/.github/workflows/pr_test_build.yml
+++ b/.github/workflows/pr_test_build.yml
@@ -45,7 +45,7 @@ jobs:
             /opt/android/cake_wallet/cw_monero/android/.cxx
             /opt/android/cake_wallet/cw_monero/ios/External
             /opt/android/cake_wallet/cw_shared_external/ios/External
-          key: externals-cache-key
+          key: ${{ hashFiles('/opt/android/cake_wallet/cw_haven/pubspec.yaml', '/opt/android/cake_wallet/cw_monero/pubspec.yaml', '/opt/android/cake_wallet/cw_shared_external/pubspec.yaml') }}
 
       - if: ${{ steps.cache-externals.outputs.cache-hit != 'true' }}
         name: Generate Externals


### PR DESCRIPTION
- Add Cache Dependencies workflow on main branch to be available for all sub-branches

- Replace static cache key with the hash of dependencies pubspec.yaml