### PR TITLE
CW-1129 fix: frozen coins displaying incorrect amounts in monero

### DIFF
--- a/cw_monero/lib/monero_wallet.dart
+++ b/cw_monero/lib/monero_wallet.dart
@@ -841,10 +841,12 @@ abstract class MoneroWalletBase extends WalletBase<MoneroBalance,
   }
 
   void _askForUpdateBalance() {
-    final unlockedBalance = _getUnlockedBalance();
+    final _ub = _getUnlockedBalance();
+    final _fb =_getFrozenBalance();
+    final unlockedBalance = _ub - _fb;
     final fullBalance = monero_wallet.getFullBalance(
-      accountIndex: walletAddresses.account!.id);
-    final frozenBalance = _getFrozenBalance();
+      accountIndex: walletAddresses.account!.id) - _fb;
+    final frozenBalance = _fb;
     if (balance[currency]!.fullBalance != fullBalance ||
         balance[currency]!.unlockedBalance != unlockedBalance ||
         balance[currency]!.frozenBalance != frozenBalance) {


### PR DESCRIPTION
# Description

fix: frozen coins displaying incorrect amounts in monero

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
