### PR TITLE
Accept 3 letter prefix for seed phrase words

### DIFF
--- a/lib/src/screens/restore/wallet_restore_page.dart
+++ b/lib/src/screens/restore/wallet_restore_page.dart
@@ -225,21 +225,35 @@ class WalletRestorePage extends BasePage {
       .currentState
       !.seedWidgetStateKey
       .currentState
-      !.words
-      .toSet();
-    return seedWords
-      .toSet()
-      .difference(words)
-      .toSet()
-      .isEmpty;
+      !.words;
+
+    if (walletRestoreViewModel.type == WalletType.monero) {
+      return seedWords.every(
+        (seedWord) => words.any(
+          (word) => word.startsWith(seedWord)
+        )
+      );
+    }
+    return seedWords.every((String word) => words.contains(word));
   }
 
   Map<String, dynamic> _credentials() {
     final credentials = <String, dynamic>{};
 
     if (walletRestoreViewModel.mode == WalletRestoreMode.seed) {
-      credentials['seed'] = walletRestoreFromSeedFormKey
-          .currentState!.seedWidgetStateKey.currentState!.text;
+      final words = walletRestoreFromSeedFormKey
+          .currentState!.seedWidgetStateKey.currentState!.words;
+
+      final seed = walletRestoreFromSeedFormKey
+          .currentState!.seedWidgetStateKey.currentState!.text
+          .split(' ')
+          .map(
+            (seedWord) => words.firstWhere(
+              (word) => seedWord.startsWith(word)
+            )
+          ).join();
+
+      credentials['seed'] = seed;
 
       if (walletRestoreViewModel.hasBlockchainHeightLanguageSelector) {
         credentials['height'] = walletRestoreFromSeedFormKey

--- a/lib/src/widgets/validable_annotated_editable_text.dart
+++ b/lib/src/widgets/validable_annotated_editable_text.dart
@@ -131,7 +131,9 @@ class ValidatableAnnotatedEditableTextState extends EditableTextState {
     return result;
   }
 
-  bool validate(String source) => widget.words.indexOf(source) >= 0;
+  bool validate(String source) => source.length < 3
+      ? false
+      : widget.words.any((String e) => e.startsWith(source));
 
   List<TextRange> range(String pattern, String source) {
     final result = <TextRange>[];


### PR DESCRIPTION
Fixes #566 
# Description

If it's restoring a monero wallet by mnemonic phrase, it only needs 3 letter prefixes for every word to validate.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Formate code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
