### PR TITLE
CW-331-Add-option-to-disable-market-place-in-display-settings

### DIFF
--- a/lib/entities/preferences_key.dart
+++ b/lib/entities/preferences_key.dart
@@ -39,4 +39,5 @@ class PreferencesKey {
   static const exchangeProvidersSelection = 'exchange-providers-selection';
   static const clearnetDonationLink = 'clearnet_donation_link'; 
   static const onionDonationLink = 'onion_donation_link'; 
+  static const shouldShowMarketPlaceInDashboard = 'should_show_marketplace_in_dashboard';
 }

--- a/lib/src/screens/dashboard/dashboard_page.dart
+++ b/lib/src/screens/dashboard/dashboard_page.dart
@@ -109,14 +109,15 @@ class _DashboardPageView extends BasePage {
 
   final DashboardViewModel dashboardViewModel;
   final WalletAddressListViewModel addressListViewModel;
-  final controller = PageController(initialPage: 1);
-
+  int get initialPage => dashboardViewModel.shouldShowMarketPlaceInDashboard ? 1 : 0;
   ObservableList<Widget> pages = ObservableList<Widget>();
   bool _isEffectsInstalled = false;
   StreamSubscription<bool>? _onInactiveSub;
 
   @override
   Widget body(BuildContext context) {
+    final controller = PageController(initialPage: initialPage);
+    
     reaction((_) => dashboardViewModel.shouldShowMarketPlaceInDashboard, (bool value) {
       if (!dashboardViewModel.shouldShowMarketPlaceInDashboard) {
         controller.jumpToPage(0);

--- a/lib/src/screens/dashboard/dashboard_page.dart
+++ b/lib/src/screens/dashboard/dashboard_page.dart
@@ -111,12 +111,26 @@ class _DashboardPageView extends BasePage {
   final WalletAddressListViewModel addressListViewModel;
   final controller = PageController(initialPage: 1);
 
-  var pages = <Widget>[];
+  ObservableList<Widget> pages = ObservableList<Widget>();
   bool _isEffectsInstalled = false;
   StreamSubscription<bool>? _onInactiveSub;
 
   @override
   Widget body(BuildContext context) {
+    reaction((_) => dashboardViewModel.shouldShowMarketPlaceInDashboard, (bool value) {
+      if (!dashboardViewModel.shouldShowMarketPlaceInDashboard) {
+        controller.jumpToPage(0);
+      }
+      pages.clear();
+      _isEffectsInstalled = false;
+      _setEffects(context);
+
+      if (value) {
+        controller.jumpToPage(1);
+      } else {
+        controller.jumpToPage(0);
+      }
+    }); 
     _setEffects(context);
 
     return SafeArea(
@@ -125,23 +139,28 @@ class _DashboardPageView extends BasePage {
           mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             Expanded(
-                child: PageView.builder(
-                    controller: controller,
-                    itemCount: pages.length,
-                    itemBuilder: (context, index) => pages[index])),
+                child: Observer(builder: (context) {
+              return PageView.builder(
+                  controller: controller,
+                  itemCount: pages.length,
+                  itemBuilder: (context, index) => pages[index]);
+            })),
             Padding(
                 padding: EdgeInsets.only(bottom: 24, top: 10),
-                child: SmoothPageIndicator(
-                  controller: controller,
-                  count: pages.length,
-                  effect: ColorTransitionEffect(
-                      spacing: 6.0,
-                      radius: 6.0,
-                      dotWidth: 6.0,
-                      dotHeight: 6.0,
-                      dotColor: Theme.of(context).indicatorColor,
-                      activeDotColor:
-                          Theme.of(context).accentTextTheme!.headline4!.backgroundColor!),
+                child: Observer(builder: (context) {
+                  return SmoothPageIndicator(
+                    controller: controller,
+                    count: pages.length,
+                    effect: ColorTransitionEffect(
+                        spacing: 6.0,
+                        radius: 6.0,
+                        dotWidth: 6.0,
+                        dotHeight: 6.0,
+                        dotColor: Theme.of(context).indicatorColor,
+                        activeDotColor:
+                            Theme.of(context).accentTextTheme!.headline4!.backgroundColor!),
+                  );
+                }
                 )),
             Observer(builder: (_) {
               return ClipRect(
@@ -201,7 +220,9 @@ class _DashboardPageView extends BasePage {
     if (_isEffectsInstalled) {
       return;
     }
-    pages.add(MarketPlacePage(dashboardViewModel: dashboardViewModel));
+    if (dashboardViewModel.shouldShowMarketPlaceInDashboard) {
+      pages.add(MarketPlacePage(dashboardViewModel: dashboardViewModel));
+    }
     pages.add(balancePage);
     pages.add(TransactionsPage(dashboardViewModel: dashboardViewModel));
     _isEffectsInstalled = true;

--- a/lib/src/screens/settings/display_settings_page.dart
+++ b/lib/src/screens/settings/display_settings_page.dart
@@ -34,6 +34,13 @@ class DisplaySettingsPage extends BasePage {
             onValueChange: (_, bool value) {
                _displaySettingsViewModel.setShouldDisplayBalance(value);          
             }),
+            SettingsSwitcherCell(
+              title: S.current.show_market_place,
+              value: _displaySettingsViewModel.shouldShowMarketPlaceInDashboard,
+              onValueChange: (_, bool value) {
+                _displaySettingsViewModel.setShouldShowMarketPlaceInDashbaord(value);
+              },
+            ),
             //if (!isHaven) it does not work correctly
             if(!_displaySettingsViewModel.disabledFiatApiMode)
               SettingsPickerCell<FiatCurrency>(

--- a/lib/store/settings_store.dart
+++ b/lib/store/settings_store.dart
@@ -27,6 +27,7 @@ class SettingsStore = SettingsStoreBase with _$SettingsStore;
 abstract class SettingsStoreBase with Store {
   SettingsStoreBase(
       {required SharedPreferences sharedPreferences,
+      required bool initialShouldShowMarketPlaceInDashboard,
       required FiatCurrency initialFiatCurrency,
       required BalanceDisplayMode initialBalanceDisplayMode,
       required bool initialSaveRecipientAddress,
@@ -54,6 +55,7 @@ abstract class SettingsStoreBase with Store {
     shouldSaveRecipientAddress = initialSaveRecipientAddress,
     fiatApiMode = initialFiatMode,
     allowBiometricalAuthentication = initialAllowBiometricalAuthentication,
+        shouldShowMarketPlaceInDashboard = initialShouldShowMarketPlaceInDashboard,
     exchangeStatus = initialExchangeStatus,
     currentTheme = initialTheme,
     pinCodeLength = initialPinLength,
@@ -134,6 +136,11 @@ abstract class SettingsStoreBase with Store {
             biometricalAuthentication));
 
     reaction(
+        (_) => shouldShowMarketPlaceInDashboard,
+        (bool value) =>
+            sharedPreferences.setBool(PreferencesKey.shouldShowMarketPlaceInDashboard, value));
+
+    reaction(
         (_) => pinCodeLength,
         (int pinLength) => sharedPreferences.setInt(
             PreferencesKey.currentPinLength, pinLength));
@@ -176,6 +183,9 @@ abstract class SettingsStoreBase with Store {
 
   @observable
   bool shouldShowYatPopup;
+
+  @observable
+  bool shouldShowMarketPlaceInDashboard;
 
   @observable
   ObservableList<ActionListDisplayMode> actionlistDisplayMode;
@@ -285,6 +295,8 @@ abstract class SettingsStoreBase with Store {
     final allowBiometricalAuthentication = sharedPreferences
             .getBool(PreferencesKey.allowBiometricalAuthenticationKey) ??
         false;
+    final shouldShowMarketPlaceInDashboard =
+        sharedPreferences.getBool(PreferencesKey.shouldShowMarketPlaceInDashboard) ?? true;
     final exchangeStatus = ExchangeApiMode.deserialize(
         raw: sharedPreferences
             .getInt(PreferencesKey.exchangeStatusKey) ?? ExchangeApiMode.enabled.raw);
@@ -348,6 +360,7 @@ abstract class SettingsStoreBase with Store {
 
     return SettingsStore(
         sharedPreferences: sharedPreferences,
+        initialShouldShowMarketPlaceInDashboard: shouldShowMarketPlaceInDashboard,
         nodes: nodes,
         appVersion: packageInfo.version,
         isBitcoinBuyEnabled: isBitcoinBuyEnabled,
@@ -402,6 +415,9 @@ abstract class SettingsStoreBase with Store {
     allowBiometricalAuthentication = sharedPreferences
         .getBool(PreferencesKey.allowBiometricalAuthenticationKey) ??
         allowBiometricalAuthentication;
+    shouldShowMarketPlaceInDashboard =
+        sharedPreferences.getBool(PreferencesKey.shouldShowMarketPlaceInDashboard) ??
+            shouldShowMarketPlaceInDashboard;
     exchangeStatus = ExchangeApiMode.deserialize(
         raw: sharedPreferences
             .getInt(PreferencesKey.exchangeStatusKey) ?? ExchangeApiMode.enabled.raw);

--- a/lib/view_model/dashboard/dashboard_view_model.dart
+++ b/lib/view_model/dashboard/dashboard_view_model.dart
@@ -213,6 +213,11 @@ abstract class DashboardViewModelBase with Store {
   @computed
   BalanceDisplayMode get balanceDisplayMode =>
       appStore.settingsStore.balanceDisplayMode;
+    
+  @computed
+  bool get shouldShowMarketPlaceInDashboard {
+    return appStore.settingsStore.shouldShowMarketPlaceInDashboard;
+  }
 
   @computed
   List<TradeListItem> get trades => tradesStore.trades

--- a/lib/view_model/settings/display_settings_view_model.dart
+++ b/lib/view_model/settings/display_settings_view_model.dart
@@ -29,6 +29,9 @@ abstract class DisplaySettingsViewModelBase with Store {
   bool get shouldDisplayBalance => balanceDisplayMode == BalanceDisplayMode.displayableBalance;
 
   @computed
+  bool get shouldShowMarketPlaceInDashboard => _settingsStore.shouldShowMarketPlaceInDashboard;
+
+  @computed
   ThemeBase get theme => _settingsStore.currentTheme;
 
   @computed
@@ -58,4 +61,9 @@ abstract class DisplaySettingsViewModelBase with Store {
 
   @action
   void setFiatCurrency(FiatCurrency value) => _settingsStore.fiatCurrency = value;
+
+  @action
+  void setShouldShowMarketPlaceInDashbaord(bool value) {
+    _settingsStore.shouldShowMarketPlaceInDashboard = value;
+  }
 }

--- a/res/values/strings_ar.arb
+++ b/res/values/strings_ar.arb
@@ -696,5 +696,6 @@
    "clearnet_link": "رابط Clearnet",
    "onion_link": "رابط البصل",
    "settings": "إعدادات",
-   "sell_monero_com_alert_content": "بيع Monero غير مدعوم حتى الآن"
+   "sell_monero_com_alert_content": "بيع Monero غير مدعوم حتى الآن",
+   "show_market_place": "إظهار السوق"
 }

--- a/res/values/strings_bg.arb
+++ b/res/values/strings_bg.arb
@@ -697,5 +697,6 @@
   "optional_name": "Незадължително име на получател",
   "clearnet_link": "Clearnet връзка",
   "onion_link": "Лукова връзка",
-  "sell_monero_com_alert_content": "Продажбата на Monero все още не се поддържа"
+  "sell_monero_com_alert_content": "Продажбата на Monero все още не се поддържа",
+  "show_market_place":"Покажи пазар"
 }

--- a/res/values/strings_cs.arb
+++ b/res/values/strings_cs.arb
@@ -697,5 +697,6 @@
   "optional_name": "Volitelné jméno příjemce",
   "clearnet_link": "Odkaz na Clearnet",
   "onion_link": "Cibulový odkaz",
-  "sell_monero_com_alert_content": "Prodej Monero zatím není podporován"
+  "sell_monero_com_alert_content": "Prodej Monero zatím není podporován",
+  "show_market_place": "Zobrazit trh"
 }

--- a/res/values/strings_de.arb
+++ b/res/values/strings_de.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "Clearnet-Link",
   "onion_link": "Zwiebel-Link",
   "settings": "Einstellungen",
-  "sell_monero_com_alert_content": "Der Verkauf von Monero wird noch nicht unterstützt"
+  "sell_monero_com_alert_content": "Der Verkauf von Monero wird noch nicht unterstützt",
+  "show_market_place": "Marktplatz anzeigen"
 }

--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -698,5 +698,6 @@
   "decimal_places_error": "Too many decimal places",
   "edit_node": "Edit Node",
   "settings": "Settings",
-  "sell_monero_com_alert_content": "Selling Monero is not supported yet"
+  "sell_monero_com_alert_content": "Selling Monero is not supported yet",
+  "show_market_place" :"Show Marketplace"
 }

--- a/res/values/strings_es.arb
+++ b/res/values/strings_es.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "enlace Clearnet",
   "onion_link": "Enlace de cebolla",
   "settings": "Configuraciones",
-  "sell_monero_com_alert_content": "Aún no se admite la venta de Monero"
+  "sell_monero_com_alert_content": "Aún no se admite la venta de Monero",
+  "show_market_place": "Mostrar mercado"
 }

--- a/res/values/strings_fr.arb
+++ b/res/values/strings_fr.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "Lien Clearnet",
   "settings": "Paramètres",
   "onion_link": "Lien .onion",
-  "sell_monero_com_alert_content": "La vente de Monero n'est pas encore prise en charge"
+  "sell_monero_com_alert_content": "La vente de Monero n'est pas encore prise en charge",
+  "show_market_place" :"Afficher la place de marché"
 }

--- a/res/values/strings_hi.arb
+++ b/res/values/strings_hi.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "क्लियरनेट लिंक",
   "onion_link": "प्याज का लिंक",
   "settings": "समायोजन",
-  "sell_monero_com_alert_content": "मोनेरो बेचना अभी तक समर्थित नहीं है"
+  "sell_monero_com_alert_content": "मोनेरो बेचना अभी तक समर्थित नहीं है",
+  "show_market_place":"बाज़ार दिखाएँ"
 }

--- a/res/values/strings_hr.arb
+++ b/res/values/strings_hr.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "Clearnet veza",
   "onion_link": "Poveznica luka",
   "settings": "Postavke",
-  "sell_monero_com_alert_content": "Prodaja Monera još nije podržana"
+  "sell_monero_com_alert_content": "Prodaja Monera još nije podržana",
+  "show_market_place" : "Prikaži tržište"
 }

--- a/res/values/strings_id.arb
+++ b/res/values/strings_id.arb
@@ -679,5 +679,6 @@
   "optional_name": "Nama penerima opsional",
   "clearnet_link": "Tautan clearnet",
   "onion_link": "Tautan bawang",
-  "sell_monero_com_alert_content": "Menjual Monero belum didukung"
+  "sell_monero_com_alert_content": "Menjual Monero belum didukung",
+  "show_market_place": "Tampilkan Pasar"
 }

--- a/res/values/strings_it.arb
+++ b/res/values/strings_it.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "Collegamento Clearnet",
   "onion_link": "Collegamento a cipolla",
   "settings": "Impostazioni",
-  "sell_monero_com_alert_content": "La vendita di Monero non è ancora supportata"
+  "sell_monero_com_alert_content": "La vendita di Monero non è ancora supportata",
+  "show_market_place":"Mostra mercato"
 }

--- a/res/values/strings_ja.arb
+++ b/res/values/strings_ja.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "クリアネット リンク",
   "onion_link": "オニオンリンク",
   "settings": "設定",
-  "sell_monero_com_alert_content": "モネロの販売はまだサポートされていません"
+  "sell_monero_com_alert_content": "モネロの販売はまだサポートされていません",
+  "show_market_place":"マーケットプレイスを表示"
 }

--- a/res/values/strings_ko.arb
+++ b/res/values/strings_ko.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "클리어넷 링크",
   "onion_link": "양파 링크",
   "settings": "설정",
-  "sell_monero_com_alert_content": "지원되지 않습니다."
+  "sell_monero_com_alert_content": "지원되지 않습니다.",
+  "show_market_place":"마켓플레이스 표시"
 }

--- a/res/values/strings_my.arb
+++ b/res/values/strings_my.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "Clearnet လင့်ခ်",
   "onion_link": "ကြက်သွန်လင့်",
   "settings": "ဆက်တင်များ",
-  "sell_monero_com_alert_content": "Monero ရောင်းချခြင်းကို မပံ့ပိုးရသေးပါ။"
+  "sell_monero_com_alert_content": "Monero ရောင်းချခြင်းကို မပံ့ပိုးရသေးပါ။",
+  "show_market_place":"စျေးကွက်ကိုပြသပါ။"
 }

--- a/res/values/strings_nl.arb
+++ b/res/values/strings_nl.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "Clearnet-link",
   "onion_link": "Ui koppeling",
   "settings": "Instellingen",
-  "sell_monero_com_alert_content": "Het verkopen van Monero wordt nog niet ondersteund"
+  "sell_monero_com_alert_content": "Het verkopen van Monero wordt nog niet ondersteund",
+  "show_market_place":"Toon Marktplaats"
 }

--- a/res/values/strings_pl.arb
+++ b/res/values/strings_pl.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "łącze Clearnet",
   "onion_link": "Łącznik cebulowy",
   "settings": "Ustawienia",
-  "sell_monero_com_alert_content": "Sprzedaż Monero nie jest jeszcze obsługiwana"
+  "sell_monero_com_alert_content": "Sprzedaż Monero nie jest jeszcze obsługiwana",
+  "show_market_place" : "Pokaż rynek"
 }

--- a/res/values/strings_pt.arb
+++ b/res/values/strings_pt.arb
@@ -697,5 +697,6 @@
   "clearnet_link": "link clear net",
   "onion_link": "ligação de cebola",
   "settings": "Configurações",
-  "sell_monero_com_alert_content": "A venda de Monero ainda não é suportada"
+  "sell_monero_com_alert_content": "A venda de Monero ainda não é suportada",
+  "show_market_place":"Mostrar mercado"
 }

--- a/res/values/strings_ru.arb
+++ b/res/values/strings_ru.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "Клирнет ссылка",
   "onion_link": "Луковая ссылка",
   "settings": "Настройки",
-  "sell_monero_com_alert_content": "Продажа Monero пока не поддерживается"
+  "sell_monero_com_alert_content": "Продажа Monero пока не поддерживается",
+  "show_market_place":"Показать торговую площадку"
 }

--- a/res/values/strings_th.arb
+++ b/res/values/strings_th.arb
@@ -696,5 +696,6 @@
   "clearnet_link": "ลิงค์เคลียร์เน็ต",
   "onion_link": "ลิงค์หัวหอม",
   "settings": "การตั้งค่า",
-  "sell_monero_com_alert_content": "ยังไม่รองรับการขาย Monero"
+  "sell_monero_com_alert_content": "ยังไม่รองรับการขาย Monero",
+  "show_market_place":"แสดงตลาดกลาง"
 }

--- a/res/values/strings_tr.arb
+++ b/res/values/strings_tr.arb
@@ -698,5 +698,6 @@
   "clearnet_link": "Net bağlantı",
   "onion_link": "soğan bağlantısı",
   "settings": "ayarlar",
-  "sell_monero_com_alert_content": "Monero satışı henüz desteklenmiyor"
+  "sell_monero_com_alert_content": "Monero satışı henüz desteklenmiyor",
+  "show_market_place":"Pazar Yerini Göster"
 }

--- a/res/values/strings_uk.arb
+++ b/res/values/strings_uk.arb
@@ -697,5 +697,6 @@
   "clearnet_link": "Посилання Clearnet",
   "onion_link": "Посилання на цибулю",
   "settings": "Налаштування",
-  "sell_monero_com_alert_content": "Продаж Monero ще не підтримується"
+  "sell_monero_com_alert_content": "Продаж Monero ще не підтримується",
+  "show_market_place":"Шоу Ринок"
 }

--- a/res/values/strings_ur.arb
+++ b/res/values/strings_ur.arb
@@ -698,5 +698,6 @@
   "optional_name": "اختیاری وصول کنندہ کا نام",
   "clearnet_link": "کلیرنیٹ لنک",
   "onion_link": "پیاز کا لنک",
-  "sell_monero_com_alert_content": "Monero فروخت کرنا ابھی تک تعاون یافتہ نہیں ہے۔"
+  "sell_monero_com_alert_content": "Monero فروخت کرنا ابھی تک تعاون یافتہ نہیں ہے۔",
+  "show_market_place":"بازار دکھائیں۔"
 }

--- a/res/values/strings_zh.arb
+++ b/res/values/strings_zh.arb
@@ -697,5 +697,6 @@
   "clearnet_link": "明网链接",
   "onion_link": "洋葱链接",
   "settings": "设置",
-  "sell_monero_com_alert_content": "尚不支持出售门罗币"
+  "sell_monero_com_alert_content": "尚不支持出售门罗币",
+  "show_market_place" :"显示市场"
 }


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description
Add switcher in display settings to enable/disable marketplace page

if enabled: it will be the same behavior as it is right now

if disabled: the dashboard screen will only have the balance and transactions screen

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [] Double check modified code and verify it with the feature/task requirements
- [x] Formate code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
