### PR TITLE
make analyzer less red

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,7 +10,18 @@ analyzer:
     lib/generated/*.dart,
     cw_monero/ios/External/**,
     cw_shared_external/**,
-    shared_external/**]
+    shared_external/**,
+    lib/bitcoin/cw_bitcoin.dart,
+    lib/bitcoin_cash/cw_bitcoin_cash.dart,
+    lib/ethereum/cw_ethereum.dart,
+    lib/haven/cw_haven.dart,
+    lib/monero/cw_monero.dart,
+    lib/nano/cw_nano.dart,
+    lib/polygon/cw_polygon.dart,
+    lib/solana/cw_solana.dart,
+    lib/tron/cw_tron.dart,
+    lib/wownero/cw_wownero.dart,
+    ]
   language:
     strict-casts: true
     strict-raw-types: true

--- a/tool/download_moneroc_prebuilds.dart
+++ b/tool/download_moneroc_prebuilds.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:archive/archive_io.dart';
 
@@ -46,5 +48,13 @@ Future<void> main() async {
       final outputStream = OutputFileStream(localFilename.replaceAll(".xz", ""));
       outputStream.writeBytes(archive);
     }
+  }
+  if (Platform.isMacOS) {
+    print("Generating ios framework");
+    final result = Process.runSync("bash", [
+      "-c",
+      "cd scripts/ios && ./gen_framework.sh && cd ../.."
+    ]);
+    print((result.stdout+result.stderr).toString().trim());
   }
 }


### PR DESCRIPTION
# Description

Remove cw_*.dart files from analyzer
So my IDE is full of red, and I have to go and confirm that I do want to debug the app without fixing the errors (VSCode) or hide prompts warning me about that (Android Studio), because of errors in files that are not being used in the wallet.

Pros:
- no analyzer smalltalk for working code

Cons:
- no analyzer smalltalk for when something is wrong in the cw_*.dart files (it will still complain while compiling/running so it should be fine imo)

Also: `dart run tool/download_moneroc_prebuilds.dart` now runs gen_framework.sh to make running iOS app easier.

| With PR | Without |
| ---- | ---- |
| ![obraz](https://github.com/user-attachments/assets/6f6f2d14-6d41-474f-8585-4777b9445708) | ![obraz](https://github.com/user-attachments/assets/bce4cfc5-d34b-4ebf-9d04-fb4b8e5edab3) |

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
