### PR TITLE
i18n: fix brand capitalization in exchange confirmation

### DIFF
--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -375,10 +375,6 @@
   "exchange_result_write_down_trade_id": "Please copy or write down the trade ID to continue.",
   "exchange_sync_alert_content": "Please wait until your wallet is synchronized",
   "exchange_trade_result_confirm": "By pressing send from Cake Wallet, you will be sending ${fetchingLabel} ${from} from your wallet called ${walletName} to the address shown below. Or you can send from your external wallet to the address/QR code on the send from external wallet details page.\n\nPlease press either of the buttons to continue or go back to change the amounts.",
-  "@exchange_trade_result_confirm": {
-
-    "description": "Brand must remain 'Cake Wallet' (proper case). Do not translate."
-},
   "expired": "Expired",
   "expires": "Expires",
   "expiresOn": "Expires on",

--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -374,7 +374,7 @@
   "exchange_result_write_down_ID": "*Please copy or write down your ID shown above.",
   "exchange_result_write_down_trade_id": "Please copy or write down the trade ID to continue.",
   "exchange_sync_alert_content": "Please wait until your wallet is synchronized",
-  "exchange_trade_result_confirm": "By pressing send from cake wallet, you will be sending ${fetchingLabel} ${from} from your wallet called ${walletName} to the address shown below. Or you can send from your external wallet to the address/QR code on the send from external wallet details page.\n\nPlease press either of the buttons to continue or go back to change the amounts.",
+  "exchange_trade_result_confirm": "By pressing send fromake walleCake Wallett, you will be sending ${fetchingLabel} ${from} from your wallet called ${walletName} to the address shown below. Or you can send from your external wallet to the address/QR code on the send from external wallet details page.\n\nPlease press either of the buttons to continue or go back to change the amounts.",
   "expired": "Expired",
   "expires": "Expires",
   "expiresOn": "Expires on",

--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -374,7 +374,7 @@
   "exchange_result_write_down_ID": "*Please copy or write down your ID shown above.",
   "exchange_result_write_down_trade_id": "Please copy or write down the trade ID to continue.",
   "exchange_sync_alert_content": "Please wait until your wallet is synchronized",
-  "exchange_trade_result_confirm": "By pressing send fromake walleCake Wallett, you will be sending ${fetchingLabel} ${from} from your wallet called ${walletName} to the address shown below. Or you can send from your external wallet to the address/QR code on the send from external wallet details page.\n\nPlease press either of the buttons to continue or go back to change the amounts.",
+  "exchange_trade_result_confirm": "By pressing send from Cake Wallet, you will be sending ${fetchingLabel} ${from} from your wallet called ${walletName} to the address shown below. Or you can send from your external wallet to the address/QR code on the send from external wallet details page.\n\nPlease press either of the buttons to continue or go back to change the amounts.",
   "expired": "Expired",
   "expires": "Expires",
   "expiresOn": "Expires on",

--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -375,6 +375,10 @@
   "exchange_result_write_down_trade_id": "Please copy or write down the trade ID to continue.",
   "exchange_sync_alert_content": "Please wait until your wallet is synchronized",
   "exchange_trade_result_confirm": "By pressing send from Cake Wallet, you will be sending ${fetchingLabel} ${from} from your wallet called ${walletName} to the address shown below. Or you can send from your external wallet to the address/QR code on the send from external wallet details page.\n\nPlease press either of the buttons to continue or go back to change the amounts.",
+  "@exchange_trade_result_confirm": {
+
+    "description": "Brand must remain 'Cake Wallet' (proper case). Do not translate."
+},
   "expired": "Expired",
   "expires": "Expires",
   "expiresOn": "Expires on",


### PR DESCRIPTION
> Fixes #2548 

I updated the English translation key 'exchange_trade_result_confirm' to capitalize 'Cake Wallet' and prevent edible-cake translations in other languages. The brand name should remain unlocalized in future translations.

 # Pull Request - Checklist
* [x]  Initial Manual Tests Passed
* [x]  Double check modified code and verify it with the feature/task requirements
* [x]  Format code
* [x]  Look for code duplication
* [x]  Clear naming for variables and methods
* [ ]  Manual tests in accessibility mode (TalkBack on Android) passed