### PR TITLE
Fix null checks on disposed screens

### DIFF
--- a/lib/src/screens/dashboard/dashboard_page.dart
+++ b/lib/src/screens/dashboard/dashboard_page.dart
@@ -8,7 +8,6 @@ import 'package:cake_wallet/src/widgets/alert_with_one_action.dart';
 import 'package:cake_wallet/themes/theme_base.dart';
 import 'package:cake_wallet/utils/show_pop_up.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:cake_wallet/view_model/dashboard/dashboard_view_model.dart';
 import 'package:cake_wallet/src/screens/base_page.dart';
 import 'package:cake_wallet/src/screens/dashboard/widgets/menu_widget.dart';
@@ -229,7 +228,8 @@ class DashboardPage extends BasePage {
       }
 
       await Future<void>.delayed(Duration(seconds: 1));
-      await showPopUp<void>(
+      if (context.mounted) {
+        await showPopUp<void>(
           context: context,
           builder: (BuildContext context) {
             return AlertWithOneAction(
@@ -239,6 +239,7 @@ class DashboardPage extends BasePage {
                 buttonText: S.of(context).understand,
                 buttonAction: () => Navigator.of(context).pop());
           });
+      }
     });
 
     var needToPresentYat = false;

--- a/lib/src/screens/dashboard/widgets/address_page.dart
+++ b/lib/src/screens/dashboard/widgets/address_page.dart
@@ -117,7 +117,8 @@ class AddressPage extends BasePage {
       }
 
       await Future<void>.delayed(Duration(seconds: 1));
-      await showPopUp<void>(
+      if (context.mounted) {
+        await showPopUp<void>(
           context: context,
           builder: (BuildContext context) {
             return AlertWithTwoActions(
@@ -131,6 +132,7 @@ class AddressPage extends BasePage {
                   Navigator.of(context).pop();
                 });
           });
+      }
     });
 
     return KeyboardActions(

--- a/lib/src/screens/send/send_page.dart
+++ b/lib/src/screens/send/send_page.dart
@@ -379,7 +379,8 @@ class SendPage extends BasePage {
 
       if (state is ExecutedSuccessfullyState) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          showPopUp<void>(
+          if (context.mounted) {
+            showPopUp<void>(
               context: context,
               builder: (BuildContext context) {
                 return ConfirmSendingAlert(
@@ -423,6 +424,7 @@ class SendPage extends BasePage {
                     },
                     actionLeftButton: () => Navigator.of(context).pop());
               });
+          }
         });
       }
 


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Check if context is still mounted before showing a popup

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
