### PR TITLE
migrate monero.dart from it's own repository to monero_c

### DIFF
--- a/cw_monero/pubspec.lock
+++ b/cw_monero/pubspec.lock
@@ -438,8 +438,8 @@ packages:
     dependency: "direct main"
     description:
       path: "impls/monero.dart"
-      ref: "64e02614f5a509dc6ea310282caa04d77fe5a3cb"
-      resolved-ref: "64e02614f5a509dc6ea310282caa04d77fe5a3cb"
+      ref: "c094ed5da69d2274747bf6edd7ca24124487bd34"
+      resolved-ref: "c094ed5da69d2274747bf6edd7ca24124487bd34"
       url: "https://github.com/mrcyjanek/monero_c"
     source: git
     version: "0.0.0"

--- a/cw_monero/pubspec.lock
+++ b/cw_monero/pubspec.lock
@@ -437,10 +437,10 @@ packages:
   monero:
     dependency: "direct main"
     description:
-      path: "."
-      ref: d46753eca865e9e56c2f0ef6fe485c42e11982c5
-      resolved-ref: d46753eca865e9e56c2f0ef6fe485c42e11982c5
-      url: "https://github.com/mrcyjanek/monero.dart"
+      path: "impls/monero.dart"
+      ref: "64e02614f5a509dc6ea310282caa04d77fe5a3cb"
+      resolved-ref: "64e02614f5a509dc6ea310282caa04d77fe5a3cb"
+      url: "https://github.com/mrcyjanek/monero_c"
     source: git
     version: "0.0.0"
   mutex:

--- a/cw_monero/pubspec.yaml
+++ b/cw_monero/pubspec.yaml
@@ -24,8 +24,9 @@ dependencies:
     path: ../cw_core
   monero:
     git:
-      url: https://github.com/mrcyjanek/monero.dart
-      ref: d46753eca865e9e56c2f0ef6fe485c42e11982c5
+      url: https://github.com/mrcyjanek/monero_c
+      ref: 64e02614f5a509dc6ea310282caa04d77fe5a3cb # monero_c hash
+      path: impls/monero.dart
   mutex: ^3.1.0
 
 dev_dependencies:

--- a/cw_monero/pubspec.yaml
+++ b/cw_monero/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   monero:
     git:
       url: https://github.com/mrcyjanek/monero_c
-      ref: 64e02614f5a509dc6ea310282caa04d77fe5a3cb # monero_c hash
+      ref: c094ed5da69d2274747bf6edd7ca24124487bd34 # monero_c hash
       path: impls/monero.dart
   mutex: ^3.1.0
 

--- a/cw_wownero/pubspec.lock
+++ b/cw_wownero/pubspec.lock
@@ -438,8 +438,8 @@ packages:
     dependency: "direct main"
     description:
       path: "impls/monero.dart"
-      ref: "64e02614f5a509dc6ea310282caa04d77fe5a3cb"
-      resolved-ref: "64e02614f5a509dc6ea310282caa04d77fe5a3cb"
+      ref: "c094ed5da69d2274747bf6edd7ca24124487bd34"
+      resolved-ref: "c094ed5da69d2274747bf6edd7ca24124487bd34"
       url: "https://github.com/mrcyjanek/monero_c"
     source: git
     version: "0.0.0"

--- a/cw_wownero/pubspec.lock
+++ b/cw_wownero/pubspec.lock
@@ -437,10 +437,10 @@ packages:
   monero:
     dependency: "direct main"
     description:
-      path: "."
-      ref: d46753eca865e9e56c2f0ef6fe485c42e11982c5
-      resolved-ref: d46753eca865e9e56c2f0ef6fe485c42e11982c5
-      url: "https://github.com/mrcyjanek/monero.dart"
+      path: "impls/monero.dart"
+      ref: "64e02614f5a509dc6ea310282caa04d77fe5a3cb"
+      resolved-ref: "64e02614f5a509dc6ea310282caa04d77fe5a3cb"
+      url: "https://github.com/mrcyjanek/monero_c"
     source: git
     version: "0.0.0"
   mutex:

--- a/cw_wownero/pubspec.yaml
+++ b/cw_wownero/pubspec.yaml
@@ -24,8 +24,9 @@ dependencies:
     path: ../cw_core
   monero:
     git:
-      url: https://github.com/mrcyjanek/monero.dart
-      ref: d46753eca865e9e56c2f0ef6fe485c42e11982c5
+      url: https://github.com/mrcyjanek/monero_c
+      ref: 64e02614f5a509dc6ea310282caa04d77fe5a3cb # monero_c hash
+      path: impls/monero.dart
   mutex: ^3.1.0
 
 dev_dependencies:

--- a/cw_wownero/pubspec.yaml
+++ b/cw_wownero/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   monero:
     git:
       url: https://github.com/mrcyjanek/monero_c
-      ref: 64e02614f5a509dc6ea310282caa04d77fe5a3cb # monero_c hash
+      ref: c094ed5da69d2274747bf6edd7ca24124487bd34 # monero_c hash
       path: impls/monero.dart
   mutex: ^3.1.0
 

--- a/scripts/prepare_moneroc.sh
+++ b/scripts/prepare_moneroc.sh
@@ -8,7 +8,7 @@ if [[ ! -d "monero_c" ]];
 then
     git clone https://github.com/mrcyjanek/monero_c --branch rewrite-wip
     cd monero_c
-    git checkout c094ed5da69d2274747bf6edd7ca24124487bd34
+    git checkout bcb328a4956105dc182afd0ce2e48fe263f5f20b # v0.18.3.3-RC51 
     git reset --hard
     git submodule update --init --force --recursive
     ./apply_patches.sh monero


### PR DESCRIPTION
# Description

This is more of a cleanup on the monero_c/monero.dart side - nothing changes in the API, but the package changed it's distribution url 

- [x] ~~Don't merge until this PR gets merged: https://github.com/MrCyjaneK/monero_c/pull/16~~

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods