### PR TITLE
fix: selection of the wordlist for seed validation on the restore from seed page

### DIFF
--- a/lib/src/screens/restore/wallet_restore_from_seed_form.dart
+++ b/lib/src/screens/restore/wallet_restore_from_seed_form.dart
@@ -215,7 +215,7 @@ class WalletRestoreFromSeedFormState extends State<WalletRestoreFromSeedForm> {
                           items: _getItems(),
                           selectedAtIndex: isPolyseed
                               ? 1
-                              : seedTypeController.value.text.contains("14") && widget.type == WalletType.wownero
+                              : (seedTypeController.value.text.contains("14") && widget.type == WalletType.wownero) || isBip39
                                   ? 2
                                   : 0,
                           mainAxisAlignment: MainAxisAlignment.start,
@@ -325,9 +325,9 @@ class WalletRestoreFromSeedFormState extends State<WalletRestoreFromSeedForm> {
       '${language.replaceAll("POLYSEED_", "")} (Seed language)';
 
   void _changeSeedType(MoneroSeedType item) {
-    _setSeedType(item);
-    _changeLanguage('English');
     widget.seedSettingsViewModel.setMoneroSeedType(item);
+    _setSeedType(item);
+    _changeLanguage('English', isPolyseed || isBip39);
   }
 
   void _setSeedType(MoneroSeedType item) {


### PR DESCRIPTION
Issue Number: Fixes #2248

# Description

This PR fixes the wordlist selection on the restore from seed screen for Monero Wallets 

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
