### PR TITLE
fix: backup-compatible db location on all platforms

### DIFF
--- a/cw_core/lib/db/sqlite.dart
+++ b/cw_core/lib/db/sqlite.dart
@@ -15,10 +15,10 @@ Future<void> initDb({String? pathOverride}) async {
   final dbFileOld = File("${await getDatabasesPath()}/cake.db");
   final dbFile = File("${(await getAppDir()).path}/cake.db");
 
-  if (await dbFileOld.exists()) {
-    final copied = await dbFileOld.copy(dbFile.path);
-    if (await copied.exists()) {
-      await dbFileOld.delete();
+  if (dbFileOld.existsSync()) {
+    final copied = dbFileOld.copySync(dbFile.path);
+    if (copied.existsSync()) {
+      dbFileOld.deleteSync();
     }
   }
 


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Moves the SQLite database to getAppDir() for all platforms. This ensures the DB gets included in backups and no data is lost.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
