### PR TITLE
fix: windows storing the db in random places

### DIFF
--- a/cw_core/lib/db/sqlite.dart
+++ b/cw_core/lib/db/sqlite.dart
@@ -1,6 +1,7 @@
 
 import 'dart:io';
 
+import 'package:cw_core/root_dir.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 late Database db; 
@@ -8,6 +9,9 @@ late Database db;
 Future<void> initDb({String? pathOverride}) async {
   if (Platform.isLinux || Platform.isWindows) { 
     databaseFactory = databaseFactoryFfi;
+  }
+  if (Platform.isWindows) {
+    pathOverride ??= "${(await getAppDir()).path}/cake.db";
   }
   db = await openDatabase(
     pathOverride ?? "cake.db",


### PR DESCRIPTION
# Description

Ensure CakeWallet stores it's DB on Windows with the rest of the wallet files

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
