### PR TITLE
fix cached wallet race condition

### DIFF
--- a/lib/reactions/on_current_wallet_change.dart
+++ b/lib/reactions/on_current_wallet_change.dart
@@ -10,9 +10,6 @@ import 'package:cw_core/transaction_history.dart';
 import 'package:cw_core/balance.dart';
 import 'package:cw_core/transaction_info.dart';
 import 'package:mobx/mobx.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:cake_wallet/di.dart';
-import 'package:cake_wallet/entities/preferences_key.dart';
 import 'package:cake_wallet/reactions/check_connection.dart';
 import 'package:cake_wallet/reactions/on_wallet_sync_status_change.dart';
 import 'package:cake_wallet/store/dashboard/fiat_conversion_store.dart';
@@ -65,10 +62,6 @@ void startCurrentWalletChangeReaction(
 
       startWalletSyncStatusChangeReaction(wallet, fiatConversionStore);
       startCheckConnectionReaction(wallet, settingsStore);
-      await getIt.get<SharedPreferences>().setString(PreferencesKey.currentWalletName, wallet.name);
-      await getIt
-          .get<SharedPreferences>()
-          .setInt(PreferencesKey.currentWalletType, serializeToInt(wallet.type));
 
       if (wallet.type == WalletType.monero ||
           wallet.type == WalletType.wownero ||

--- a/lib/store/app_store.dart
+++ b/lib/store/app_store.dart
@@ -1,8 +1,10 @@
 import 'package:cake_wallet/core/wallet_connect/web3wallet_service.dart';
 import 'package:cake_wallet/di.dart';
+import 'package:cake_wallet/entities/preferences_key.dart';
 import 'package:cake_wallet/reactions/wallet_connect.dart';
 import 'package:cake_wallet/utils/exception_handler.dart';
 import 'package:cw_core/transaction_info.dart';
+import 'package:cw_core/wallet_type.dart';
 import 'package:mobx/mobx.dart';
 import 'package:cw_core/balance.dart';
 import 'package:cw_core/wallet_base.dart';
@@ -11,6 +13,7 @@ import 'package:cake_wallet/store/wallet_list_store.dart';
 import 'package:cake_wallet/store/authentication_store.dart';
 import 'package:cake_wallet/store/settings_store.dart';
 import 'package:cake_wallet/store/node_list_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 part 'app_store.g.dart';
 
@@ -47,5 +50,9 @@ abstract class AppStoreBase with Store {
       getIt.get<Web3WalletService>().create();
       await getIt.get<Web3WalletService>().init();
     }
+    await getIt.get<SharedPreferences>().setString(PreferencesKey.currentWalletName, wallet.name);
+    await getIt
+        .get<SharedPreferences>()
+        .setInt(PreferencesKey.currentWalletType, serializeToInt(wallet.type));
   }
 }


### PR DESCRIPTION
Potential fix for the race condition of loading a wallet while the name in the shared prefs hasn't updated yet

Issue Number (if Applicable): Fixes #

# Description

Please include a summary of the changes and which issue is fixed / feature is added. 

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
