### PR TITLE
feat: add currency override support in fiat conversion service

### DIFF
--- a/lib/core/fiat_conversion_service.dart
+++ b/lib/core/fiat_conversion_service.dart
@@ -48,11 +48,19 @@ Future<double> _fetchPrice(String crypto, String fiat, bool torOnly) async {
   }
 }
 
+/// Override specific [CryptoCurrency] to fix its price to the price of another
+/// e.g. nDEPS should have the same price as DEPS, but only DEPS is tracked
+CryptoCurrency _overrideCryptoCurrency(CryptoCurrency crypto) {
+  if (crypto.title == CryptoCurrency.ndeps.title)
+      return CryptoCurrency.deps;
+    return crypto;
+}
+
 class FiatConversionService {
   static Future<double> fetchPrice({
     required CryptoCurrency crypto,
     required FiatCurrency fiat,
     required bool torOnly,
   }) async =>
-      await _fetchPrice(crypto.toString(), fiat.toString(), torOnly);
+      await _fetchPrice(_overrideCryptoCurrency(crypto).toString(), fiat.toString(), torOnly);
 }


### PR DESCRIPTION
# Description

This PR ensures that nDEPS show a price despite not being tracked by the FIAT API since nDEPS are just unwraped DEPS 

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
