### PR TITLE
CW-745 don't show txkey when it's unavailable

### DIFF
--- a/cw_monero/lib/api/transaction_history.dart
+++ b/cw_monero/lib/api/transaction_history.dart
@@ -319,27 +319,9 @@ class Transaction {
     final txKey = monero.Wallet_getTxKey(wptr!, txid: monero.TransactionInfo_hash(txInfo));
     final status = monero.Wallet_status(wptr!);
     if (status != 0) {
-      return monero.Wallet_errorString(wptr!);
+      return "";
     }
-    return breakTxKey(txKey);
-  }
-
-  static String breakTxKey(String input) {
-    final x = 64;
-    StringBuffer buffer = StringBuffer();
-
-    for (int i = 0; i < input.length; i += x) {
-      int endIndex = i + x;
-      if (endIndex > input.length) {
-        endIndex = input.length;
-      }
-      buffer.write(input.substring(i, endIndex));
-      if (endIndex != input.length) {
-        buffer.write('\n\n');
-      }
-    }
-
-    return buffer.toString().trim();
+    return txKey;
   }
 
   Transaction.dummy({


### PR DESCRIPTION
# Description

This fixes the txkey display, and not show the error

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
