### PR TITLE
decred: Update derivation info.

### DIFF
--- a/cw_decred/lib/api/libdcrwallet.dart
+++ b/cw_decred/lib/api/libdcrwallet.dart
@@ -26,66 +26,40 @@ void initLibdcrwallet(String logDir) {
 
 /// createWalletAsync calls the libdcrwallet's createWallet function
 /// asynchronously.
-Future<void> createWalletAsync(
-    {required String name,
-    required String dataDir,
-    required String password,
-    required String network,
-    String? mnemonic}) {
-  final args = <String, String>{
-    "name": name,
-    "dataDir": dataDir,
-    "password": password,
-    "network": network,
-    "mnemonic": mnemonic ?? "",
-  };
-  return compute(createWalletSync, args);
+Future<void> createWalletAsync(String config) {
+  return compute(createWalletSync, config);
 }
 
 /// createWalletSync calls the libdcrwallet's createWallet function
 /// synchronously.
-void createWalletSync(Map<String, String> args) {
-  final name = args["name"]!.toCString();
-  final dataDir = args["dataDir"]!.toCString();
-  final password = args["password"]!.toCString();
-  final mnemonic = args["mnemonic"]!.toCString();
-  final network = args["network"]!.toCString();
+void createWalletSync(String config) {
+  final cConfig = config.toCString();
 
   executePayloadFn(
-    fn: () => dcrwalletApi.createWallet(name, dataDir, network, password, mnemonic),
-    ptrsToFree: [name, dataDir, network, password, mnemonic],
+    fn: () => dcrwalletApi.createWallet(cConfig),
+    ptrsToFree: [cConfig],
   );
 }
 
-void createWatchOnlyWallet(String walletName, String datadir, String pubkey, String network) {
-  final cName = walletName.toCString();
-  final cDataDir = datadir.toCString();
-  final cPub = pubkey.toCString();
-  final cNet = network.toCString();
+void createWatchOnlyWallet(String config) {
+  final cConfig = config.toCString();
   executePayloadFn(
-    fn: () => dcrwalletApi.createWatchOnlyWallet(cName, cDataDir, cNet, cPub),
-    ptrsToFree: [cName, cDataDir, cNet, cPub],
+    fn: () => dcrwalletApi.createWatchOnlyWallet(cConfig),
+    ptrsToFree: [cConfig],
   );
 }
 
 /// loadWalletAsync calls the libdcrwallet's loadWallet function asynchronously.
-Future<void> loadWalletAsync({required String name, required String dataDir, required String net}) {
-  final args = <String, String>{
-    "name": name,
-    "dataDir": dataDir,
-    "network": net,
-  };
-  return compute(loadWalletSync, args);
+Future<void> loadWalletAsync(String config) {
+  return compute(loadWalletSync, config);
 }
 
 /// loadWalletSync calls the libdcrwallet's loadWallet function synchronously.
-void loadWalletSync(Map<String, String> args) {
-  final name = args["name"]!.toCString();
-  final dataDir = args["dataDir"]!.toCString();
-  final network = args["network"]!.toCString();
+void loadWalletSync(String config) {
+  final cConfig = config.toCString();
   executePayloadFn(
-    fn: () => dcrwalletApi.loadWallet(name, dataDir, network),
-    ptrsToFree: [name, dataDir, network],
+    fn: () => dcrwalletApi.loadWallet(cConfig),
+    ptrsToFree: [cConfig],
   );
 }
 

--- a/cw_decred/lib/wallet.dart
+++ b/cw_decred/lib/wallet.dart
@@ -250,11 +250,13 @@ abstract class DecredWalletBase
       persistantPeer = addr;
       libdcrwallet.closeWallet(walletInfo.name);
       final network = isTestnet ? "testnet" : "mainnet";
-      libdcrwallet.loadWalletSync({
+      final config = {
         "name": walletInfo.name,
-        "dataDir": walletInfo.dirPath,
-        "network": network,
-      });
+        "datadir": walletInfo.dirPath,
+        "net": network,
+        "unsyncedaddrs": true,
+      };
+      libdcrwallet.loadWalletSync(jsonEncode(config));
     }
     await this._startSync();
     connecting = false;
@@ -445,6 +447,7 @@ abstract class DecredWalletBase
       final fee = (feeDouble * 1e8).toInt().abs();
       final confs = d["confirmations"] ?? 0;
       final sendTime = d["time"] ?? 0;
+      final height = d["height"] ?? 0;
       final txInfo = DecredTransactionInfo(
         id: txid,
         amount: amount,
@@ -452,7 +455,7 @@ abstract class DecredWalletBase
         direction: direction,
         isPending: confs == 0,
         date: DateTime.fromMillisecondsSinceEpoch(sendTime * 1000, isUtc: true),
-        height: 0,
+        height: height,
         confirmations: confs,
         to: d["address"] ?? "",
       );

--- a/cw_decred/lib/wallet_service.dart
+++ b/cw_decred/lib/wallet_service.dart
@@ -49,8 +49,9 @@ class DecredWalletService extends WalletService<
       password: credentials.password!,
       network: isTestnet == true ? testnet : mainnet,
     );
-    credentials.walletInfo!.derivationPath =
-        isTestnet == true ? seedRestorePathTestnet : seedRestorePath;
+    final di = DerivationInfo(
+        derivationPath: isTestnet == true ? seedRestorePathTestnet : seedRestorePath);
+    credentials.walletInfo!.derivationInfo = di;
     final wallet =
         DecredWallet(credentials.walletInfo!, credentials.password!, this.unspentCoinsInfoSource);
     await wallet.init();
@@ -61,8 +62,8 @@ class DecredWalletService extends WalletService<
   Future<DecredWallet> openWallet(String name, String password) async {
     final walletInfo = walletInfoSource.values
         .firstWhereOrNull((info) => info.id == WalletBase.idFor(name, getType()))!;
-    final network = walletInfo.derivationPath == seedRestorePathTestnet ||
-            walletInfo.derivationPath == pubkeyRestorePathTestnet
+    final network = walletInfo.derivationInfo?.derivationPath == seedRestorePathTestnet ||
+            walletInfo.derivationInfo?.derivationPath == pubkeyRestorePathTestnet
         ? testnet
         : mainnet;
 
@@ -93,8 +94,8 @@ class DecredWalletService extends WalletService<
   Future<void> rename(String currentName, String password, String newName) async {
     final currentWalletInfo = walletInfoSource.values
         .firstWhereOrNull((info) => info.id == WalletBase.idFor(currentName, getType()))!;
-    final network = currentWalletInfo.derivationPath == seedRestorePathTestnet ||
-            currentWalletInfo.derivationPath == pubkeyRestorePathTestnet
+    final network = currentWalletInfo.derivationInfo?.derivationPath == seedRestorePathTestnet ||
+            currentWalletInfo.derivationInfo?.derivationPath == pubkeyRestorePathTestnet
         ? testnet
         : mainnet;
     final currentWallet = DecredWallet(currentWalletInfo, password, this.unspentCoinsInfoSource);
@@ -120,8 +121,9 @@ class DecredWalletService extends WalletService<
         password: credentials.password!,
         mnemonic: credentials.mnemonic,
         network: isTestnet == true ? testnet : mainnet);
-    credentials.walletInfo!.derivationPath =
-        isTestnet == true ? seedRestorePathTestnet : seedRestorePath;
+    final di = DerivationInfo(
+        derivationPath: isTestnet == true ? seedRestorePathTestnet : seedRestorePath);
+    credentials.walletInfo!.derivationInfo = di;
     final wallet =
         DecredWallet(credentials.walletInfo!, credentials.password!, this.unspentCoinsInfoSource);
     await wallet.init();
@@ -139,8 +141,9 @@ class DecredWalletService extends WalletService<
       credentials.pubkey,
       isTestnet == true ? testnet : mainnet,
     );
-    credentials.walletInfo!.derivationPath =
-        isTestnet == true ? pubkeyRestorePathTestnet : pubkeyRestorePath;
+    final di = DerivationInfo(
+        derivationPath: isTestnet == true ? pubkeyRestorePathTestnet : pubkeyRestorePath);
+    credentials.walletInfo!.derivationInfo = di;
     final wallet =
         DecredWallet(credentials.walletInfo!, credentials.password!, this.unspentCoinsInfoSource);
     await wallet.init();

--- a/cw_decred/lib/wallet_service.dart
+++ b/cw_decred/lib/wallet_service.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:cw_decred/api/libdcrwallet.dart';
 import 'package:cw_decred/wallet_creation_credentials.dart';
@@ -43,12 +44,14 @@ class DecredWalletService extends WalletService<
 
   @override
   Future<DecredWallet> create(DecredNewWalletCredentials credentials, {bool? isTestnet}) async {
-    await createWalletAsync(
-      name: credentials.walletInfo!.name,
-      dataDir: credentials.walletInfo!.dirPath,
-      password: credentials.password!,
-      network: isTestnet == true ? testnet : mainnet,
-    );
+    final config = {
+      "name": credentials.walletInfo!.name,
+      "datadir": credentials.walletInfo!.dirPath,
+      "pass": credentials.password!,
+      "net": isTestnet == true ? testnet : mainnet,
+      "unsyncedaddrs": true,
+    };
+    await createWalletAsync(jsonEncode(config));
     final di = DerivationInfo(
         derivationPath: isTestnet == true ? seedRestorePathTestnet : seedRestorePath);
     credentials.walletInfo!.derivationInfo = di;
@@ -72,11 +75,13 @@ class DecredWalletService extends WalletService<
       walletInfo.dirPath = await pathForWalletDir(name: name, type: getType());
     }
 
-    await loadWalletAsync(
-      name: walletInfo.name,
-      dataDir: walletInfo.dirPath,
-      net: network,
-    );
+    final config = {
+      "name": walletInfo.name,
+      "datadir": walletInfo.dirPath,
+      "net": network,
+      "unsyncedaddrs": true,
+    };
+    await loadWalletAsync(jsonEncode(config));
     final wallet = DecredWallet(walletInfo, password, this.unspentCoinsInfoSource);
     await wallet.init();
     return wallet;
@@ -115,12 +120,15 @@ class DecredWalletService extends WalletService<
   @override
   Future<DecredWallet> restoreFromSeed(DecredRestoreWalletFromSeedCredentials credentials,
       {bool? isTestnet}) async {
-    await createWalletAsync(
-        name: credentials.walletInfo!.name,
-        dataDir: credentials.walletInfo!.dirPath,
-        password: credentials.password!,
-        mnemonic: credentials.mnemonic,
-        network: isTestnet == true ? testnet : mainnet);
+    final config = {
+      "name": credentials.walletInfo!.name,
+      "datadir": credentials.walletInfo!.dirPath,
+      "pass": credentials.password!,
+      "mnemonic": credentials.mnemonic,
+      "net": isTestnet == true ? testnet : mainnet,
+      "unsyncedaddrs": true,
+    };
+    await createWalletAsync(jsonEncode(config));
     final di = DerivationInfo(
         derivationPath: isTestnet == true ? seedRestorePathTestnet : seedRestorePath);
     credentials.walletInfo!.derivationInfo = di;
@@ -135,12 +143,14 @@ class DecredWalletService extends WalletService<
   @override
   Future<DecredWallet> restoreFromKeys(DecredRestoreWalletFromPubkeyCredentials credentials,
       {bool? isTestnet}) async {
-    createWatchOnlyWallet(
-      credentials.walletInfo!.name,
-      credentials.walletInfo!.dirPath,
-      credentials.pubkey,
-      isTestnet == true ? testnet : mainnet,
-    );
+    final config = {
+      "name": credentials.walletInfo!.name,
+      "datadir": credentials.walletInfo!.dirPath,
+      "pubkey": credentials.pubkey,
+      "net": isTestnet == true ? testnet : mainnet,
+      "unsyncedaddrs": true,
+    };
+    createWatchOnlyWallet(jsonEncode(config));
     final di = DerivationInfo(
         derivationPath: isTestnet == true ? pubkeyRestorePathTestnet : pubkeyRestorePath);
     credentials.walletInfo!.derivationInfo = di;

--- a/cw_decred/pubspec.lock
+++ b/cw_decred/pubspec.lock
@@ -769,10 +769,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:

--- a/scripts/android/build_decred.sh
+++ b/scripts/android/build_decred.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 CW_DECRED_DIR=$(realpath ../..)/cw_decred
 LIBWALLET_PATH="${PWD}/decred/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="82ed8a80ae9fa3b15a2d5609bc748fc663be7e37" # v2.2.1
+LIBWALLET_VERSION="e02273ad75a029a4f020f11c4575025f4e4eb132"
 
 if [ -e $LIBWALLET_PATH ]; then
        rm -fr $LIBWALLET_PATH/{*,.*} || true

--- a/scripts/android/build_decred.sh
+++ b/scripts/android/build_decred.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 CW_DECRED_DIR=$(realpath ../..)/cw_decred
 LIBWALLET_PATH="${PWD}/decred/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="e02273ad75a029a4f020f11c4575025f4e4eb132"
+LIBWALLET_VERSION="c186a1040136552b7b610b51213b9ecf607db3aa"
 
 if [ -e $LIBWALLET_PATH ]; then
        rm -fr $LIBWALLET_PATH/{*,.*} || true

--- a/scripts/ios/build_decred.sh
+++ b/scripts/ios/build_decred.sh
@@ -3,7 +3,7 @@ set -e
 . ./config.sh
 LIBWALLET_PATH="${EXTERNAL_IOS_SOURCE_DIR}/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="82ed8a80ae9fa3b15a2d5609bc748fc663be7e37" # v2.2.1
+LIBWALLET_VERSION="e02273ad75a029a4f020f11c4575025f4e4eb132"
 
 if [ -e $LIBWALLET_PATH ]; then
        rm -fr $LIBWALLET_PATH

--- a/scripts/ios/build_decred.sh
+++ b/scripts/ios/build_decred.sh
@@ -3,7 +3,7 @@ set -e
 . ./config.sh
 LIBWALLET_PATH="${EXTERNAL_IOS_SOURCE_DIR}/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="e02273ad75a029a4f020f11c4575025f4e4eb132"
+LIBWALLET_VERSION="c186a1040136552b7b610b51213b9ecf607db3aa"
 
 if [ -e $LIBWALLET_PATH ]; then
        rm -fr $LIBWALLET_PATH

--- a/scripts/macos/build_decred.sh
+++ b/scripts/macos/build_decred.sh
@@ -4,7 +4,7 @@
 
 LIBWALLET_PATH="${EXTERNAL_MACOS_SOURCE_DIR}/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="82ed8a80ae9fa3b15a2d5609bc748fc663be7e37" # v2.2.1
+LIBWALLET_VERSION="e02273ad75a029a4f020f11c4575025f4e4eb132"
 
 echo "======================= DECRED LIBWALLET ========================="
 

--- a/scripts/macos/build_decred.sh
+++ b/scripts/macos/build_decred.sh
@@ -4,7 +4,7 @@
 
 LIBWALLET_PATH="${EXTERNAL_MACOS_SOURCE_DIR}/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="e02273ad75a029a4f020f11c4575025f4e4eb132"
+LIBWALLET_VERSION="c186a1040136552b7b610b51213b9ecf607db3aa"
 
 echo "======================= DECRED LIBWALLET ========================="
 


### PR DESCRIPTION
The wallet was panicking when viewing keys from watching only. Also the derivationInfo we were using was deprecated. This stops the panic and no longer uses the deprecated property.

Will add more commits for fixing list transacitons time and height if this is up for a while.