### PR TITLE
Fix incorrect amount parsing

### DIFF
--- a/cw_bitcoin/lib/bitcoin_amount_format.dart
+++ b/cw_bitcoin/lib/bitcoin_amount_format.dart
@@ -17,7 +17,7 @@ int stringDoubleToBitcoinAmount(String amount) {
   int result = 0;
 
   try {
-    result = (double.parse(amount) * bitcoinAmountDivider).toInt();
+    result = (double.parse(amount) * bitcoinAmountDivider).round();
   } catch (e) {
     result = 0;
   }

--- a/cw_core/lib/monero_amount_format.dart
+++ b/cw_core/lib/monero_amount_format.dart
@@ -15,4 +15,4 @@ double moneroAmountToDouble({required int amount}) =>
     cryptoAmountToDouble(amount: amount, divider: moneroAmountDivider);
 
 int moneroParseAmount({required String amount}) =>
-    (double.parse(amount) * moneroAmountDivider).toInt();
+    (double.parse(amount) * moneroAmountDivider).round();


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Fix Amount parsed with a slightly different amount due to double not being represented exactly


<img width="569" alt="Screen Shot 2023-02-15 at 11 30 48 PM" src="https://user-images.githubusercontent.com/31170694/219172527-33c6f5db-4267-4081-8724-2cb682669272.png">

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
