### PR TITLE
decred: Add passphrase to restore from mnemonic.

### DIFF
--- a/cw_decred/lib/api/libdcrwallet.dart
+++ b/cw_decred/lib/api/libdcrwallet.dart
@@ -490,8 +490,7 @@ class Libwallet {
     return res.payload;
   }
 
-  Future<String> createTransaction(
-      String walletName, String createTransactionReq) async {
+  Future<String> createTransaction(String walletName, String createTransactionReq) async {
     if (_closed) throw StateError('Closed');
     final completer = Completer<Object?>.sync();
     final id = _idCounter++;

--- a/cw_decred/lib/wallet.dart
+++ b/cw_decred/lib/wallet.dart
@@ -37,8 +37,8 @@ class DecredWallet = DecredWalletBase with _$DecredWallet;
 
 abstract class DecredWalletBase
     extends WalletBase<DecredBalance, DecredTransactionHistory, DecredTransactionInfo> with Store {
-  DecredWalletBase(WalletInfo walletInfo, DerivationInfo derivationInfo, String password, Box<UnspentCoinsInfo> unspentCoinsInfo,
-      Libwallet libwallet, Function() closeLibwallet)
+  DecredWalletBase(WalletInfo walletInfo, DerivationInfo derivationInfo, String password,
+      Box<UnspentCoinsInfo> unspentCoinsInfo, Libwallet libwallet, Function() closeLibwallet)
       : _password = password,
         _libwallet = libwallet,
         _closeLibwallet = closeLibwallet,
@@ -46,13 +46,11 @@ abstract class DecredWalletBase
         this.unspentCoinsInfo = unspentCoinsInfo,
         this.watchingOnly =
             derivationInfo.derivationPath == DecredWalletService.pubkeyRestorePath ||
-                derivationInfo.derivationPath ==
-                    DecredWalletService.pubkeyRestorePathTestnet,
+                derivationInfo.derivationPath == DecredWalletService.pubkeyRestorePathTestnet,
         this.balance = ObservableMap.of({CryptoCurrency.dcr: DecredBalance.zero()}),
-        this.isTestnet = derivationInfo.derivationPath ==
-                DecredWalletService.seedRestorePathTestnet ||
-            derivationInfo.derivationPath ==
-                DecredWalletService.pubkeyRestorePathTestnet,
+        this.isTestnet =
+            derivationInfo.derivationPath == DecredWalletService.seedRestorePathTestnet ||
+                derivationInfo.derivationPath == DecredWalletService.pubkeyRestorePathTestnet,
         super(walletInfo, derivationInfo) {
     walletAddresses = DecredWalletAddresses(walletInfo, libwallet);
     transactionHistory = DecredTransactionHistory();

--- a/cw_decred/lib/wallet_addresses.dart
+++ b/cw_decred/lib/wallet_addresses.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'package:cw_core/utils/print_verbose.dart';
 import 'package:mobx/mobx.dart';
 
-import 'package:cw_core/address_info.dart';
 import 'package:cw_core/wallet_addresses.dart';
 import 'package:cw_core/wallet_info.dart';
 import 'package:cw_decred/api/libdcrwallet.dart';

--- a/cw_decred/lib/wallet_creation_credentials.dart
+++ b/cw_decred/lib/wallet_creation_credentials.dart
@@ -3,7 +3,8 @@ import 'package:cw_core/wallet_info.dart';
 import 'package:cw_core/hardware/hardware_account_data.dart';
 
 class DecredNewWalletCredentials extends WalletCredentials {
-  DecredNewWalletCredentials({required String name, WalletInfo? walletInfo, required this.isBip39, required this.mnemonic})
+  DecredNewWalletCredentials(
+      {required String name, WalletInfo? walletInfo, required this.isBip39, required this.mnemonic})
       : super(name: name, walletInfo: walletInfo);
 
   final bool isBip39;

--- a/cw_decred/pubspec.yaml
+++ b/cw_decred/pubspec.yaml
@@ -18,6 +18,11 @@ dependencies:
   cw_core:
     path: ../cw_core
 
+  mobx: any
+  ffi: any
+  path: any
+  hive: any
+  intl: any
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/scripts/android/build_decred.sh
+++ b/scripts/android/build_decred.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 CW_DECRED_DIR=$(realpath ../..)/cw_decred
 LIBWALLET_PATH="${PWD}/decred/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="29c832efedd48514db9552a0c95ef02ce9cd5dc8"
+LIBWALLET_VERSION="cbfeb71a1343ce93d24e4b11fc7268f733ab600c"
 
 if [[ -e $LIBWALLET_PATH ]]; then
     rm -fr $LIBWALLET_PATH || true

--- a/scripts/ios/build_decred.sh
+++ b/scripts/ios/build_decred.sh
@@ -3,7 +3,7 @@ set -e
 . ./config.sh
 LIBWALLET_PATH="${EXTERNAL_IOS_SOURCE_DIR}/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="29c832efedd48514db9552a0c95ef02ce9cd5dc8"
+LIBWALLET_VERSION="cbfeb71a1343ce93d24e4b11fc7268f733ab600c"
 
 if [[ -e $LIBWALLET_PATH ]]; then
     rm -fr $LIBWALLET_PATH

--- a/scripts/macos/build_decred.sh
+++ b/scripts/macos/build_decred.sh
@@ -4,7 +4,7 @@
 
 LIBWALLET_PATH="${EXTERNAL_MACOS_SOURCE_DIR}/libwallet"
 LIBWALLET_URL="https://github.com/decred/libwallet.git"
-LIBWALLET_VERSION="29c832efedd48514db9552a0c95ef02ce9cd5dc8"
+LIBWALLET_VERSION="cbfeb71a1343ce93d24e4b11fc7268f733ab600c"
 
 echo "======================= DECRED LIBWALLET ========================="
 


### PR DESCRIPTION
Adds a passphrase option to the libwallet. I am having trouble building recently so not tested within cake, I'm sorry. Working on building again.

The passphrase will not work with 15 words. Libwallet will return an error.

Also ran `dart format --line-length=100 .` and `dart fix --apply .`
