### PR TITLE
Load Edit backup password ViewModel as lazy singleton

### DIFF
--- a/lib/di.dart
+++ b/lib/di.dart
@@ -1353,8 +1353,8 @@ Future<void> setup({
 
   getIt.registerFactory(() => BackupPage(getIt.get<BackupViewModel>()));
 
-  getIt.registerSingleton<EditBackupPasswordViewModel>(
-    EditBackupPasswordViewModel(getIt.get<SecureStorage>()),
+  getIt.registerLazySingleton<EditBackupPasswordViewModel>(
+    () => EditBackupPasswordViewModel(getIt.get<SecureStorage>()),
   );
 
   getIt.registerFactory(() => BackupViewModel(


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Switches EditBackupPasswordViewModel from Singleton to LazySingleton to prevent loading before the backup password is created.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
