### PR TITLE
refactor: remove double `_nextIndex` increment in `wallet_hardware_restore_view_model`

### DIFF
--- a/lib/view_model/wallet_hardware_restore_view_model.dart
+++ b/lib/view_model/wallet_hardware_restore_view_model.dart
@@ -14,9 +14,7 @@ import 'package:cw_core/hardware/hardware_account_data.dart';
 import 'package:cw_core/utils/print_verbose.dart';
 import 'package:cw_core/wallet_base.dart';
 import 'package:cw_core/wallet_credentials.dart';
-import 'package:cw_core/wallet_info.dart';
 import 'package:cw_core/wallet_type.dart';
-import 'package:hive/hive.dart';
 import 'package:mobx/mobx.dart';
 
 part 'wallet_hardware_restore_view_model.g.dart';
@@ -57,7 +55,7 @@ abstract class WalletHardwareRestoreViewModelBase extends WalletCreationVM with 
   Future<void> getNextAvailableAccounts(int limit) async {
     try {
       final service = await hardwareWalletVM.getHardwareWalletService(type);
-      List<HardwareAccountData> accounts = await service
+      final accounts = await service
           .getAvailableAccounts(index: _nextIndex, limit: limit);
 
       availableAccounts.addAll(accounts);
@@ -69,7 +67,6 @@ abstract class WalletHardwareRestoreViewModelBase extends WalletCreationVM with 
     }
 
     isLoadingMoreAccounts = false;
-    _nextIndex += limit;
   }
 
   @override


### PR DESCRIPTION
# Description

Fix Skipping the next chunk of account indexes during Hardware Wallet Recovery

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
