### PR TITLE
fix: pin hashlib version

### DIFF
--- a/pubspec_base.yaml
+++ b/pubspec_base.yaml
@@ -115,7 +115,7 @@ dependencies:
     git:
       url: https://github.com/vespr-wallet/ledger-flutter-plus
       ref: 60817d4b20144f9da9029f5034790272795b9d38
-  hashlib: ^1.19.2
+  hashlib: 1.19.2
   on_chain:
     git:
       url: https://github.com/cake-tech/on_chain.git


### PR DESCRIPTION
Fixes build issue in current main

# Description

```
../../.pub-cache/hosted/pub.dev/polyseed-0.0.7/lib/src/mnemonics/legacy/legacy_seed_lang.dart:131:29: Error: Too many positional arguments: 1 allowed, but 2 found.
Try removing the extra positional arguments.
    var checksum = crc32code(trimmedWords, Encoding.getByName('utf-8'));
                            ^
../../.pub-cache/hosted/pub.dev/hashlib-1.22.0/lib/src/crc32.dart:52:5: Context: Found this candidate, but the arguments don't match.
int crc32code(
    ^^^^^^^^^
Target kernel_snapshot_program failed: Exception
```

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
