### PR TITLE
add missing error messages

### DIFF
--- a/cw_bitcoin/lib/exceptions.dart
+++ b/cw_bitcoin/lib/exceptions.dart
@@ -3,6 +3,11 @@ import 'package:cw_core/exceptions.dart';
 
 class BitcoinTransactionWrongBalanceException extends TransactionWrongBalanceException {
   BitcoinTransactionWrongBalanceException({super.amount}) : super(CryptoCurrency.btc);
+
+  @override
+  String toString() {
+    return "BitcoinTransactionWrongBalanceException: $amount, $currency";
+  }
 }
 
 class BitcoinTransactionNoInputsException extends TransactionNoInputsException {}
@@ -13,10 +18,20 @@ class BitcoinTransactionNoDustException extends TransactionNoDustException {}
 
 class BitcoinTransactionNoDustOnChangeException extends TransactionNoDustOnChangeException {
   BitcoinTransactionNoDustOnChangeException(super.max, super.min);
+
+  @override
+  String toString() {
+    return "BitcoinTransactionNoDustOnChangeException: max: $max, min: $min";
+  }
 }
 
 class BitcoinTransactionCommitFailed extends TransactionCommitFailed {
   BitcoinTransactionCommitFailed({super.errorMessage});
+
+  @override
+  String toString() {
+    return errorMessage??"unknown error";
+  }
 }
 
 class BitcoinTransactionCommitFailedDustChange extends TransactionCommitFailedDustChange {}

--- a/cw_core/lib/exceptions.dart
+++ b/cw_core/lib/exceptions.dart
@@ -24,6 +24,11 @@ class TransactionCommitFailed implements Exception {
   final String? errorMessage;
 
   TransactionCommitFailed({this.errorMessage});
+
+  @override
+  String toString() {
+    return errorMessage??"unknown error";
+  }
 }
 
 class TransactionCommitFailedDustChange implements Exception {}

--- a/cw_haven/lib/api/exceptions/setup_wallet_exception.dart
+++ b/cw_haven/lib/api/exceptions/setup_wallet_exception.dart
@@ -2,4 +2,9 @@ class SetupWalletException implements Exception {
   SetupWalletException({required this.message});
   
   final String message;
+
+  @override
+  String toString() {
+    return message;
+  }
 }

--- a/cw_monero/lib/api/exceptions/setup_wallet_exception.dart
+++ b/cw_monero/lib/api/exceptions/setup_wallet_exception.dart
@@ -2,4 +2,7 @@ class SetupWalletException implements Exception {
   SetupWalletException({required this.message});
   
   final String message;
+
+  @override
+  String toString() => message;
 }

--- a/cw_monero/lib/api/exceptions/wallet_restore_from_keys_exception.dart
+++ b/cw_monero/lib/api/exceptions/wallet_restore_from_keys_exception.dart
@@ -2,4 +2,7 @@ class WalletRestoreFromKeysException implements Exception {
   WalletRestoreFromKeysException({required this.message});
   
   final String message;
+
+  @override
+  String toString() => message;
 }

--- a/cw_monero/lib/api/exceptions/wallet_restore_from_seed_exception.dart
+++ b/cw_monero/lib/api/exceptions/wallet_restore_from_seed_exception.dart
@@ -2,4 +2,7 @@ class WalletRestoreFromSeedException implements Exception {
   WalletRestoreFromSeedException({required this.message});
   
   final String message;
+
+  @override
+  String toString() => message;
 }

--- a/cw_wownero/lib/api/exceptions/setup_wallet_exception.dart
+++ b/cw_wownero/lib/api/exceptions/setup_wallet_exception.dart
@@ -2,4 +2,7 @@ class SetupWalletException implements Exception {
   SetupWalletException({required this.message});
   
   final String message;
+
+  @override
+  String toString() => message;
 }

--- a/cw_wownero/lib/api/exceptions/wallet_restore_from_keys_exception.dart
+++ b/cw_wownero/lib/api/exceptions/wallet_restore_from_keys_exception.dart
@@ -2,4 +2,6 @@ class WalletRestoreFromKeysException implements Exception {
   WalletRestoreFromKeysException({required this.message});
   
   final String message;
+
+  String toString() => message;
 }


### PR DESCRIPTION
# Description

Some Exception classes were missing toString override, which caused the error to show only the class that was thrown, rather than the error.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
