### PR TITLE
LCW-1189 reown improvements

### DIFF
--- a/.github/workflows/pr_test_build_android.yml
+++ b/.github/workflows/pr_test_build_android.yml
@@ -202,14 +202,20 @@ jobs:
             pushd torch_dart
               tar -xzf ../torch_dart.tar.gz
             popd
+            rm ./torch_dart.tar.gz
           popd
 
-      - name: Fetch reown dependencies
+      - name: Fetch prebuilt Reown
         run: |
           set -x -e
-          wget https://static.mrcyjanek.net/lfs/cake-yttrium/x86_64.so -O android/app/src/main/jniLibs/x86_64/libuniffi_yttrium.so
-          wget https://static.mrcyjanek.net/lfs/cake-yttrium/arm64-v8a.so -O android/app/src/main/jniLibs/arm64-v8a/libuniffi_yttrium.so
-          wget https://static.mrcyjanek.net/lfs/cake-yttrium/armeabi-v7a.so -O android/app/src/main/jniLibs/armeabi-v7a/libuniffi_yttrium.so
+          pushd scripts
+            wget https://github.com/cake-tech/reown_flutter/releases/download/v0.0.4/reown_flutter-v0.0.4.tar.gz -O reown_flutter.tar.gz
+            mkdir reown_flutter
+            pushd reown_flutter
+              tar -xzf ../reown_flutter.tar.gz
+            popd
+            rm ./reown_flutter.tar.gz
+          popd
 
       - name: Execute Build and Setup Commands
         run: |

--- a/.github/workflows/pr_test_build_linux.yml
+++ b/.github/workflows/pr_test_build_linux.yml
@@ -186,6 +186,19 @@ jobs:
             pushd torch_dart
               tar -xzf ../torch_dart.tar.gz
             popd
+            rm ./torch_dart.tar.gz
+          popd
+
+      - name: Fetch prebuilt Reown
+        run: |
+          set -x -e
+          pushd scripts
+            wget https://github.com/cake-tech/reown_flutter/releases/download/v0.0.4/reown_flutter-v0.0.4.tar.gz -O reown_flutter.tar.gz
+            mkdir reown_flutter
+            pushd reown_flutter
+              tar -xzf ../reown_flutter.tar.gz
+            popd
+            rm ./reown_flutter.tar.gz
           popd
 
       - name: Execute Build and Setup Commands

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,7 @@ RUN ARCH=$(uname -m) && \
     "platforms;android-33" \
     "platforms;android-34" \
     "platforms;android-35" \
+    "platforms;android-36" \
     "build-tools;33.0.2" \
     "build-tools;33.0.1" \
     "build-tools;33.0.0" \

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,7 +102,6 @@ flutter {
 }
 
 dependencies {
-    implementation 'net.java.dev.jna:jna:5.17.0@aar'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - bitbox_flutter (0.0.1):
+    - Flutter
   - connectivity_plus (0.0.1):
     - Flutter
   - CryptoSwift (1.8.4)
@@ -112,6 +114,7 @@ PODS:
   - YttriumWrapper (0.8.35)
 
 DEPENDENCIES:
+  - bitbox_flutter (from `.symlinks/plugins/bitbox_flutter/ios`)
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - CryptoSwift
   - cw_decred (from `.symlinks/plugins/cw_decred/ios`)
@@ -158,6 +161,8 @@ SPEC REPOS:
     - YttriumWrapper
 
 EXTERNAL SOURCES:
+  bitbox_flutter:
+    :path: ".symlinks/plugins/bitbox_flutter/ios"
   connectivity_plus:
     :path: ".symlinks/plugins/connectivity_plus/ios"
   cw_decred:
@@ -226,31 +231,32 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/wakelock_plus/ios"
 
 SPEC CHECKSUMS:
-  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
+  bitbox_flutter: 9505732798041c413152669751beeaecc5fe400f
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   CryptoSwift: e64e11850ede528a02a0f3e768cec8e9d92ecb90
-  cw_decred: 9c0e1df74745b51a1289ec5e91fb9e24b68fa14a
-  cw_mweb: 22cd01dfb8ad2d39b15332006f22046aaa8352a3
-  device_display_brightness: 1510e72c567a1f6ce6ffe393dcd9afd1426034f7
-  device_info_plus: c6fb39579d0f423935b0c9ce7ee2f44b71b9fce6
-  devicelocale: 35ba84dc7f45f527c3001535d8c8d104edd5d926
+  cw_decred: a02cf30175a46971c1e2fa22c48407534541edc6
+  cw_mweb: 3aea2fb35b2bd04d8b2d21b83216f3b8fb768d85
+  device_display_brightness: 04374ebd653619292c1d996f00f42877ea19f17f
+  device_info_plus: 335f3ce08d2e174b9fdc3db3db0f4e3b1f66bd89
+  devicelocale: bd64aa714485a8afdaded0892c1e7d5b7f680cf8
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   dnssec_proof: d461cac7bd3301eb7447f87936745a0c1ae0a67e
-  fast_scanner: 44c00940355a51258cd6c2085734193cd23d95bc
-  file_picker: 09aa5ec1ab24135ccd7a1621c46c84134bfd6655
+  fast_scanner: 2cb1ad3e69e645e9980fb4961396ce5804caa3e3
+  file_picker: 9b3292d7c8bc68c8a7bf8eb78f730e49c8efc517
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
-  flutter_local_authentication: 1172a4dd88f6306dadce067454e2c4caf07977bb
-  flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
-  flutter_mailer: 2ef5a67087bc8c6c4cefd04a178bf1ae2c94cd83
-  flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
-  fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  in_app_review: 436034b18594851a7328d7f1c2ed5ec235b79cfc
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
+  flutter_local_authentication: 989278c681612f1ee0e36019e149137f114b9d7f
+  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
+  flutter_mailer: 3a8cd4f36c960fb04528d5471097270c19fec1c4
+  flutter_secure_storage: 2c2ff13db9e0a5647389bff88b0ecac56e3f3418
+  fluttertoast: 2c67e14dce98bbdb200df9e1acf610d7a6264ea1
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  in_app_review: 7dd1ea365263f834b8464673f9df72c80c17c937
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   payjoin_flutter: d9d4c8aa16bd5dfedb9b21d0edc8199e0187d96e
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   reown_yttrium: cee334ade64725b1d83f7b34c706a6aae2696d58
@@ -259,19 +265,12 @@ SPEC CHECKSUMS:
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sp_scanner: b1bc9321690980bdb44bba7ec85d5543e716d1b5
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
-  reown_yttrium: c0e87e5965fa60a3559564cc35cffbba22976089
-  SDWebImage: 9f177d83116802728e122410fb25ad88f5c7608a
-  sensitive_clipboard: d4866e5d176581536c27bb1618642ee83adca986
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sp_scanner: eaa617fa827396b967116b7f1f43549ca62e9a12
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  torch_dart: d2cf778332cc6e6a3b362dcf45e4dde52bc34e35
-  uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
-  universal_ble: cf52a7b3fd2e7c14d6d7262e9fdadb72ab6b88a6
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  wakelock_plus: 76957ab028e12bfa4e66813c99e46637f367fc7e
+  torch_dart: f4620705d10f05492fab047f2fa1c3a600e7d17d
+  uni_links: ed8c961e47ed9ce42b6d91e1de8049e38a4b3152
+  universal_ble: ff19787898040d721109c6324472e5dd4bc86adc
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
   YttriumWrapper: 31e937fe9fbe0f1314d2ca6be9ce9b379a059966
 
 PODFILE CHECKSUM: 5296465b1c6d14d506230356756826012f65d97a

--- a/pubspec_base.yaml
+++ b/pubspec_base.yaml
@@ -127,7 +127,8 @@ dependencies:
     git:
       url: https://github.com/cake-tech/on_chain.git
       ref: cake-update-v2
-  reown_walletkit: 1.1.5+1
+  reown_walletkit:
+    path: ./scripts/reown_flutter/packages/reown_walletkit
   blockchain_utils:
     git:
       url: https://github.com/cake-tech/blockchain_utils
@@ -181,7 +182,6 @@ dependency_overrides:
     git:
       url: https://github.com/cake-tech/web3dart.git
       ref: cake
-  flutter_secure_storage_platform_interface: 1.0.2
   protobuf: ^3.1.0
   bitcoin_base:
     git:

--- a/scripts/android/build_reown_deps.sh
+++ b/scripts/android/build_reown_deps.sh
@@ -1,32 +1,11 @@
 #!/bin/bash
 
-# NOTE: This script is used to build the reown dependencies for the android app.
-# ideally we should be able to get rid of this script when yttrium updates at some point.
-# CI uses prebuilds that are provided as-is at https://static.mrcyjanek.net/lfs/cake-yttrium/
-# please, do **NOT** use those prebuilds for production.
-
 cd "$(dirname $0)"
 
 set -x -e
 
-if [ ! -e yttrium/.git ]; then
-    rm -rf yttrium
-    git clone https://github.com/reown-com/yttrium
-fi
-cd yttrium
-# git checkout ed8e8f5af2029406263be5993e484c3a69c1db7a
-git reset --hard
-git checkout 9f81ab8e0fb879a994392d603b7908b2104d1735
-git reset --hard
+../prepare_reown.sh
 
-sed -i.bak "s/-i ''/-i.bak/g" build-kotlin.sh
-sed -i.bak "s/--bin uniffi-bindgen generate/-p kotlin-ffi --bin uniffi-bindgen generate/g" build-kotlin.sh
-sed -i.bak "s/stat -f%z/echo stat -f%z/g" build-kotlin.sh
-sed -i.bak "s/ -t arm64-v8a/ -t arm64-v8a -t x86_64/g" build-kotlin.sh
-
-cargo install cargo-ndk
-ENABLE_STRIP=false PROFILE=release bash -x ./build-kotlin.sh
-
-cp target/x86_64-linux-android/release/deps/libuniffi_yttrium.so ../../../android/app/src/main/jniLibs/x86_64/libuniffi_yttrium.so
-cp target/aarch64-linux-android/release/deps/libuniffi_yttrium.so ../../../android/app/src/main/jniLibs/arm64-v8a/libuniffi_yttrium.so
-cp target/armv7-linux-androideabi/release/deps/libuniffi_yttrium.so ../../../android/app/src/main/jniLibs/armeabi-v7a/libuniffi_yttrium.so
+../reown_flutter/scripts/build_native_deps.sh
+cd ../reown_flutter/scripts/yttrium/
+./generate_kotlin_locally.sh

--- a/scripts/linux/app_config.sh
+++ b/scripts/linux/app_config.sh
@@ -13,7 +13,7 @@ CONFIG_ARGS=""
 
 case $APP_LINUX_TYPE in
         $CAKEWALLET)
-		CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --dogecoin --base";;
+		CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --dogecoin --base --excludeFlutterSecureStorage";;
 esac
 
 cp -rf pubspec_description.yaml pubspec.yaml

--- a/scripts/prepare_reown.sh
+++ b/scripts/prepare_reown.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -x -e
+cd "$(dirname "$0")"
+
+# IMPORTANT: Make sure to update action 'Build Reown` in
+# - .github/workflows/pr_test_build_android.yml 
+# - .github/workflows/pr_test_build_linux.yml
+# https://github.com/cake-tech/reown_flutter/releases/download/v0.0.4/reown_flutter-v0.0.4.tar.gz
+
+HASH=8a6d79ef7a268c493eeba45feef9991eea119bbd
+
+if [[ ! -d "reown_flutter/.git" ]];
+then
+    rm -rf reown_flutter
+    git clone https://github.com/cake-tech/reown_flutter
+    cd reown_flutter
+else
+    cd reown_flutter
+    git fetch -a
+fi
+
+git reset --hard
+git checkout $HASH
+git reset --hard
+
+./scripts/generate_all.sh


### PR DESCRIPTION
# Description

fix: downgrade and fork reown
Due to reown changing their license in version
1.2.0 we switched to use last open source release
of reown with all fixes for flutter 3.32.0 and
16kb page size requirements.

chore: drop dependency overrides for reown
ci: switch prebuilds to use github releases instead of CDN
fix: reown socket errors in onDone and onError

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
