### PR TITLE
Hotfix CI

### DIFF
--- a/.github/workflows/pr_test_build_android.yml
+++ b/.github/workflows/pr_test_build_android.yml
@@ -286,3 +286,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/build/app/outputs/flutter-apk
+          name: "android apk"

--- a/.github/workflows/pr_test_build_android.yml
+++ b/.github/workflows/pr_test_build_android.yml
@@ -283,6 +283,6 @@ jobs:
         run: rm -rf build/app/outputs/flutter-apk/test-apk/
   
       - name: Upload Artifact to github
-        uses: kittaakos/upload-artifact-as-is@v0
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/build/app/outputs/flutter-apk

--- a/.github/workflows/pr_test_build_linux.yml
+++ b/.github/workflows/pr_test_build_linux.yml
@@ -224,6 +224,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/build/linux/x64/release/cakewallet_linux.zip
+          name: cakewallet_linux
 
       - name: Prepare virtual desktop
         if: ${{ contains(github.event.head_commit.message, 'run tests') }}
@@ -295,3 +296,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/screen_grab.mkv.gpg
+          name: tests_screen_grab

--- a/.github/workflows/pr_test_build_linux.yml
+++ b/.github/workflows/pr_test_build_linux.yml
@@ -221,7 +221,7 @@ jobs:
           popd
 
       - name: Upload Artifact to github
-        uses: kittaakos/upload-artifact-as-is@v0
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/build/linux/x64/release/cakewallet_linux.zip
 
@@ -292,6 +292,6 @@ jobs:
       - name: Upload Artifact to github
         if: always()
         continue-on-error: true
-        uses: kittaakos/upload-artifact-as-is@v0
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/screen_grab.mkv.gpg


### PR DESCRIPTION
It looks like during our sleep github decided to break artifact upload api..

![image](https://github.com/user-attachments/assets/d681cab7-6865-492d-ad41-f1d806dcd9ec)

This PR moves to using official action instead. Please merge after CI check passes, this can be another issue on github servers side.