### PR TITLE
fix: Payjoin button not showing

### DIFF
--- a/lib/src/screens/receive/widgets/qr_widget.dart
+++ b/lib/src/screens/receive/widgets/qr_widget.dart
@@ -210,24 +210,30 @@ class QRWidget extends StatelessWidget {
                 ),
               ),
             ),
-            if (addressListViewModel.payjoinEndpoint.isNotEmpty) ...[
-              Padding(
-                padding: EdgeInsets.only(top: 12),
-                child: PrimaryImageButton(
-                  onPressed: () {
-                    Clipboard.setData(ClipboardData(
-                        text: addressListViewModel.payjoinEndpoint));
-                    showBar<void>(context, S.of(context).copied_to_clipboard);
-                  },
-                  image: Image.asset('assets/images/payjoin.png', width: 25,),
-                  text: S.of(context).copy_payjoin_url,
-                  color: Theme.of(context).cardColor,
-                  textColor: Theme.of(context)
-                      .extension<CakeTextTheme>()!
-                      .buttonTextColor,
+            Observer(
+              builder: (_) => Offstage(
+                offstage: addressListViewModel.payjoinEndpoint.isEmpty,
+                child: Padding(
+                  padding: EdgeInsets.only(top: 12),
+                  child: PrimaryImageButton(
+                    onPressed: () {
+                      Clipboard.setData(
+                          ClipboardData(text: addressUri.toString()));
+                      showBar<void>(context, S.of(context).copied_to_clipboard);
+                    },
+                    image: Image.asset(
+                      'assets/images/payjoin.png',
+                      width: 25,
+                    ),
+                    text: S.of(context).copy_payjoin_url,
+                    color: Theme.of(context).cardColor,
+                    textColor: Theme.of(context)
+                        .extension<CakeTextTheme>()!
+                        .buttonTextColor,
+                  ),
                 ),
               ),
-            ],
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
# Description

Fix an issue vik experienced with the copy payjoin url button not showing 

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
