### PR TITLE
fix: incorrect mapping of tokens for DFX

### DIFF
--- a/lib/buy/dfx/dfx_buy_provider.dart
+++ b/lib/buy/dfx/dfx_buy_provider.dart
@@ -169,6 +169,11 @@ class DFXBuyProvider extends BuyProvider {
         final responseData = jsonDecode(response.body);
 
         if (responseData is List && responseData.isNotEmpty) {
+          for (final i in responseData) {
+            if (assetsName.toLowerCase() == i["dexName"].toString().toLowerCase()) {
+              return i as Map<String, dynamic>;
+            }
+          }
           return responseData.first as Map<String, dynamic>;
         } else if (responseData is Map<String, dynamic>) {
           return responseData;
@@ -251,8 +256,6 @@ class DFXBuyProvider extends BuyProvider {
     }
 
     final action = isBuyAction ? 'buy' : 'sell';
-
-    if (isBuyAction && cryptoCurrency != wallet.currency) return null;
 
     final fiatCredentials = await fetchFiatCredentials(fiatCurrency.name.toString());
     if (fiatCredentials['id'] == null) return null;


### PR DESCRIPTION
# Description

Fixes an issue where DFX provider would always use ETH rate and won't show any other tokens as available

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
