### PR TITLE
CW-476 Only get Transactions of one Account on tx-history refresh

### DIFF
--- a/cw_monero/lib/api/transaction_history.dart
+++ b/cw_monero/lib/api/transaction_history.dart
@@ -55,7 +55,7 @@ void refreshTransactions() => transactionsRefreshNative();
 
 int countOfTransactions() => transactionsCountNative();
 
-List<TransactionInfoRow> getAllTransations() {
+List<TransactionInfoRow> getAllTransactions() {
   final size = transactionsCountNative();
   final transactionsPointer = transactionsGetAllNative();
   final transactionsAddresses = transactionsPointer.asTypedList(size);

--- a/cw_monero/lib/monero_wallet.dart
+++ b/cw_monero/lib/monero_wallet.dart
@@ -482,7 +482,7 @@ abstract class MoneroWalletBase extends WalletBase<MoneroBalance,
   @override
   Future<Map<String, MoneroTransactionInfo>> fetchTransactions() async {
     transaction_history.refreshTransactions();
-    return _getAllTransactions(null).fold<Map<String, MoneroTransactionInfo>>(
+    return _getAllTransactionsOfAccount(walletAddresses.account?.id).fold<Map<String, MoneroTransactionInfo>>(
         <String, MoneroTransactionInfo>{},
         (Map<String, MoneroTransactionInfo> acc, MoneroTransactionInfo tx) {
       acc[tx.id] = tx;
@@ -497,6 +497,7 @@ abstract class MoneroWalletBase extends WalletBase<MoneroBalance,
       }
 
       _isTransactionUpdating = true;
+      transactionHistory.clear();
       final transactions = await fetchTransactions();
       transactionHistory.addMany(transactions);
       await transactionHistory.save();
@@ -511,10 +512,11 @@ abstract class MoneroWalletBase extends WalletBase<MoneroBalance,
     return monero_wallet.getSubaddressLabel(accountIndex, addressIndex);
   }
 
-  List<MoneroTransactionInfo> _getAllTransactions(dynamic _) =>
+  List<MoneroTransactionInfo> _getAllTransactionsOfAccount(int? accountIndex) =>
       transaction_history
-          .getAllTransations()
+          .getAllTransactions()
           .map((row) => MoneroTransactionInfo.fromRow(row))
+          .where((element) => element.accountIndex == (accountIndex ?? 0))
           .toList();
 
   void _setListeners() {


### PR DESCRIPTION
# Description

Fix Typos and now transactions between accounts show up correctly. 

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
