### PR TITLE
fix: use async api to checkNodeHealth

### DIFF
--- a/cw_monero/lib/api/wallet.dart
+++ b/cw_monero/lib/api/wallet.dart
@@ -175,7 +175,10 @@ int getNodeHeightSync() {
   return cachedNodeHeight;
 }
 
-bool isConnectedSync() => currentWallet?.connected() != 0;
+Future<bool> isConnected() async {
+  final wptrAddress = currentWallet!.ffiAddress();
+  return await Isolate.run(() => monero.Wallet_connected(Pointer.fromAddress(wptrAddress))) == 1;
+}
 
 Future<bool> setupNodeSync(
     {required String address,
@@ -395,8 +398,6 @@ Future<bool> _setupNodeSync(Map<String, Object?> args) async {
 void startRefresh() => startRefreshSync();
 
 Future<void> store() async => _storeSync(0);
-
-Future<bool> isConnected() async => isConnectedSync();
 
 Future<int> getNodeHeight() async => getNodeHeightSync();
 

--- a/cw_monero/lib/monero_wallet.dart
+++ b/cw_monero/lib/monero_wallet.dart
@@ -188,7 +188,7 @@ abstract class MoneroWalletBase extends WalletBase<MoneroBalance,
   Future<bool> checkNodeHealth() async {
     try {
       // Check if the wallet is currently connected to the daemon
-      final isConnected = monero_wallet.isConnectedSync();
+      final isConnected = await monero_wallet.isConnected();
       
       if (!isConnected) {
         return false; // It's not connected to daemon


### PR DESCRIPTION
# Description

fix: use async api to checkNodeHealth

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
