### PR TITLE
CW-1025 renaming wallets makes them inaccessible

### DIFF
--- a/cw_monero/lib/monero_wallet.dart
+++ b/cw_monero/lib/monero_wallet.dart
@@ -506,6 +506,7 @@ abstract class MoneroWalletBase extends WalletBase<MoneroBalance,
       final currentCacheFile = File(renamedWalletPath);
       final currentKeysFile = File('$renamedWalletPath.keys');
       final currentAddressListFile = File('$renamedWalletPath.address.txt');
+      final backgroundSyncFile = File('$renamedWalletPath.background');
 
       final newWalletPath =
           await pathForWallet(name: newWalletName, type: type);
@@ -518,6 +519,9 @@ abstract class MoneroWalletBase extends WalletBase<MoneroBalance,
       }
       if (currentAddressListFile.existsSync()) {
         await currentAddressListFile.rename('$newWalletPath.address.txt');
+      }
+      if (backgroundSyncFile.existsSync()) {
+        await backgroundSyncFile.rename('$newWalletPath.background');
       }
 
       await backupWalletFiles(newWalletName);


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

rename background sync cache file

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
