### PR TITLE
fix: alert close button clipping under navbar

### DIFF
--- a/lib/src/widgets/alert_close_button.dart
+++ b/lib/src/widgets/alert_close_button.dart
@@ -18,25 +18,27 @@ class AlertCloseButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final button = GestureDetector(
-      onTap: onTap ?? () => Navigator.of(context).pop(),
-      child: Semantics(
-        label: S.of(context).close,
-        button: true,
-        enabled: true,
-        child: Container(
-          height: 42,
-          width: 42,
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.onSurface,
-            shape: BoxShape.circle,
-          ),
-          child: Center(
-            child: image ??
-                Image.asset(
-                  'assets/images/close.png',
-                  color: Theme.of(context).colorScheme.surface,
-                ),
+    final button = SafeArea(
+      child: GestureDetector(
+        onTap: onTap ?? () => Navigator.of(context).pop(),
+        child: Semantics(
+          label: S.of(context).close,
+          button: true,
+          enabled: true,
+          child: Container(
+            height: 42,
+            width: 42,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.onSurface,
+              shape: BoxShape.circle,
+            ),
+            child: Center(
+              child: image ??
+                  Image.asset(
+                    'assets/images/close.png',
+                    color: Theme.of(context).colorScheme.surface,
+                  ),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Wrap alert close button in SafeArea to keep it from clipping under the system navbar.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
