### PR TITLE
chore: don't default to installing system files in scripts

### DIFF
--- a/.github/workflows/automated_integration_test.yml
+++ b/.github/workflows/automated_integration_test.yml
@@ -256,7 +256,7 @@ jobs:
           echo MWEBD_HASH=$MWEBD_HASH >> /etc/environment
           pushd scripts/android
             gomobile init;
-            ./build_mwebd.sh --dont-install
+            ./build_mwebd.sh
           popd
 
       - name: Build Decred

--- a/.github/workflows/pr_test_build_android.yml
+++ b/.github/workflows/pr_test_build_android.yml
@@ -245,7 +245,7 @@ jobs:
           export MWEBD_HASH=$(cat scripts/android/build_mwebd.sh | grep 'git reset --hard' | xargs | awk '{ print $4 }')
           echo MWEBD_HASH=$MWEBD_HASH >> /etc/environment
           pushd scripts/android
-            ./build_mwebd.sh --dont-install
+            ./build_mwebd.sh
           popd
 
       - name: Build Decred

--- a/.github/workflows/pr_test_build_linux.yml
+++ b/.github/workflows/pr_test_build_linux.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           set -x -e
           pushd scripts
-            ./build_bitbox_flutter.sh --dont-install
+            ./build_bitbox_flutter.sh
           popd
 
       - name: Install Flutter dependencies
@@ -222,7 +222,7 @@ jobs:
           export MWEBD_HASH=$(cat scripts/android/build_mwebd.sh | grep 'git reset --hard' | xargs | awk '{ print $4 }')
           echo MWEBD_HASH=$MWEBD_HASH >> /etc/environment
           pushd scripts/android
-            ./build_mwebd.sh --dont-install
+            ./build_mwebd.sh
           popd
 
       - name: Build generated code

--- a/docs/builds/ANDROID.md
+++ b/docs/builds/ANDROID.md
@@ -28,7 +28,7 @@ pushd scripts/android
     ./app_config.sh
     ./build_monero_all.sh
     ./build_decred.sh
-    ./build_mwebd.sh --dont-install
+    ./build_mwebd.sh
 popd
 pushd android/app
     [[ -f key.jks ]] || keytool -genkey -v -keystore key.jks -keyalg RSA -keysize 2048 -validity 10000 -alias testKey -noprompt -dname "CN=CakeWallet, OU=CakeWallet, O=CakeWallet, L=Florida, S=America, C=USA" -storepass hunter1 -keypass hunter1

--- a/scripts/android/build_mwebd.sh
+++ b/scripts/android/build_mwebd.sh
@@ -1,6 +1,6 @@
-if [[ "$1" == "--dont-install" ]]; then
-  echo "Skipping Go installation as per --dont-install flag"
-else
+#!/bin/bash
+
+if [[ "$1" == "--install" ]]; then
   # install go > 1.24:
   wget https://go.dev/dl/go1.24.1.linux-amd64.tar.gz
   sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.24.1.linux-amd64.tar.gz

--- a/scripts/ios/build_mwebd.sh
+++ b/scripts/ios/build_mwebd.sh
@@ -2,9 +2,7 @@
 
 set -e -x
 
-if [[ "$1" == "--dont-install" ]]; then
-  echo "Skipping Go installation as per --dont-install flag"
-else
+if [[ "$1" == "--install" ]]; then
   # install go > 1.24:
   brew install go
   export PATH=$PATH:~/go/bin


### PR DESCRIPTION
# Description

Currently simply executing build scripts can break system env if not called with --dont-install, this PR inverts that logic by using --install instead.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
