### PR TITLE
fix: set `useLegacyPackaging = true` so `libtor.so` gets extracted

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,6 +38,12 @@ android {
     compileSdkVersion 35
     buildToolsVersion "35.0.0"
 
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
+
     lintOptions {
         disable 'InvalidPackage'
     }


### PR DESCRIPTION
# Description

This is a temporary workaround. Proper fix will involve not using `libtor.so` as an executable and using it as static library.
That fix will most likely occur when we will bring support for iOS.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
