### PR TITLE
Remove replaced electrum transactions

### DIFF
--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -2705,7 +2705,6 @@ abstract class ElectrumWalletBase
 
   void _syncStatusReaction(SyncStatus syncStatus) async {
     printV("SYNC_STATUS_CHANGE: ${syncStatus}");
-    print((await electrumClient.getMempool("10540c13c5b7f8c36da1c732b07a91655c38e4a801e38011295d8a7a0b8e9674")));
     if (syncStatus is SyncingSyncStatus) {
       return;
     }


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Remove transactions replaced via RBF (replace by fee) from transaction history on the receiving end. This is achieved by checking if one of the saved transactions for a given address no longer gets returned by the API, at which point it is assumed invalid.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
