### PR TITLE
feat: Add fiat api and last used wallet type to support chat

### DIFF
--- a/lib/di.dart
+++ b/lib/di.dart
@@ -1260,7 +1260,8 @@ Future<void> setup({
   getIt.registerFactoryParam<OrderDetailsPage, Order, void>(
       (Order order, _) => OrderDetailsPage(getIt.get<OrderDetailsViewModel>(param1: order)));
 
-  getIt.registerFactory(() => SupportViewModel(getIt.get<SettingsStore>()));
+  getIt.registerFactory(() =>
+      SupportViewModel(getIt.get<SettingsStore>(), getIt.get<AppStore>()));
 
   getIt.registerFactory(() => SupportPage(getIt.get<SupportViewModel>()));
 

--- a/lib/src/screens/support_chat/support_chat_page.dart
+++ b/lib/src/screens/support_chat/support_chat_page.dart
@@ -26,6 +26,8 @@ class SupportChatPage extends BasePage {
               secureStorage,
               supportUrl: supportViewModel.fetchUrl(authToken: snapshot.data!),
               appVersion: supportViewModel.appVersion,
+              fiatApiMode: supportViewModel.fiatApiMode,
+              walletType: supportViewModel.walletType,
             );
           return Container();
         },

--- a/lib/src/screens/support_chat/widgets/chatwoot_widget.dart
+++ b/lib/src/screens/support_chat/widgets/chatwoot_widget.dart
@@ -11,11 +11,15 @@ class ChatwootWidget extends StatefulWidget {
     this.secureStorage, {
     required this.supportUrl,
     required this.appVersion,
+    required this.fiatApiMode,
+    required this.walletType,
   });
 
   final SecureStorage secureStorage;
   final String supportUrl;
   final String appVersion;
+  final String fiatApiMode;
+  final String walletType;
 
   @override
   ChatwootWidgetState createState() => ChatwootWidgetState();
@@ -43,8 +47,11 @@ class ChatwootWidgetState extends State<ChatwootWidget> {
                   if (eventType == 'loaded') {
                     final authToken = parsedMessage["config"]["authToken"];
                     _storeCookie(authToken as String);
-                    _setCustomAttributes(
-                        controller, {"app_version": widget.appVersion});
+                    _setCustomAttributes(controller, {
+                      "app_version": widget.appVersion,
+                      "fiat_api_mode": widget.fiatApiMode,
+                      "wallet_type": widget.walletType,
+                    });
                   }
                 }
               },

--- a/lib/view_model/support_view_model.dart
+++ b/lib/view_model/support_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:cake_wallet/.secrets.g.dart' as secrets;
 import 'package:cake_wallet/generated/i18n.dart';
+import 'package:cake_wallet/store/app_store.dart';
 import 'package:cake_wallet/store/settings_store.dart';
 import 'package:cake_wallet/view_model/settings/link_list_item.dart';
 import 'package:cake_wallet/view_model/settings/settings_list_item.dart';
@@ -11,9 +12,10 @@ part 'support_view_model.g.dart';
 class SupportViewModel = SupportViewModelBase with _$SupportViewModel;
 
 abstract class SupportViewModelBase with Store {
-  final SettingsStore settingsStore;
+  final SettingsStore _settingsStore;
+  final AppStore _appStore;
 
-  SupportViewModelBase(this.settingsStore)
+  SupportViewModelBase(this._settingsStore, this._appStore)
       : items = [
           LinkListItem(
               title: 'Email',
@@ -120,7 +122,11 @@ abstract class SupportViewModelBase with Store {
   }
 
   String get appVersion =>
-      "${isMoneroOnly ? "Monero.com" : "Cake Wallet"} - ${settingsStore.appVersion}";
+      "${isMoneroOnly ? "Monero.com" : "Cake Wallet"} - ${_settingsStore.appVersion}";
+
+  String get fiatApiMode => _settingsStore.fiatApiMode.title;
+
+  String get walletType => _appStore.wallet?.type.name ?? 'Unknown';
 
   List<SettingsListItem> items;
 }


### PR DESCRIPTION
# Description

This PR adds infos about wallet type and fiat api setting to Chatwoot chats.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed (Tested with Jack)
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
