### PR TITLE
chore: update `trezor_connect` dependency to latest commit hash across pubspec files

### DIFF
--- a/cw_bitcoin/pubspec.yaml
+++ b/cw_bitcoin/pubspec.yaml
@@ -57,7 +57,7 @@ dependencies:
   trezor_connect:
     git:
       url: https://github.com/cake-tech/trezor_connect
-      ref: 59b3ceec158d3393b20d0c596cab2abcc62ac8e4
+      ref: d1242cea90f84b00200e7bcab914a5af750e23fb
   bitbox_flutter:
     path: ../scripts/bitbox_flutter
   socks_socket:

--- a/cw_evm/pubspec.yaml
+++ b/cw_evm/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   trezor_connect:
     git:
       url: https://github.com/cake-tech/trezor_connect
-      ref: 59b3ceec158d3393b20d0c596cab2abcc62ac8e4
+      ref: d1242cea90f84b00200e7bcab914a5af750e23fb
 
 dependency_overrides:
   web3dart:

--- a/pubspec_base.yaml
+++ b/pubspec_base.yaml
@@ -119,7 +119,7 @@ dependencies:
   trezor_connect:
     git:
       url: https://github.com/cake-tech/trezor_connect
-      ref: 59b3ceec158d3393b20d0c596cab2abcc62ac8e4
+      ref: d1242cea90f84b00200e7bcab914a5af750e23fb
   bitbox_flutter:
     path: ./scripts/bitbox_flutter
   hashlib: 1.19.2


### PR DESCRIPTION
# Description

This PR fixes iOS opening trezor-connect deeplinks in an in-app-browser.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
