### PR TITLE
hotfix nodes page loading in the wrong nodes

### DIFF
--- a/lib/entities/default_settings_migration.dart
+++ b/lib/entities/default_settings_migration.dart
@@ -161,7 +161,7 @@ Future<void> defaultSettingsMigration(
           break;
         case 22:
           await addNanoNodeList(nodes: nodes);
-          await addNanoPowNodeList(nodes: nodes);
+          await addNanoPowNodeList(nodes: powNodes);
           await changeNanoCurrentNodeToDefault(sharedPreferences: sharedPreferences, nodes: nodes);
           await changeNanoCurrentPowNodeToDefault(
               sharedPreferences: sharedPreferences, nodes: powNodes);


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description
1 line change to fix nano pow nodes loading into the nodes page

Please include a summary of the changes and which issue is fixed / feature is added. 

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
