### PR TITLE
Migrate to new Chainflip endpoints

### DIFF
--- a/lib/exchange/provider/chainflip_exchange_provider.dart
+++ b/lib/exchange/provider/chainflip_exchange_provider.dart
@@ -297,18 +297,11 @@ class ChainflipExchangeProvider extends ExchangeProvider {
       throw Exception('Unexpected response: ${response.statusCode} / ${uri.toString()} / ${response.body}');
     }
 
-    //printV(response.body);
-
     final quotes = json.decode(response.body) as List<dynamic>;
 
     Map<String, dynamic> highestQuote = quotes.reduce((current, next) {
       double currentAmount = current['egressAmount'];
       double nextAmount = next['egressAmount'];
-
-      String currentType = current['type'];
-      String nextType = next['type'];
-
-      printV('Current: $currentType -> $currentAmount, Next: $nextType -> $nextAmount');
 
       return currentAmount > nextAmount ? current : next;
     });


### PR DESCRIPTION
# Description

When we initially added Chainflip a quote only returned 1 response, this has changed over time to include 2 responses. We now take this into account an select the best option for the user (the one returning most money).

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
