### PR TITLE
fix: fixes missing model generation that causes build failures

### DIFF
--- a/model_generator.sh
+++ b/model_generator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x -e
 
-for cwcoin in cw_{arbitrum,core,evm,monero,bitcoin,nano,bitcoin_cash,solana,tron,wownero,zano,decred,dogecoin,base}
+for cwcoin in cw_{core,evm,monero,bitcoin,nano,bitcoin_cash,solana,tron,wownero,zano,decred,dogecoin,base,arbitrum}
 do
     if [[ "x$1" == "xasync" ]];
     then


### PR DESCRIPTION
# Description

The omission of arbitrum in ./model_generator.sh was causing errors when building the app from scratch