### PR TITLE
decred: Fix background sync panic.

### DIFF
--- a/scripts/android/build_decred.sh
+++ b/scripts/android/build_decred.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 CW_DECRED_DIR=$(realpath ../..)/cw_decred
 LIBWALLET_PATH="${PWD}/decred/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="c186a1040136552b7b610b51213b9ecf607db3aa"
+LIBWALLET_VERSION="1f74eccbe0d84839084fc0358e17cc5d72845a71"
 
 if [ -e $LIBWALLET_PATH ]; then
        rm -fr $LIBWALLET_PATH/{*,.*} || true

--- a/scripts/ios/build_decred.sh
+++ b/scripts/ios/build_decred.sh
@@ -3,7 +3,7 @@ set -e
 . ./config.sh
 LIBWALLET_PATH="${EXTERNAL_IOS_SOURCE_DIR}/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="c186a1040136552b7b610b51213b9ecf607db3aa"
+LIBWALLET_VERSION="1f74eccbe0d84839084fc0358e17cc5d72845a71"
 
 if [ -e $LIBWALLET_PATH ]; then
        rm -fr $LIBWALLET_PATH

--- a/scripts/macos/build_decred.sh
+++ b/scripts/macos/build_decred.sh
@@ -4,7 +4,7 @@
 
 LIBWALLET_PATH="${EXTERNAL_MACOS_SOURCE_DIR}/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="c186a1040136552b7b610b51213b9ecf607db3aa"
+LIBWALLET_VERSION="1f74eccbe0d84839084fc0358e17cc5d72845a71"
 
 echo "======================= DECRED LIBWALLET ========================="
 


### PR DESCRIPTION
Fixes a recently found bug where the libwallet blows up while in the background. Was due to closing an already closed channel and has been fixed.
