### PR TITLE
Fix Bitcoin transactions not showing

### DIFF
--- a/cw_bitcoin/lib/electrum.dart
+++ b/cw_bitcoin/lib/electrum.dart
@@ -66,9 +66,14 @@ class ElectrumClient {
     socket!.listen((Uint8List event) {
       try {
         final msg = utf8.decode(event.toList());
-        final response =
-            json.decode(msg) as Map<String, dynamic>;
-        _handleResponse(response);
+        final messagesList = msg.split("\n");
+        for (var message in messagesList) {
+          if (message.isEmpty) {
+            continue;
+          }
+          final response = json.decode(message) as Map<String, dynamic>;
+          _handleResponse(response);
+        }
       } on FormatException catch (e) {
         final msg = e.message.toLowerCase();
 

--- a/cw_bitcoin/lib/electrum.dart
+++ b/cw_bitcoin/lib/electrum.dart
@@ -112,8 +112,10 @@ class ElectrumClient {
       }
     }, onError: (Object error) {
       print(error.toString());
+      unterminatedString = '';
       _setIsConnected(false);
     }, onDone: () {
+      unterminatedString = '';
       _setIsConnected(false);
     });
     keepAlive();
@@ -222,7 +224,7 @@ class ElectrumClient {
 
   Future<Map<String, dynamic>> getTransactionRaw(
           {required String hash}) async =>
-      call(method: 'blockchain.transaction.get', params: [hash, true])
+      callWithTimeout(method: 'blockchain.transaction.get', params: [hash, true], timeout: 10000)
           .then((dynamic result) {
         if (result is Map<String, dynamic>) {
           return result;
@@ -233,7 +235,7 @@ class ElectrumClient {
 
   Future<String> getTransactionHex(
           {required String hash}) async =>
-      call(method: 'blockchain.transaction.get', params: [hash, false])
+      callWithTimeout(method: 'blockchain.transaction.get', params: [hash, false], timeout: 10000)
           .then((dynamic result) {
         if (result is String) {
           return result;


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

handle multiple responses coming in a single event

sometimes the events we receive in `socket!.listen((Uint8List event)` has more than one RPC response
ex.
```
{"jsonrpc": "2.0", "result": "f2c0cea5f.......1e4ca", "id": "4498"}
{"jsonrpc": "2.0", "result": "d5694e3f........87dd", "id": "4499"}
```
thus failing to parse this event as json, resulting in failure of parsing any response afterwards

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
