### PR TITLE
feat: enable DNSSEC BIP353 in PSBT

### DIFF
--- a/cw_bitcoin/lib/bitcoin_wallet.dart
+++ b/cw_bitcoin/lib/bitcoin_wallet.dart
@@ -21,6 +21,7 @@ import 'package:cw_bitcoin/psbt/v0_deserialize.dart';
 import 'package:cw_bitcoin/psbt/v0_finalizer.dart';
 import 'package:cw_core/crypto_currency.dart';
 import 'package:cw_core/encryption_file_utils.dart';
+import 'package:cw_core/output_info.dart';
 import 'package:cw_core/payjoin_session.dart';
 import 'package:cw_core/pending_transaction.dart';
 import 'package:cw_core/unspent_coins_info.dart';
@@ -284,6 +285,7 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
 
   Future<PsbtV2> buildPsbt({
     required List<BitcoinBaseOutput> outputs,
+    required List<OutputInfo> cwOutputs,
     required BigInt fee,
     required BasedUtxoNetwork network,
     required List<UtxoWithAddress> utxos,
@@ -312,7 +314,7 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
     }
 
     return PSBTTransactionBuild(
-            inputs: psbtReadyInputs, outputs: outputs, enableRBF: enableRBF)
+            inputs: psbtReadyInputs, outputs: outputs, enableRBF: enableRBF, cwOutputs: cwOutputs)
         .psbt;
   }
 
@@ -322,6 +324,7 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
     required BigInt fee,
     required BasedUtxoNetwork network,
     required List<UtxoWithAddress> utxos,
+    required List<OutputInfo> cwOutputs,
     required Map<String, PublicKeyWithDerivationPath> publicKeys,
     String? memo,
     bool enableRBF = false,
@@ -335,6 +338,7 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
       fee: fee,
       network: network,
       utxos: utxos,
+      cwOutputs: cwOutputs,
       publicKeys: publicKeys,
       masterFingerprint: masterFingerprint,
       memo: memo,
@@ -367,6 +371,7 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
                   isChange: e.isChange,
                 ))
             .toList(),
+        cwOutputs: credentials.outputs,
         fee: BigInt.from(tx.fee),
         network: network,
         memo: credentials.outputs.first.memo,

--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -42,6 +42,7 @@ import 'package:cw_core/wallet_info.dart';
 import 'package:cw_core/wallet_keys_file.dart';
 import 'package:cw_core/wallet_type.dart';
 import 'package:cw_core/unspent_coin_type.dart';
+import 'package:cw_core/output_info.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 import 'package:ledger_flutter_plus/ledger_flutter_plus.dart' as ledger;
@@ -1113,6 +1114,7 @@ abstract class ElectrumWalletBase
           memo: estimatedTx.memo,
           outputOrdering: BitcoinOrdering.none,
           enableRBF: true,
+          cwOutputs: transactionCredentials.outputs,
         );
 
         return PendingBitcoinTransaction(
@@ -1240,6 +1242,7 @@ abstract class ElectrumWalletBase
     required BigInt fee,
     required BasedUtxoNetwork network,
     required List<UtxoWithAddress> utxos,
+    required List<OutputInfo> cwOutputs,
     required Map<String, PublicKeyWithDerivationPath> publicKeys,
     String? memo,
     bool enableRBF = false,

--- a/cw_bitcoin/lib/litecoin_wallet.dart
+++ b/cw_bitcoin/lib/litecoin_wallet.dart
@@ -38,6 +38,7 @@ import 'package:cw_bitcoin/litecoin_wallet_addresses.dart';
 import 'package:cw_core/transaction_priority.dart';
 import 'package:cw_core/wallet_info.dart';
 import 'package:cw_core/wallet_keys_file.dart';
+import 'package:cw_core/output_info.dart';
 import 'package:flutter/foundation.dart';
 import 'package:grpc/grpc.dart';
 import 'package:hive/hive.dart';
@@ -1383,6 +1384,7 @@ abstract class LitecoinWalletBase extends ElectrumWallet with Store {
     required BigInt fee,
     required BasedUtxoNetwork network,
     required List<UtxoWithAddress> utxos,
+    required List<OutputInfo> cwOutputs,
     required Map<String, PublicKeyWithDerivationPath> publicKeys,
     String? memo,
     bool enableRBF = false,

--- a/cw_bitcoin/lib/psbt/transaction_builder.dart
+++ b/cw_bitcoin/lib/psbt/transaction_builder.dart
@@ -1,7 +1,9 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:bitcoin_base/bitcoin_base.dart';
 import 'package:convert/convert.dart';
+import 'package:cw_core/output_info.dart';
 import 'package:cw_core/utils/print_verbose.dart';
 import 'package:ledger_bitcoin/psbt.dart';
 
@@ -9,7 +11,7 @@ class PSBTTransactionBuild {
   final PsbtV2 psbt = PsbtV2();
 
   PSBTTransactionBuild(
-      {required List<PSBTReadyUtxoWithAddress> inputs, required List<BitcoinBaseOutput> outputs, bool enableRBF = true}) {
+      {required List<PSBTReadyUtxoWithAddress> inputs, required List<BitcoinBaseOutput> outputs, required List<OutputInfo> cwOutputs, bool enableRBF = true}) {
     psbt.setGlobalTxVersion(2);
     psbt.setGlobalInputCount(inputs.length);
     psbt.setGlobalOutputCount(outputs.length);
@@ -24,7 +26,7 @@ class PSBTTransactionBuild {
       psbt.setInputPreviousTxId(i, Uint8List.fromList(hex.decode(input.utxo.txHash).reversed.toList()));
       psbt.setInputOutputIndex(i, input.utxo.vout);
       psbt.setInputSequence(i, enableRBF ? 0x1 : 0xffffffff);
-
+      
 
       if (input.utxo.isSegwit()) {
         setInputSegwit(i, input);
@@ -43,6 +45,29 @@ class PSBTTransactionBuild {
       if (output is BitcoinOutput) {
         psbt.setOutputScript(i, Uint8List.fromList(output.address.toScriptPubKey().toBytes()));
         psbt.setOutputAmount(i, output.value.toInt());
+        if (cwOutputs.isNotEmpty) {
+          try {
+            final cwOutput = cwOutputs.where((e) => e.address.toLowerCase() == output.address.toAddress().toLowerCase()).firstOrNull;
+            if (cwOutput != null) {
+              final bip353Name = utf8.encode(cwOutput.extra['bip353_name'] as String);
+              final bip353Rsig = base64.decode(cwOutput.extra['bip353_rsig'] as String);
+
+              if (bip353Name.length > 255) {
+                printV('BIP353 name is too long, skipping');
+                continue;
+              }
+              final proof = Uint8List.fromList([
+                bip353Name.length,
+                ...bip353Name,
+                ...bip353Rsig,
+              ]);
+
+              psbt.setOutputDNSSECProof(i, proof);
+            }
+          } catch (e) {
+            printV('Error setting DNSSEC proof: $e');
+          }
+        }
       }
     }
   }

--- a/cw_bitcoin/pubspec.lock
+++ b/cw_bitcoin/pubspec.lock
@@ -597,8 +597,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/ledger-bitcoin"
-      ref: eab179d487cddda3f647f6608115a89662facde4
-      resolved-ref: eab179d487cddda3f647f6608115a89662facde4
+      ref: e8ab1a98493dfdd2277edde07a66b8d378ca70f6
+      resolved-ref: e8ab1a98493dfdd2277edde07a66b8d378ca70f6
       url: "https://github.com/cake-tech/ledger-flutter-plus-plugins"
     source: git
     version: "0.0.3"

--- a/cw_bitcoin/pubspec.yaml
+++ b/cw_bitcoin/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
     git:
       url: https://github.com/cake-tech/ledger-flutter-plus-plugins
       path: packages/ledger-bitcoin
-      ref: eab179d487cddda3f647f6608115a89662facde4
+      ref: e8ab1a98493dfdd2277edde07a66b8d378ca70f6
   ledger_litecoin:
     git:
       url: https://github.com/cake-tech/ledger-flutter-plus-plugins

--- a/cw_core/lib/output_info.dart
+++ b/cw_core/lib/output_info.dart
@@ -8,7 +8,8 @@ class OutputInfo {
     this.fiatAmount,
     this.note,
     this.extractedAddress,
-    this.memo});
+    this.memo,
+    this.extra = const {}});
 
   	final String? fiatAmount;
   	final String? cryptoAmount;
@@ -19,4 +20,5 @@ class OutputInfo {
   	final bool isParsedAddress;
   	final int? formattedCryptoAmount;
   	final String? memo;
+    final Map<String, dynamic> extra;
 }

--- a/lib/bitcoin/cw_bitcoin.dart
+++ b/lib/bitcoin/cw_bitcoin.dart
@@ -130,7 +130,8 @@ class CWBitcoin extends Bitcoin {
                 extractedAddress: out.extractedAddress,
                 isParsedAddress: out.isParsedAddress,
                 formattedCryptoAmount: out.formattedCryptoAmount,
-                memo: out.memo))
+                memo: out.memo,
+                extra: out.extra))
             .toList(),
         priority: priority as BitcoinTransactionPriority,
         feeRate: bitcoinFeeRate,

--- a/lib/entities/parse_address_from_domain.dart
+++ b/lib/entities/parse_address_from_domain.dart
@@ -344,7 +344,13 @@ class AddressResolver {
       if (bip353AddressMap != null && bip353AddressMap.isNotEmpty) {
         final chosenAddress = await Bip353Record.pickBip353AddressChoice(context, text, bip353AddressMap);
         if (chosenAddress != null) {
-          return ParsedAddress.fetchBip353AddressAddress(address: chosenAddress, name: text);
+          try {
+            final rsigRecord = await Bip353Record.fetchRsigRecord(text);
+            return ParsedAddress.fetchBip353AddressAddress(address: chosenAddress, name: text, rsigRecord: rsigRecord);
+          } catch (e) {
+            printV('Bip353Record.fetchBip353AddressAddress error: $e');
+            return ParsedAddress.fetchBip353AddressAddress(address: chosenAddress, name: text);
+          }
         }
       }
 

--- a/lib/entities/parsed_address.dart
+++ b/lib/entities/parsed_address.dart
@@ -26,6 +26,7 @@ class ParsedAddress {
     this.profileImageUrl = '',
     this.profileName = '',
     this.parseFrom = ParseFrom.notParsed,
+    this.bip353RsigRecord,
   });
 
   factory ParsedAddress.fetchEmojiAddress({
@@ -59,11 +60,13 @@ class ParsedAddress {
   factory ParsedAddress.fetchBip353AddressAddress ({
     required String address,
     required String name,
+    String? rsigRecord,
   }) {
     return ParsedAddress(
       addresses: [address],
       name: name,
       parseFrom: ParseFrom.bip353,
+      bip353RsigRecord: rsigRecord,
     );
   }
 
@@ -178,4 +181,5 @@ class ParsedAddress {
   final String profileImageUrl;
   final String profileName;
   final ParseFrom parseFrom;
+  final String? bip353RsigRecord;
 }

--- a/lib/view_model/send/output.dart
+++ b/lib/view_model/send/output.dart
@@ -289,6 +289,15 @@ abstract class OutputBase with Store {
     }
   }
 
+  Map<String, dynamic> get extra {
+    final fields = <String, dynamic>{};
+    if (parsedAddress.parseFrom == ParseFrom.bip353) {
+      fields['bip353_name'] = parsedAddress.name;
+      fields['bip353_rsig'] = parsedAddress.bip353RsigRecord;
+    }
+    return fields;
+  }
+
   void _setCryptoNumMaximumFractionDigits() {
     var maximumFractionDigits = 0;
 


### PR DESCRIPTION
# Description

feat: enable DNSSEC BIP353 in PSBT

This PR enables hardware wallets to validate DNSSEC proof of a BIP353 parsed address

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
