### PR TITLE
fix download monero_c prebuilds issue caused by cleanup

### DIFF
--- a/tool/download_moneroc_prebuilds.dart
+++ b/tool/download_moneroc_prebuilds.dart
@@ -43,11 +43,13 @@ Future<void> main() async {
       final url = asset["browser_download_url"] as String;
       printV("- downloading $localFilename");
       await _dio.download(url, localFilename);
-      printV("  extracting $localFilename");
-      final inputStream = InputFileStream(localFilename);
-      final archive = XZDecoder().decodeBuffer(inputStream);
-      final outputStream = OutputFileStream(localFilename.replaceAll(".xz", ""));
-      outputStream.writeBytes(archive);
+      if (localFilename.endsWith(".xz")) {
+        printV("  extracting $localFilename");
+        final inputStream = InputFileStream(localFilename);
+        final archive = XZDecoder().decodeBuffer(inputStream);
+        final outputStream = OutputFileStream(localFilename.replaceAll(".xz", ""));
+        outputStream.writeBytes(archive);
+      }
     }
   }
   if (Platform.isMacOS) {


### PR DESCRIPTION
# Description

I'm in the process of removing .xz compression of artifacts

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
