### PR TITLE
fix: handle username/password parsing for Monero node URIs with fallback to query parameters

### DIFF
--- a/lib/view_model/node_list/node_create_or_edit_view_model.dart
+++ b/lib/view_model/node_list/node_create_or_edit_view_model.dart
@@ -244,13 +244,18 @@ abstract class NodeCreateOrEditViewModelBase with Store {
         throw Exception('Invalid QR code: Unable to parse or missing host.');
       }
 
-      final userInfo = uri.userInfo;
-      final rpcUser = userInfo.length == 2 ? userInfo[0] : '';
-      final rpcPassword = userInfo.length == 2 ? userInfo[1] : '';
       final ipAddress = uri.host;
       final port = uri.hasPort ? uri.port.toString() : '';
       final path = uri.path;
-      final queryParams = uri.queryParameters; // Currently not used
+      final userInfo = uri.userInfo;
+      var rpcUser = userInfo.length == 2 ? userInfo[0] : '';
+      var rpcPassword = userInfo.length == 2 ? userInfo[1] : '';
+
+      if (uri.scheme == "monero_node" && rpcUser.isEmpty && rpcPassword.isEmpty) {
+        final queryParams = uri.queryParameters;
+        rpcUser = queryParams['username'] ?? '';
+        rpcPassword = queryParams['password'] ?? '';
+      }
 
       await Future.delayed(Duration(milliseconds: 345));
 


### PR DESCRIPTION
# Description

Add support for monero nodo NodeURI scheme

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
