### PR TITLE
require whitespace in twitter/mastodon pinned posts

### DIFF
--- a/lib/entities/parse_address_from_domain.dart
+++ b/lib/entities/parse_address_from_domain.dart
@@ -293,7 +293,7 @@ class AddressResolver {
             final addressFromPinnedTweet = extractAddressByType(
                 raw: pinnedTweet,
                 type: CryptoCurrency.fromString(ticker, walletCurrency: wallet.currency),
-                requireSurroundingWhitespaces: false);
+                requireSurroundingWhitespaces: true);
             if (addressFromPinnedTweet != null) {
               return ParsedAddress.fetchTwitterAddress(
                   address: addressFromPinnedTweet,
@@ -332,7 +332,7 @@ class AddressResolver {
               await MastodonAPI.lookupUserByUserName(userName: userName, apiHost: hostName);
 
           if (mastodonUser != null) {
-            String? addressFromBio = extractAddressByType(raw: mastodonUser.note, type: currency, requireSurroundingWhitespaces: false);
+            String? addressFromBio = extractAddressByType(raw: mastodonUser.note, type: currency, requireSurroundingWhitespaces: true);
 
             if (addressFromBio != null && addressFromBio.isNotEmpty) {
               return ParsedAddress.fetchMastodonAddress(
@@ -348,7 +348,7 @@ class AddressResolver {
                 final userPinnedPostsText = pinnedPosts.map((item) => item.content).join('\n');
                 String? addressFromPinnedPost =
                     extractAddressByType(raw: userPinnedPostsText, type: currency,
-                        requireSurroundingWhitespaces: false);
+                        requireSurroundingWhitespaces: true);
 
                 if (addressFromPinnedPost != null && addressFromPinnedPost.isNotEmpty) {
                   return ParsedAddress.fetchMastodonAddress(


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description
Restores whitespace check to pinned Twitter and Mastodon posts to prevent addresses for other currencies be mistakenly interpreted as those for the current currency.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
