### PR TITLE
Fix missing passphrase for bip39 Monero Wallets

### DIFF
--- a/cw_monero/lib/monero_wallet_service.dart
+++ b/cw_monero/lib/monero_wallet_service.dart
@@ -403,6 +403,8 @@ class MoneroWalletService extends WalletService<
 
     monero.Wallet_setCacheAttribute(wptr!,
         key: "cakewallet.seed.bip39", value: mnemonic);
+    monero.Wallet_setCacheAttribute(wptr!,
+        key: "cakewallet.passphrase", value: passphrase ?? '');
 
     monero.Wallet_store(wptr!);
 


### PR DESCRIPTION

# Description

Fix the missing passphrase for the bip39 monero wallets 

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
