### PR TITLE
Add PYUSD to token list [skip ci]

### DIFF
--- a/cw_ethereum/lib/default_erc20_tokens.dart
+++ b/cw_ethereum/lib/default_erc20_tokens.dart
@@ -283,6 +283,13 @@ class DefaultErc20Tokens {
       decimal: 18,
       enabled: false,
     ),
+    Erc20Token(
+      name: "PayPal USD",
+      symbol: "PYUSD",
+      contractAddress: "0x6c3ea9036406852006290770bedfcaba0e23a0e8",
+      decimal: 6,
+      enabled: false,
+    ),
   ];
 
   List<Erc20Token> get initialErc20Tokens => _defaultTokens.map((token) {


### PR DESCRIPTION
PayPal USD (PYUSD) is disabled by default, to appear only in the token search list.

https://github.com/paxosglobal/pyusd-contract