### PR TITLE
fix: prevent writes to socket after closing

### DIFF
--- a/cw_core/lib/utils/proxy_socket/insecure.dart
+++ b/cw_core/lib/utils/proxy_socket/insecure.dart
@@ -1,4 +1,5 @@
 
+import 'package:cw_core/utils/print_verbose.dart';
 import 'package:cw_core/utils/proxy_socket/abstract.dart';
 import 'dart:async';
 import 'dart:typed_data';
@@ -9,16 +10,30 @@ class ProxySocketInsecure implements ProxySocket {
 
   ProxySocketInsecure(this.socket);
   
+  bool _isClosed = false;
+
   ProxyAddress get address => ProxyAddress(host: socket.remoteAddress.host, port: socket.remotePort);
   
   @override
-  Future<void> close() => socket.close();
+  Future<void> close() {
+    _isClosed = true;
+    return socket.close();
+  }
   
   @override
-  void destroy() => socket.destroy();
+  void destroy() {
+    _isClosed = true;
+    socket.destroy();
+  }
   
   @override
-  void write(String data) => socket.write(data);
+  void write(String data) {
+    if (_isClosed) {
+      printV("ProxySocketInsecure: write: socket is closed");
+      return;
+    }
+    socket.write(data);
+  }
   
   @override
   StreamSubscription<List<int>> listen(Function(Uint8List event) onData, {Function(Object error)? onError, Function()? onDone, bool cancelOnError = true}) {

--- a/cw_core/lib/utils/proxy_socket/secure.dart
+++ b/cw_core/lib/utils/proxy_socket/secure.dart
@@ -2,23 +2,38 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:cw_core/utils/print_verbose.dart';
 import 'package:cw_core/utils/proxy_socket/abstract.dart';
 
 class ProxySocketSecure implements ProxySocket {
   final SecureSocket socket;
+
+  bool _isClosed = false;
 
   ProxySocketSecure(this.socket);
   
   ProxyAddress get address => ProxyAddress(host: socket.remoteAddress.host, port: socket.remotePort);
   
   @override
-  Future<void> close() => socket.close();
+  Future<void> close() {
+    _isClosed = true;
+    return socket.close();
+  }
   
   @override
-  void destroy() => socket.destroy();
+  void destroy() {
+    _isClosed = true;
+    socket.destroy();
+  }
   
   @override
-  void write(String data) => socket.write(data);
+  void write(String data) {
+    if (_isClosed) {
+      printV("ProxySocketSecure: write: socket is closed");
+      return;
+    }
+    socket.write(data);
+  }
   
   @override
   StreamSubscription<List<int>> listen(Function(Uint8List event) onData, {Function(Object error)? onError, Function()? onDone, bool cancelOnError = true}) {

--- a/cw_core/lib/utils/proxy_socket/socks.dart
+++ b/cw_core/lib/utils/proxy_socket/socks.dart
@@ -1,25 +1,35 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:cw_core/utils/print_verbose.dart';
 import 'package:cw_core/utils/proxy_socket/abstract.dart';
 import 'package:socks_socket/socks_socket.dart';
 
 class ProxySocketSocks implements ProxySocket {
   final SOCKSSocket socket;
-
+  bool _isClosed = false;
   ProxySocketSocks(this.socket);
   
   @override
   ProxyAddress get address => ProxyAddress(host: socket.proxyHost, port: socket.proxyPort);
   
   @override
-  Future<void> close() => socket.close();
+  Future<void> close() {
+    _isClosed = true;
+    return socket.close();
+  }
   
   @override
   void destroy() => close();
   
   @override
-  void write(String data) => socket.write(data);
+  void write(String data) {
+    if (_isClosed) {
+      printV("ProxySocketSocks: write: socket is closed");
+      return;
+    }
+    socket.write(data);
+  }
 
   @override
   StreamSubscription<List<int>> listen(Function(Uint8List event) onData, {Function(Object error)? onError, Function()? onDone, bool cancelOnError = true}) {


### PR DESCRIPTION
# Description

This fix prevents writes to socket after them being closed

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
