### PR TITLE
CW-1015: Desktop Issues

### DIFF
--- a/lib/src/screens/buy/buy_sell_page.dart
+++ b/lib/src/screens/buy/buy_sell_page.dart
@@ -490,11 +490,19 @@ class BuySellPage extends BasePage {
           return DesktopExchangeCardsSection(
             firstExchangeCard: fiatExchangeCard,
             secondExchangeCard: cryptoExchangeCard,
+            onBuyTap: () => null,
+            onSellTap: () =>
+                buySellViewModel.isBuyAction ? buySellViewModel.changeBuySellAction() : null,
+            isBuySellOption: true,
           );
         } else {
           return DesktopExchangeCardsSection(
             firstExchangeCard: cryptoExchangeCard,
             secondExchangeCard: fiatExchangeCard,
+            onBuyTap: () =>
+                !buySellViewModel.isBuyAction ? buySellViewModel.changeBuySellAction() : null,
+            onSellTap: () => null,
+            isBuySellOption: true,
           );
         }
       },

--- a/lib/src/screens/exchange/widgets/desktop_exchange_cards_section.dart
+++ b/lib/src/screens/exchange/widgets/desktop_exchange_cards_section.dart
@@ -1,14 +1,21 @@
+import 'package:cake_wallet/src/screens/exchange/widgets/mobile_exchange_cards_section.dart';
 import 'package:flutter/material.dart';
 
 class DesktopExchangeCardsSection extends StatelessWidget {
-  final Widget firstExchangeCard;
-  final Widget secondExchangeCard;
-
   const DesktopExchangeCardsSection({
     Key? key,
     required this.firstExchangeCard,
     required this.secondExchangeCard,
+    this.isBuySellOption = false,
+    this.onBuyTap,
+    this.onSellTap,
   }) : super(key: key);
+
+  final Widget firstExchangeCard;
+  final Widget secondExchangeCard;
+  final bool isBuySellOption;
+  final VoidCallback? onBuyTap;
+  final VoidCallback? onSellTap;
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +25,18 @@ class DesktopExchangeCardsSection extends StatelessWidget {
         children: <Widget>[
           Padding(
             padding: EdgeInsets.only(top: 55, left: 24, right: 24),
-            child: firstExchangeCard,
+            child: Column(
+              children: [
+                if (isBuySellOption)
+                  Column(
+                    children: [
+                      const SizedBox(height: 16),
+                      BuySellOptionButtons(onBuyTap: onBuyTap, onSellTap: onSellTap),
+                    ],
+                  ),
+                firstExchangeCard,
+              ],
+            ),
           ),
           Padding(
             padding: EdgeInsets.only(top: 29, left: 24, right: 24),

--- a/lib/src/screens/pin_code/pin_code_widget.dart
+++ b/lib/src/screens/pin_code/pin_code_widget.dart
@@ -38,6 +38,7 @@ class PinCodeState<T extends PinCodeWidget> extends State<T> {
   static const fourPinLength = 4;
   final _gridViewKey = GlobalKey();
   final _key = GlobalKey<ScaffoldState>();
+  late final FocusNode _focusNode;
 
   int pinLength;
   String pin;
@@ -54,7 +55,17 @@ class PinCodeState<T extends PinCodeWidget> extends State<T> {
     pin = '';
     title = S.current.enter_your_pin;
     _aspectRatio = 0;
-    WidgetsBinding.instance.addPostFrameCallback(_afterLayout);
+    _focusNode = FocusNode();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusNode.requestFocus();
+      _afterLayout(_);
+    });
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
   }
 
   void setTitle(String title) => setState(() => this.title = title);
@@ -120,8 +131,8 @@ class PinCodeState<T extends PinCodeWidget> extends State<T> {
     );
 
     return KeyboardListener(
-      focusNode: FocusNode(),
-      autofocus: true,
+      focusNode: _focusNode,
+      autofocus: false,
       onKeyEvent: (keyEvent) {
         if (keyEvent is KeyDownEvent) {
           if (keyEvent.logicalKey.keyLabel == "Backspace") {
@@ -144,8 +155,7 @@ class PinCodeState<T extends PinCodeWidget> extends State<T> {
                 style: TextStyle(
                     fontSize: 20,
                     fontWeight: FontWeight.w500,
-                    color:
-                        Theme.of(context).extension<CakeTextTheme>()!.titleColor)),
+                    color: Theme.of(context).extension<CakeTextTheme>()!.titleColor)),
             Spacer(flex: 8),
             Container(
               width: 180,
@@ -162,7 +172,9 @@ class PinCodeState<T extends PinCodeWidget> extends State<T> {
                         shape: BoxShape.circle,
                         color: isFilled
                             ? Theme.of(context).extension<CakeTextTheme>()!.titleColor
-                            : Theme.of(context).extension<PinCodeTheme>()!.indicatorsColor
+                            : Theme.of(context)
+                                .extension<PinCodeTheme>()!
+                                .indicatorsColor
                                 .withOpacity(0.25),
                       ));
                 }),
@@ -225,7 +237,8 @@ class PinCodeState<T extends PinCodeWidget> extends State<T> {
                                         child: TextButton(
                                           onPressed: () => _pop(),
                                           style: TextButton.styleFrom(
-                                            backgroundColor: Theme.of(context).colorScheme.background,
+                                            backgroundColor:
+                                                Theme.of(context).colorScheme.background,
                                             shape: CircleBorder(),
                                           ),
                                           child: deleteIconImage,
@@ -250,7 +263,9 @@ class PinCodeState<T extends PinCodeWidget> extends State<T> {
                                         style: TextStyle(
                                             fontSize: 25.0,
                                             fontWeight: FontWeight.w600,
-                                            color: Theme.of(context).extension<CakeTextTheme>()!.titleColor)),
+                                            color: Theme.of(context)
+                                                .extension<CakeTextTheme>()!
+                                                .titleColor)),
                                   ),
                                 );
                               }),


### PR DESCRIPTION
fix(desktop-pin-code-issue): persist FocusNode so KeyboardListener works on macOS

Previously, every rebuild created a new FocusNode, so KeyboardListener never held focus and missed key events on macOS.

This change:
- Moves the FocusNode into state and initializes it in initState
- Requests focus once after the first frame
- Disposes of the FocusNode in dispose
- Removes the inline FocusNode creation from build

Issue Number (if Applicable): Fixes #

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
