### PR TITLE
chore: bump compileSdkVersion to 36 to prevent warnings during build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,7 +35,7 @@ if (appPropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 36
     buildToolsVersion "35.0.0"
 
     packagingOptions {


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

There's a warning currently when trying to run the app on android originating from ledger plugins, this fixes it and according to google is a fully backwards compatible change 

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
