### PR TITLE
CW-441 xmr price issue

### DIFF
--- a/lib/view_model/dashboard/balance_view_model.dart
+++ b/lib/view_model/dashboard/balance_view_model.dart
@@ -66,7 +66,6 @@ abstract class BalanceViewModelBase with Store {
     final price = fiatConvertationStore.prices[appStore.wallet!.currency];
 
     if (price == null) {
-      // throw Exception('No price for ${appStore.wallet!.currency} (current wallet)');
       // price should update on next fetch:
       return 0;
     }

--- a/lib/view_model/dashboard/balance_view_model.dart
+++ b/lib/view_model/dashboard/balance_view_model.dart
@@ -66,7 +66,9 @@ abstract class BalanceViewModelBase with Store {
     final price = fiatConvertationStore.prices[appStore.wallet!.currency];
 
     if (price == null) {
-      throw Exception('No price for ${appStore.wallet!.currency} (current wallet)');
+      // throw Exception('No price for ${appStore.wallet!.currency} (current wallet)');
+      // price should update on next fetch:
+      return 0;
     }
 
     return price;


### PR DESCRIPTION
Issue Number (if Applicable): Fixes # CW-441

# Description

Fixes CW-441, which was an issue where when enabling the fiat API setting there would not be any price info which would lead to an exception.
Now when the fiat API setting is enabled the timer for fetching fiat data is reset and run immediately, and canceled otherwise.

# Pull Request - Checklist  

- [X] Initial Manual Tests Passed
- [X] Double check modified code and verify it with the feature/task requirements
- [X] Format code
- [X] Look for code duplication
- [X] Clear naming for variables and methods
