### PR TITLE
Exception Handler Enhancements

### DIFF
--- a/lib/anypay/anypay_api.dart
+++ b/lib/anypay/anypay_api.dart
@@ -80,7 +80,7 @@ class AnyPayApi {
 		final response = await post(Uri.parse(uri), headers: headers, body: utf8.encode(json.encode(body)));
 		if (response.statusCode == 400) {
 			final decodedBody = json.decode(response.body) as Map<String, dynamic>;
-			throw Exception(decodedBody['message'] as String);
+			throw Exception(decodedBody['message'] as String? ?? 'Unexpected response\nError code: 400');
 		}
 
 		if (response.statusCode != 200) {

--- a/lib/utils/exception_handler.dart
+++ b/lib/utils/exception_handler.dart
@@ -59,7 +59,7 @@ class ExceptionHandler {
   }
 
   static void onError(FlutterErrorDetails errorDetails) {
-    if (_isErrorFromUser(errorDetails.exception.toString())) {
+    if (_ignoreError(errorDetails.exception.toString())) {
       return;
     }
 
@@ -97,8 +97,9 @@ class ExceptionHandler {
     );
   }
 
-  /// User related errors to be added as exceptions here to not report
-  static bool _isErrorFromUser(String error) {
-    return error.contains("Software caused connection abort"); // User connection issue
+  /// Ignore User related errors or system errors
+  static bool _ignoreError(String error) {
+    return error.contains("errno = 103") || // SocketException: Software caused connection abort
+        error.contains("errno = 9"); // SocketException: Bad file descriptor (iOS socket exception)
   }
 }


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

- Ignore Socket Exception "bad file descriptor" caused on iOS devices due to sockets getting closed if App is idle or screen lock ([issue ref](https://github.com/dart-lang/http/issues/197))
- Add nullability to anypay API response failure

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
