### PR TITLE
Fix Additional characters on scanned QR addresses

### DIFF
--- a/lib/entities/qr_scanner.dart
+++ b/lib/entities/qr_scanner.dart
@@ -7,7 +7,7 @@ Future<String> presentQRScanner() async {
   try {
     final result = await BarcodeScanner.scan();
     isQrScannerShown = false;
-    return result.rawContent;
+    return result.rawContent.trim();
   } catch (e) {
     isQrScannerShown = false;
     rethrow;


### PR DESCRIPTION
Trim the content scanned via QR to remove extra spaces/new lines

<img width="319" alt="Screen Shot 2023-01-10 at 7 58 33 PM" src="https://user-images.githubusercontent.com/31170694/211626964-f783d072-9567-427c-bbc2-0fa26a8d94e7.png">
