### PR TITLE
fix: use bash for bitbox build script

### DIFF
--- a/scripts/build_bitbox_flutter.sh
+++ b/scripts/build_bitbox_flutter.sh
@@ -1,6 +1,8 @@
+#!/bin/bash
+
 git clone https://github.com/konstantinullrich/bitbox_flutter
 cd bitbox_flutter
-./build_bindings.sh --dont-install
+bash ./build_bindings.sh --dont-install
 
 FILE=api.aar
 if [ -f "$FILE" ]; then


### PR DESCRIPTION
# Description

This fixes execution of the script on systems that have simple POSIX shell as /bin/sh (but still have bash installed)

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
