### PR TITLE
Bump Haven to 4.1.0

### DIFF
--- a/scripts/android/build_haven.sh
+++ b/scripts/android/build_haven.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 . ./config.sh
-HAVEN_VERSION=tags/v4.0.2
+HAVEN_VERSION=tags/v4.1.0
 HAVEN_SRC_DIR=${WORKDIR}/haven
 
 git clone https://github.com/haven-protocol-org/haven-main.git ${HAVEN_SRC_DIR}

--- a/scripts/docker/build_haven.sh
+++ b/scripts/docker/build_haven.sh
@@ -2,7 +2,7 @@
 set -x -e
 
 . ./config.sh
-HAVEN_VERSION=tags/v4.0.2
+HAVEN_VERSION=tags/v4.1.0
 HAVEN_SRC_DIR=${WORKDIR}/haven
 
 git clone https://github.com/haven-protocol-org/haven-main.git ${HAVEN_SRC_DIR}

--- a/scripts/ios/build_haven.sh
+++ b/scripts/ios/build_haven.sh
@@ -4,7 +4,7 @@
 
 HAVEN_URL="https://github.com/haven-protocol-org/haven-main.git"
 HAVEN_DIR_PATH="${EXTERNAL_IOS_SOURCE_DIR}/haven"
-HAVEN_VERSION=tags/v4.0.2
+HAVEN_VERSION=tags/v4.1.0
 BUILD_TYPE=release
 PREFIX=${EXTERNAL_IOS_DIR}
 DEST_LIB_DIR=${EXTERNAL_IOS_LIB_DIR}/haven


### PR DESCRIPTION
# Description

Haven will have a hardfork on 28.08.2024, and upgrading to version 4.1.0 is required. There are no changes to the wallet api, however this update needs to applied also in Cake Wallet due to changes in the transaction validation rules. The new version compiles with Cake Wallet, does not require any changes besides bumping the version, and the tests performed on Android did not reveal any issues.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [n.a.] Format code
- [n.a.] Look for code duplication
- [n.a. ] Clear naming for variables and methods
