### PR TITLE
fix: convert fiat to nano on send page

### DIFF
--- a/lib/view_model/send/output.dart
+++ b/lib/view_model/send/output.dart
@@ -1,14 +1,24 @@
+import 'dart:math';
+
+import 'package:cake_wallet/arbitrum/arbitrum.dart';
 import 'package:cake_wallet/base/base.dart';
+import 'package:cake_wallet/bitcoin/bitcoin.dart';
 import 'package:cake_wallet/decred/decred.dart';
 import 'package:cake_wallet/di.dart';
+import 'package:cake_wallet/entities/calculate_fiat_amount.dart';
 import 'package:cake_wallet/entities/calculate_fiat_amount_raw.dart';
+import 'package:cake_wallet/entities/contact_base.dart';
 import 'package:cake_wallet/entities/parse_address_from_domain.dart';
 import 'package:cake_wallet/entities/parsed_address.dart';
 import 'package:cake_wallet/ethereum/ethereum.dart';
+import 'package:cake_wallet/generated/i18n.dart';
+import 'package:cake_wallet/monero/monero.dart';
 import 'package:cake_wallet/polygon/polygon.dart';
 import 'package:cake_wallet/reactions/wallet_connect.dart';
 import 'package:cake_wallet/solana/solana.dart';
 import 'package:cake_wallet/src/screens/send/widgets/extract_address_from_parsed.dart';
+import 'package:cake_wallet/store/dashboard/fiat_conversion_store.dart';
+import 'package:cake_wallet/store/settings_store.dart';
 import 'package:cake_wallet/tron/tron.dart';
 import 'package:cake_wallet/wownero/wownero.dart';
 import 'package:cake_wallet/zano/zano.dart';
@@ -18,19 +28,10 @@ import 'package:cw_core/format_fixed.dart';
 import 'package:cw_core/transaction_history.dart';
 import 'package:cw_core/transaction_info.dart';
 import 'package:cw_core/utils/print_verbose.dart';
+import 'package:cw_core/wallet_base.dart';
+import 'package:cw_core/wallet_type.dart';
 import 'package:flutter/material.dart';
 import 'package:mobx/mobx.dart';
-import 'package:cw_core/wallet_base.dart';
-import 'package:cake_wallet/monero/monero.dart';
-import 'package:cake_wallet/entities/calculate_fiat_amount.dart';
-import 'package:cw_core/wallet_type.dart';
-import 'package:cake_wallet/store/dashboard/fiat_conversion_store.dart';
-import 'package:cake_wallet/store/settings_store.dart';
-import 'package:cake_wallet/generated/i18n.dart';
-import 'package:cake_wallet/bitcoin/bitcoin.dart';
-import 'package:cake_wallet/arbitrum/arbitrum.dart';
-
-import 'package:cake_wallet/entities/contact_base.dart';
 
 part 'output.g.dart';
 
@@ -350,9 +351,10 @@ abstract class OutputBase with Store {
   @action
   void _updateCryptoAmount() {
     try {
+      final decimals = min(20, cryptoCurrencyHandler().decimals);
       final crypto = (double.parse(fiatAmount.replaceAll(',', '.')) /
               _fiatConversationStore.prices[cryptoCurrencyHandler()]!)
-          .toStringAsFixed(cryptoCurrencyHandler().decimals);
+          .toStringAsFixed(decimals);
 
       if (cryptoAmount != crypto) {
         cryptoAmount = crypto;


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Fixes conversion fiat -> XNO on send page inputs by capping decimal places at 20.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
