### PR TITLE
misc-seed-page-fixes

### DIFF
--- a/lib/src/screens/restore/wallet_restore_from_seed_form.dart
+++ b/lib/src/screens/restore/wallet_restore_from_seed_form.dart
@@ -82,8 +82,11 @@ class WalletRestoreFromSeedFormState extends State<WalletRestoreFromSeedForm> {
 
   @override
   void initState() {
-    // _setSeedType(widget.seedTypeViewModel.moneroSeedType);
-    _setSeedType(MoneroSeedType.defaultSeedType);
+    if (widget.type == WalletType.monero) {
+      _setSeedType(widget.seedSettingsViewModel.moneroSeedType);
+    } else {
+      _setSeedType(MoneroSeedType.defaultSeedType);
+    }
     _setLanguageLabel(language);
 
     if (passwordTextEditingController != null) {
@@ -118,7 +121,8 @@ class WalletRestoreFromSeedFormState extends State<WalletRestoreFromSeedForm> {
     }
 
     if (repeatedPasswordListener != null) {
-      repeatedPasswordTextEditingController?.removeListener(repeatedPasswordListener!);
+      repeatedPasswordTextEditingController
+          ?.removeListener(repeatedPasswordListener!);
     }
 
     super.dispose();
@@ -158,11 +162,13 @@ class WalletRestoreFromSeedFormState extends State<WalletRestoreFromSeedForm> {
                 alignment: Alignment.centerRight,
                 children: [
                   BaseTextFormField(
-                    key: ValueKey('wallet_restore_from_seed_wallet_name_textfield_key'),
+                    key: ValueKey(
+                        'wallet_restore_from_seed_wallet_name_textfield_key'),
                     controller: nameTextEditingController,
                     hintText: S.of(context).wallet_name,
                     suffixIcon: IconButton(
-                      key: ValueKey('wallet_restore_from_seed_wallet_name_refresh_button_key'),
+                      key: ValueKey(
+                          'wallet_restore_from_seed_wallet_name_refresh_button_key'),
                       onPressed: () async {
                         final rName = await generateName();
                         FocusManager.instance.primaryFocus?.unfocus();
@@ -202,12 +208,15 @@ class WalletRestoreFromSeedFormState extends State<WalletRestoreFromSeedForm> {
             language: language,
             type: widget.type,
             onSeedChange: onSeedChange,
-            seedTextFieldKey: ValueKey('wallet_restore_from_seed_wallet_seeds_textfield_key'),
-            pasteButtonKey: ValueKey('wallet_restore_from_seed_wallet_seeds_paste_button_key'),
+            seedTextFieldKey:
+                ValueKey('wallet_restore_from_seed_wallet_seeds_textfield_key'),
+            pasteButtonKey: ValueKey(
+                'wallet_restore_from_seed_wallet_seeds_paste_button_key'),
           ),
           if ([WalletType.monero, WalletType.wownero].contains(widget.type))
             GestureDetector(
-              key: ValueKey('wallet_restore_from_seed_seedtype_picker_button_key'),
+              key: ValueKey(
+                  'wallet_restore_from_seed_seedtype_picker_button_key'),
               onTap: () async {
                 await showPopUp<void>(
                     context: context,
@@ -215,7 +224,9 @@ class WalletRestoreFromSeedFormState extends State<WalletRestoreFromSeedForm> {
                           items: _getItems(),
                           selectedAtIndex: isPolyseed
                               ? 1
-                              : (seedTypeController.value.text.contains("14") && widget.type == WalletType.wownero) || isBip39
+                              : (seedTypeController.value.text.contains("14") &&
+                                          widget.type == WalletType.wownero) ||
+                                      isBip39
                                   ? 2
                                   : 0,
                           mainAxisAlignment: MainAxisAlignment.start,
@@ -249,7 +260,8 @@ class WalletRestoreFromSeedFormState extends State<WalletRestoreFromSeedForm> {
                 obscureText: true)
           ],
           if (widget.displayLanguageSelector)
-            if (!seedTypeController.value.text.contains("14") && widget.displayLanguageSelector)
+            if (!seedTypeController.value.text.contains("14") &&
+                widget.displayLanguageSelector)
               GestureDetector(
                 onTap: () async {
                   await showPopUp<void>(
@@ -279,7 +291,8 @@ class WalletRestoreFromSeedFormState extends State<WalletRestoreFromSeedForm> {
             BlockchainHeightWidget(
               focusNode: widget.blockHeightFocusNode,
               key: blockchainHeightKey,
-              blockHeightTextFieldKey: ValueKey('wallet_restore_from_seed_blockheight_textfield_key'),
+              blockHeightTextFieldKey: ValueKey(
+                  'wallet_restore_from_seed_blockheight_textfield_key'),
               onHeightOrDateEntered: widget.onHeightOrDateEntered,
               hasDatePicker:
                   [WalletType.monero, WalletType.wownero].contains(widget.type),

--- a/lib/src/widgets/seed_widget.dart
+++ b/lib/src/widgets/seed_widget.dart
@@ -146,12 +146,12 @@ class SeedWidgetState extends State<SeedWidget> {
   }
 
   Future<void> _pasteText() async {
-    final value = await Clipboard.getData('text/plain');
+    final value = (await Clipboard.getData('text/plain'))?.text?.trim();
 
-    if (value?.text?.isNotEmpty ?? false) {
+    if (value?.isNotEmpty ?? false) {
       setState(() {
         _showPlaceholder = false;
-        controller.text = value!.text!;
+        controller.text = value!;
       });
     }
   }


### PR DESCRIPTION
# Description

Fixes Seed Type selection when restoring a Monero wallet, (if you select legacy and go back and enter the page again, it will show polyseed, but with legacy fields, and when you tap on it, it will show that the selected is legacy, yet it's written polyseed)

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
