### PR TITLE
CW-443 Use networkWallets on OnRamper

### DIFF
--- a/lib/buy/onramper/onramper_buy_provider.dart
+++ b/lib/buy/onramper/onramper_buy_provider.dart
@@ -20,6 +20,8 @@ class OnRamperBuyProvider {
     switch (_wallet.currency) {
       case CryptoCurrency.ltc:
         return "LTC_LITECOIN";
+      case CryptoCurrency.xmr:
+        return "XMR_MONERO";
       default:
         return _wallet.currency.title;
     }

--- a/lib/buy/onramper/onramper_buy_provider.dart
+++ b/lib/buy/onramper/onramper_buy_provider.dart
@@ -60,11 +60,12 @@ class OnRamperBuyProvider {
         break;
     }
 
+    final networkName = _wallet.currency.fullName?.toUpperCase().replaceAll(" ", "");
 
     return Uri.https(_baseUrl, '', <String, dynamic>{
       'apiKey': _apiKey,
       'defaultCrypto': _normalizeCryptoCurrency,
-      'wallets': '${_wallet.currency.title}:${_wallet.walletAddresses.address}',
+      'networkWallets': '${networkName}:${_wallet.walletAddresses.address}',
       'supportSell': "false",
       'supportSwap': "false",
       'primaryColor': primaryColor,


### PR DESCRIPTION
# Description

Updated onramper to use network wallet parameter instead of `wallet`

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
