### PR TITLE
decred: Add support for 12 and 24 word seeds.

### DIFF
--- a/cw_decred/lib/api/libdcrwallet.dart
+++ b/cw_decred/lib/api/libdcrwallet.dart
@@ -176,13 +176,13 @@ class Libwallet {
               ptrsToFree: [cName, cNumBlocks],
             );
             break;
-          case "createsignedtransaction":
+          case "createtransaction":
             final name = args["name"] ?? "";
             final signReq = args["signreq"] ?? "";
             final cName = name.toCString();
             final cSignReq = signReq.toCString();
             res = executePayloadFn(
-              fn: () => dcrwalletApi.createSignedTransaction(cName, cSignReq),
+              fn: () => dcrwalletApi.createTransaction(cName, cSignReq),
               ptrsToFree: [cName, cSignReq],
             );
             break;
@@ -490,16 +490,16 @@ class Libwallet {
     return res.payload;
   }
 
-  Future<String> createSignedTransaction(
-      String walletName, String createSignedTransactionReq) async {
+  Future<String> createTransaction(
+      String walletName, String createTransactionReq) async {
     if (_closed) throw StateError('Closed');
     final completer = Completer<Object?>.sync();
     final id = _idCounter++;
     _activeRequests[id] = completer;
     final req = {
-      "method": "createsignedtransaction",
+      "method": "createtransaction",
       "name": walletName,
-      "signreq": createSignedTransactionReq,
+      "signreq": createTransactionReq,
     };
     _commands.send((id, req));
     final res = await completer.future as PayloadResult;

--- a/cw_decred/lib/wallet.dart
+++ b/cw_decred/lib/wallet.dart
@@ -412,10 +412,11 @@ abstract class DecredWalletBase
       "feerate": creds.feeRate ?? defaultFeeRate,
       "password": _password,
       "sendall": sendAll,
+      "sign": true,
     };
-    final res = await _libwallet.createSignedTransaction(walletInfo.name, jsonEncode(signReq));
+    final res = await _libwallet.createTransaction(walletInfo.name, jsonEncode(signReq));
     final decoded = json.decode(res);
-    final signedHex = decoded["signedhex"];
+    final signedHex = decoded["hex"];
     final send = () async {
       await _libwallet.sendRawTransaction(walletInfo.name, signedHex);
       await updateBalance();

--- a/lib/src/screens/restore/wallet_restore_page.dart
+++ b/lib/src/screens/restore/wallet_restore_page.dart
@@ -605,7 +605,7 @@ class _WalletRestorePageBodyState extends State<_WalletRestorePageBody>
     }
 
     if ((walletRestoreViewModel.type == WalletType.decred) &&
-        seedWords.length != WalletRestoreViewModelBase.decredSeedMnemonicLength) {
+        !WalletRestoreViewModelBase.decredSeedMnemonicLengths.contains(seedWords.length)) {
       return false;
     }
 

--- a/lib/view_model/wallet_restore_view_model.dart
+++ b/lib/view_model/wallet_restore_view_model.dart
@@ -74,7 +74,7 @@ abstract class WalletRestoreViewModelBase extends WalletCreationVM with Store {
   }
 
   static const moneroSeedMnemonicLength = 25;
-  static const decredSeedMnemonicLength = 15;
+  static const decredSeedMnemonicLengths = [12, 15, 24];
 
   late List<WalletRestoreMode> availableModes;
   late final bool hasSeedLanguageSelector = [

--- a/scripts/android/build_decred.sh
+++ b/scripts/android/build_decred.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 CW_DECRED_DIR=$(realpath ../..)/cw_decred
 LIBWALLET_PATH="${PWD}/decred/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="05f8d7374999400fe4d525eb365c39b77d307b14"
+LIBWALLET_VERSION="29c832efedd48514db9552a0c95ef02ce9cd5dc8"
 
 if [[ -e $LIBWALLET_PATH ]]; then
     rm -fr $LIBWALLET_PATH || true

--- a/scripts/ios/build_decred.sh
+++ b/scripts/ios/build_decred.sh
@@ -3,7 +3,7 @@ set -e
 . ./config.sh
 LIBWALLET_PATH="${EXTERNAL_IOS_SOURCE_DIR}/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="05f8d7374999400fe4d525eb365c39b77d307b14"
+LIBWALLET_VERSION="29c832efedd48514db9552a0c95ef02ce9cd5dc8"
 
 if [[ -e $LIBWALLET_PATH ]]; then
     rm -fr $LIBWALLET_PATH

--- a/scripts/macos/build_decred.sh
+++ b/scripts/macos/build_decred.sh
@@ -4,7 +4,7 @@
 
 LIBWALLET_PATH="${EXTERNAL_MACOS_SOURCE_DIR}/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="05f8d7374999400fe4d525eb365c39b77d307b14"
+LIBWALLET_VERSION="29c832efedd48514db9552a0c95ef02ce9cd5dc8"
 
 echo "======================= DECRED LIBWALLET ========================="
 


### PR DESCRIPTION
Related to  #2594

Sets the libwallet to the most recent [commit](https://github.com/decred/libwallet/commit/29c832efedd48514db9552a0c95ef02ce9cd5dc8) which supports more seed types. The latest version also includes some changes for ledger so the create tx has an extra argument.