### PR TITLE
fix: make socket calls sync

### DIFF
--- a/cw_core/lib/utils/proxy_socket/abstract.dart
+++ b/cw_core/lib/utils/proxy_socket/abstract.dart
@@ -40,8 +40,8 @@ abstract class ProxySocket {
   }
 
   Future<void> close();
-  Future<void> destroy();
-  Future<void> write(String data);
+  void destroy();
+  void write(String data);
   StreamSubscription<List<int>> listen(Function(Uint8List event) onData, {Function (Object error)? onError, Function ()? onDone, bool cancelOnError = true});
   ProxyAddress get address;
 }

--- a/cw_core/lib/utils/proxy_socket/insecure.dart
+++ b/cw_core/lib/utils/proxy_socket/insecure.dart
@@ -15,10 +15,10 @@ class ProxySocketInsecure implements ProxySocket {
   Future<void> close() => socket.close();
   
   @override
-  Future<void> destroy() async => socket.destroy();
+  void destroy() => socket.destroy();
   
   @override
-  Future<void> write(String data) async => socket.write(data);
+  void write(String data) => socket.write(data);
   
   @override
   StreamSubscription<List<int>> listen(Function(Uint8List event) onData, {Function(Object error)? onError, Function()? onDone, bool cancelOnError = true}) {

--- a/cw_core/lib/utils/proxy_socket/secure.dart
+++ b/cw_core/lib/utils/proxy_socket/secure.dart
@@ -15,10 +15,10 @@ class ProxySocketSecure implements ProxySocket {
   Future<void> close() => socket.close();
   
   @override
-  Future<void> destroy() async => socket.destroy();
+  void destroy() => socket.destroy();
   
   @override
-  Future<void> write(String data) async => socket.write(data);
+  void write(String data) => socket.write(data);
   
   @override
   StreamSubscription<List<int>> listen(Function(Uint8List event) onData, {Function(Object error)? onError, Function()? onDone, bool cancelOnError = true}) {

--- a/cw_core/lib/utils/proxy_socket/socks.dart
+++ b/cw_core/lib/utils/proxy_socket/socks.dart
@@ -16,10 +16,10 @@ class ProxySocketSocks implements ProxySocket {
   Future<void> close() => socket.close();
   
   @override
-  Future<void> destroy() => close();
+  void destroy() => close();
   
   @override
-  Future<void> write(String data) async => socket.write(data);
+  void write(String data) => socket.write(data);
 
   @override
   StreamSubscription<List<int>> listen(Function(Uint8List event) onData, {Function(Object error)? onError, Function()? onDone, bool cancelOnError = true}) {


### PR DESCRIPTION
# Description

Should fix issues that were caused by ProxyWrapper abstract classes that added unnecessary async, which caused error leaks.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
