### PR TITLE
switch stack from rwx to rw to fix issues on some linux distribution (closes #2079)

### DIFF
--- a/cw_monero/pubspec.lock
+++ b/cw_monero/pubspec.lock
@@ -511,8 +511,8 @@ packages:
     dependency: "direct main"
     description:
       path: "impls/monero.dart"
-      ref: "65608c09e9093f1cd42c6afd8e9131016c82574b"
-      resolved-ref: "65608c09e9093f1cd42c6afd8e9131016c82574b"
+      ref: "0947c08265f2a5bab09e90b251f5f997a6f1f2fd"
+      resolved-ref: "0947c08265f2a5bab09e90b251f5f997a6f1f2fd"
       url: "https://github.com/mrcyjanek/monero_c"
     source: git
     version: "0.0.0"

--- a/cw_monero/pubspec.yaml
+++ b/cw_monero/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   monero:
     git:
       url: https://github.com/mrcyjanek/monero_c
-      ref: 65608c09e9093f1cd42c6afd8e9131016c82574b
+      ref: 0947c08265f2a5bab09e90b251f5f997a6f1f2fd
       path: impls/monero.dart
   mutex: ^3.1.0
   ledger_flutter_plus: ^1.4.1

--- a/cw_wownero/pubspec.lock
+++ b/cw_wownero/pubspec.lock
@@ -471,8 +471,8 @@ packages:
     dependency: "direct main"
     description:
       path: "impls/monero.dart"
-      ref: "65608c09e9093f1cd42c6afd8e9131016c82574b"
-      resolved-ref: "65608c09e9093f1cd42c6afd8e9131016c82574b"
+      ref: "0947c08265f2a5bab09e90b251f5f997a6f1f2fd"
+      resolved-ref: "0947c08265f2a5bab09e90b251f5f997a6f1f2fd"
       url: "https://github.com/mrcyjanek/monero_c"
     source: git
     version: "0.0.0"

--- a/cw_wownero/pubspec.yaml
+++ b/cw_wownero/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   monero:
     git:
       url: https://github.com/mrcyjanek/monero_c
-      ref: 65608c09e9093f1cd42c6afd8e9131016c82574b # monero_c hash
+      ref: 0947c08265f2a5bab09e90b251f5f997a6f1f2fd # monero_c hash
       path: impls/monero.dart
   mutex: ^3.1.0
 

--- a/cw_zano/pubspec.lock
+++ b/cw_zano/pubspec.lock
@@ -476,8 +476,8 @@ packages:
     dependency: "direct main"
     description:
       path: "impls/monero.dart"
-      ref: "65608c09e9093f1cd42c6afd8e9131016c82574b"
-      resolved-ref: "65608c09e9093f1cd42c6afd8e9131016c82574b"
+      ref: "0947c08265f2a5bab09e90b251f5f997a6f1f2fd"
+      resolved-ref: "0947c08265f2a5bab09e90b251f5f997a6f1f2fd"
       url: "https://github.com/mrcyjanek/monero_c"
     source: git
     version: "0.0.0"

--- a/cw_zano/pubspec.yaml
+++ b/cw_zano/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   monero:
     git:
       url: https://github.com/mrcyjanek/monero_c
-      ref: 65608c09e9093f1cd42c6afd8e9131016c82574b # monero_c hash
+      ref: 0947c08265f2a5bab09e90b251f5f997a6f1f2fd # monero_c hash
       path: impls/monero.dart
 dev_dependencies:
   flutter_test:

--- a/scripts/prepare_moneroc.sh
+++ b/scripts/prepare_moneroc.sh
@@ -8,7 +8,7 @@ if [[ ! -d "monero_c/.git" ]];
 then
     git clone https://github.com/mrcyjanek/monero_c --branch master monero_c
     cd monero_c
-    git checkout 65608c09e9093f1cd42c6afd8e9131016c82574b
+    git checkout 0947c08265f2a5bab09e90b251f5f997a6f1f2fd
     git reset --hard
     git submodule update --init --force --recursive
     ./apply_patches.sh monero


### PR DESCRIPTION
# Description

Switches stack from rwx to rw to fix some distros preventing monero_libwalletw_api_c.so from loading.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
