### PR TITLE
CW-362 iOS issue keyboard space is still showing in app

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -107,6 +107,7 @@ import UnstoppableDomainsResolution
     }
 
     override func applicationWillResignActive(_: UIApplication ) {
+        self.window?.rootViewController?.view.endEditing(true)
         self.window?.isHidden = true;
       }
 


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description
End editing in ios to dismiss keyboard before app goes to background

# Pull Request - Checklist  

- [X] Initial Manual Tests Passed
- [X] Double check modified code and verify it with the feature/task requirements
- [X] Format code
- [X] Look for code duplication
- [X] Clear naming for variables and methods
