### PR TITLE
feat: add `truncateDecimals` method to EVMChainFormatter and update transaction logic to improve decimal handling

### DIFF
--- a/cw_evm/lib/evm_chain_formatter.dart
+++ b/cw_evm/lib/evm_chain_formatter.dart
@@ -21,6 +21,16 @@ class EVMChainFormatter {
     }
   }
 
+  static String truncateDecimals(String amount, int decimals) {
+    final parts = amount.split(".");
+
+    if (parts.length == 2) {
+      parts[1] = parts[1].substring(0, parts[1].length > decimals ? decimals : parts[1].length);
+    }
+
+    return parts.join(".");
+  }
+
   static int _getDividerForInput(String amount) {
     final result = amount.split('.');
     if (result.length > 1) {

--- a/cw_evm/lib/evm_chain_wallet.dart
+++ b/cw_evm/lib/evm_chain_wallet.dart
@@ -490,7 +490,9 @@ abstract class EVMChainWalletBase
 
       final totalOriginalAmount = EVMChainFormatter.parseEVMChainAmountToDouble(
           outputs.fold(0, (acc, value) => acc + (value.formattedCryptoAmount ?? 0)));
-      totalAmount = parseFixed(totalOriginalAmount.toString(), exponent);
+
+      totalAmount = parseFixed(
+          EVMChainFormatter.truncateDecimals(totalOriginalAmount.toString(), exponent), exponent);
 
       final gasFeesModel = await calculateActualEstimatedFeeForCreateTransaction(
         amount: totalAmount,
@@ -512,7 +514,8 @@ abstract class EVMChainWalletBase
         final totalOriginalAmount =
             EVMChainFormatter.parseEVMChainAmountToDouble(output.formattedCryptoAmount ?? 0);
 
-        totalAmount =  parseFixed(totalOriginalAmount.toString(), exponent);
+        totalAmount = parseFixed(
+            EVMChainFormatter.truncateDecimals(totalOriginalAmount.toString(), exponent), exponent);
       }
 
       if (output.sendAll && transactionCurrency is Erc20Token) {

--- a/cw_evm/test/cw_evm_test.dart
+++ b/cw_evm/test/cw_evm_test.dart
@@ -1,12 +1,16 @@
+import 'package:cw_evm/evm_chain_formatter.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:cw_evm/cw_evm.dart';
-
 void main() {
-  test('adds one to input values', () {
-    final calculator = Calculator();
-    expect(calculator.addOne(2), 3);
-    expect(calculator.addOne(-7), -6);
-    expect(calculator.addOne(0), 1);
+  group('EVMChainFormatter', () {
+    group('truncateDecimals', () {
+      test('no decimals', () => expect(EVMChainFormatter.truncateDecimals("5", 6), "5"));
+      test('less than max decimals',
+          () => expect(EVMChainFormatter.truncateDecimals("5.00001", 6), "5.00001"));
+      test('max decimals',
+          () => expect(EVMChainFormatter.truncateDecimals("5.000001", 6), "5.000001"));
+      test('more than max decimals',
+          () => expect(EVMChainFormatter.truncateDecimals("5.0000001", 6), "5.000000"));
+    });
   });
 }


### PR DESCRIPTION
# Description

add `truncateDecimals` method to EVMChainFormatter and update transaction logic to improve decimal handling

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
