### PR TITLE
fix: don't close closed sockets

### DIFF
--- a/cw_core/lib/utils/proxy_socket/insecure.dart
+++ b/cw_core/lib/utils/proxy_socket/insecure.dart
@@ -15,13 +15,15 @@ class ProxySocketInsecure implements ProxySocket {
   ProxyAddress get address => ProxyAddress(host: socket.remoteAddress.host, port: socket.remotePort);
   
   @override
-  Future<void> close() {
+  Future<void> close() async {
+    if (_isClosed) return;
     _isClosed = true;
     return socket.close();
   }
   
   @override
-  void destroy() {
+  void destroy() async {
+    if (_isClosed) return;
     _isClosed = true;
     socket.destroy();
   }

--- a/cw_core/lib/utils/proxy_socket/secure.dart
+++ b/cw_core/lib/utils/proxy_socket/secure.dart
@@ -15,13 +15,15 @@ class ProxySocketSecure implements ProxySocket {
   ProxyAddress get address => ProxyAddress(host: socket.remoteAddress.host, port: socket.remotePort);
   
   @override
-  Future<void> close() {
+  Future<void> close() async {
+    if (_isClosed) return;
     _isClosed = true;
     return socket.close();
   }
   
   @override
-  void destroy() {
+  void destroy() async {
+    if (_isClosed) return;
     _isClosed = true;
     socket.destroy();
   }

--- a/cw_core/lib/utils/proxy_socket/socks.dart
+++ b/cw_core/lib/utils/proxy_socket/socks.dart
@@ -14,7 +14,8 @@ class ProxySocketSocks implements ProxySocket {
   ProxyAddress get address => ProxyAddress(host: socket.proxyHost, port: socket.proxyPort);
   
   @override
-  Future<void> close() {
+  Future<void> close() async {
+    if (_isClosed) return;
     _isClosed = true;
     return socket.close();
   }


### PR DESCRIPTION
# Description

This PR fixes socket passing close() call multiple times when state is already closed

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
