### PR TITLE
fix seed page on desktop

### DIFF
--- a/lib/src/widgets/seedphrase_grid_widget.dart
+++ b/lib/src/widgets/seedphrase_grid_widget.dart
@@ -12,17 +12,19 @@ class SeedPhraseGridWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
+    int minTiles = 1;
+    int maxTiles = 4;
     double desiredTileWidth = 120;
     double spacing = 4;
     double padding = 4;
     double screenWidth = MediaQuery.of(context).size.width;
 
     int crossAxisCount =
-    ((screenWidth + spacing - (2 * padding)) / (desiredTileWidth + spacing))
-        .floor();
+        ((screenWidth + spacing - (2 * padding)) / (desiredTileWidth + spacing)).floor();
 
-    if (crossAxisCount < 1) crossAxisCount = 1;
+
+    if (crossAxisCount > maxTiles) crossAxisCount = maxTiles;
+    if (crossAxisCount < minTiles) crossAxisCount = minTiles;
 
     return GridView.builder(
       itemCount: list.length,


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description
Fixes desktop seed page layout by capping the amount of seed word columns to 4.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
