### PR TITLE
monero fixes

### DIFF
--- a/cw_monero/lib/api/subaddress_list.dart
+++ b/cw_monero/lib/api/subaddress_list.dart
@@ -42,12 +42,16 @@ class Subaddress {
 
 List<Subaddress> getAllSubaddresses() {
   final size = monero.Wallet_numSubaddresses(wptr!, accountIndex: subaddress!.accountIndex);
-  return List.generate(size, (index) {
+  final list = List.generate(size, (index) {
     return Subaddress(
       accountIndex: subaddress!.accountIndex,
       addressIndex: index,
     );
   }).reversed.toList();
+  if (list.length == 0) {
+    list.add(Subaddress(addressIndex: 0, accountIndex: 0));
+  }
+  return list;
 }
 
 void addSubaddressSync({required int accountIndex, required String label}) {

--- a/cw_monero/lib/api/subaddress_list.dart
+++ b/cw_monero/lib/api/subaddress_list.dart
@@ -49,7 +49,7 @@ List<Subaddress> getAllSubaddresses() {
     );
   }).reversed.toList();
   if (list.length == 0) {
-    list.add(Subaddress(addressIndex: 0, accountIndex: 0));
+    list.add(Subaddress(addressIndex: subaddress!.accountIndex, accountIndex: 0));
   }
   return list;
 }

--- a/cw_monero/lib/api/wallet.dart
+++ b/cw_monero/lib/api/wallet.dart
@@ -131,7 +131,7 @@ void storeSync() async {
     return monero.Wallet_synchronized(Pointer.fromAddress(addr));
   });
   if (lastStorePointer == wptr!.address &&
-      lastStoreHeight + 5000 < monero.Wallet_blockChainHeight(wptr!) &&
+      lastStoreHeight + 5000 > monero.Wallet_blockChainHeight(wptr!) &&
       !synchronized) {
     return;
   }

--- a/cw_monero/lib/monero_wallet_addresses.dart
+++ b/cw_monero/lib/monero_wallet_addresses.dart
@@ -109,7 +109,7 @@ abstract class MoneroWalletAddressesBase extends WalletAddresses with Store {
         accountIndex: accountIndex,
         defaultLabel: defaultLabel,
         usedAddresses: usedAddresses.toList());
-    subaddress = subaddressList.subaddresses.last;
+    subaddress = (subaddressList.subaddresses.isEmpty) ? Subaddress(id: 0, address: address, label: defaultLabel) : subaddressList.subaddresses.last;
     address = subaddress!.address;
   }
 

--- a/cw_wownero/lib/api/subaddress_list.dart
+++ b/cw_wownero/lib/api/subaddress_list.dart
@@ -41,12 +41,16 @@ class Subaddress {
 
 List<Subaddress> getAllSubaddresses() {
   final size = wownero.Wallet_numSubaddresses(wptr!, accountIndex: subaddress!.accountIndex);
-  return List.generate(size, (index) {
+  final list = List.generate(size, (index) {
     return Subaddress(
       accountIndex: subaddress!.accountIndex,
       addressIndex: index,
     );
   }).reversed.toList();
+  if (list.isEmpty) {
+    list.add(Subaddress(addressIndex: 0, accountIndex: 0));
+  }
+  return list;
 }
 
 void addSubaddressSync({required int accountIndex, required String label}) {

--- a/cw_wownero/lib/api/subaddress_list.dart
+++ b/cw_wownero/lib/api/subaddress_list.dart
@@ -48,7 +48,7 @@ List<Subaddress> getAllSubaddresses() {
     );
   }).reversed.toList();
   if (list.isEmpty) {
-    list.add(Subaddress(addressIndex: 0, accountIndex: 0));
+    list.add(Subaddress(addressIndex: 0, accountIndex: subaddress!.accountIndex));
   }
   return list;
 }

--- a/cw_wownero/lib/wownero_wallet_addresses.dart
+++ b/cw_wownero/lib/wownero_wallet_addresses.dart
@@ -109,7 +109,7 @@ abstract class WowneroWalletAddressesBase extends WalletAddresses with Store {
         accountIndex: accountIndex,
         defaultLabel: defaultLabel,
         usedAddresses: usedAddresses.toList());
-    subaddress = subaddressList.subaddresses.last;
+    subaddress = (subaddressList.subaddresses.isEmpty) ? Subaddress(id: 0, address: address, label: defaultLabel) : subaddressList.subaddresses.last;
     address = subaddress!.address;
   }
 


### PR DESCRIPTION
# Description

This fixes the issue from the report that Omar sent me, as well as fixing a logic issue that was merged earlier...

I believe that the root of the issue of accessing .last / .first elements is this piece of code https://github.com/cake-tech/cake_wallet/blob/e58d87e94cc82e268fc5e5901e4bea47c7c4ce50/cw_monero/lib/monero_subaddress_list.dart#L28-L30 - or in general all the places where it is being set - we leave the variable as temporarily empty. I believe that the proper fix would be to add mutexes around that functions - as this should solve most of the issues (but will make the code async in all places, which may be undesired). For now it should be good.


# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
