### PR TITLE
Fix Whitespace in secret_key.dart

### DIFF
--- a/tool/utils/secret_key.dart
+++ b/tool/utils/secret_key.dart
@@ -62,7 +62,7 @@ class SecretKey {
     SecretKey('bitcoinTestWalletReceiveAddress', () => ''),
     SecretKey('ethereumTestWalletReceiveAddress', () => ''),
     SecretKey('litecoinTestWalletReceiveAddress', () => ''),
-    SecretKey('bitco inCashTestWalletReceiveAddress', () => ''),
+    SecretKey('bitcoinCashTestWalletReceiveAddress', () => ''),
     SecretKey('polygonTestWalletReceiveAddress', () => ''),
     SecretKey('solanaTestWalletReceiveAddress', () => ''),
     SecretKey('tronTestWalletReceiveAddress', () => ''),


### PR DESCRIPTION
Fixes error during building 

```bash
#11 527.9 lib/.secrets.g.dart:57:7: Error: Type 'bitco' not found.
#11 527.9 const bitco inCashTestWalletReceiveAddress = '';
#11 527.9       ^^^^^
#11 533.3 lib/.secrets.g.dart:57:7: Error: 'bitco' isn't a type.
#11 533.3 const bitco inCashTestWalletReceiveAddress = '';
#11 533.3       ^^^^^
#11 548.1 Target kernel_snapshot failed: Exception
#11 548.1 
#11 548.2 
#11 548.2 FAILURE: Build failed with an exception.
```

blame: [0fcfd76](https://github.com/cake-tech/cake_wallet/commit/0fcfd76afd75b91665e25804859497aa46a051aa#diff-3e7b3d74f017ddcc2cf3937a053a07142d958550ed7d98921ba928a48a5fce84) :D