### PR TITLE
"Save as" dialog for saving seed in desktop wallet creation

### DIFF
--- a/lib/src/screens/seed/wallet_seed_page.dart
+++ b/lib/src/screens/seed/wallet_seed_page.dart
@@ -1,11 +1,15 @@
+import 'dart:io';
+
 import 'package:cake_wallet/routes.dart';
 import 'package:cake_wallet/src/widgets/seedphrase_grid_widget.dart';
 import 'package:cake_wallet/src/widgets/warning_box_widget.dart';
 import 'package:cake_wallet/utils/clipboard_util.dart';
 import 'package:cake_wallet/utils/share_util.dart';
 import 'package:cake_wallet/utils/show_bar.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import "package:file_picker/file_picker.dart";
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:cake_wallet/generated/i18n.dart';
 import 'package:cake_wallet/src/widgets/primary_button.dart';
@@ -104,10 +108,7 @@ class WalletSeedPage extends BasePage {
                           child: PrimaryButton(
                             key: ValueKey('wallet_seed_page_save_seeds_button_key'),
                             onPressed: () {
-                              ShareUtil.share(
-                                text: walletSeedViewModel.seed,
-                                context: context,
-                              );
+                              _shareSeed(context);
                             },
                             text: S.of(context).save,
                             color: Theme.of(context).colorScheme.surfaceContainer,
@@ -138,5 +139,30 @@ class WalletSeedPage extends BasePage {
         ),
       ),
     );
+  }
+
+  void _shareSeed(BuildContext context) async {
+    switch(defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+      ShareUtil.share(
+        text: walletSeedViewModel.seed,
+        context: context,
+      );
+      break;
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+      case TargetPlatform.linux:
+        final path = await FilePicker.platform.saveFile(
+          dialogTitle: "Save seed as",
+          fileName: "${walletSeedViewModel.name}-seed.txt",
+        );
+        if(path != null) {
+          final file = File(path);
+          await file.writeAsString(walletSeedViewModel.seed);
+        }
+      default:
+break;
+    }
   }
 }


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

On desktop platforms, replaces the share sheet triggered by pressing "Save" on the wallet creation seed page with a "save as" dialog that saves a local text file.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
