### PR TITLE
fix: prevent RBF for Silent Payment addresses in Bitcoin transactions

### DIFF
--- a/lib/view_model/transaction_details_view_model.dart
+++ b/lib/view_model/transaction_details_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:cake_wallet/core/address_validator.dart';
 import 'package:cake_wallet/tron/tron.dart';
 import 'package:cake_wallet/wownero/wownero.dart';
 import 'package:cw_core/currency_for_wallet_type.dart';
@@ -947,6 +948,16 @@ abstract class TransactionDetailsViewModelBase with Store {
   Future<void> _checkForRBF(TransactionInfo tx) async {
     if (wallet.type == WalletType.bitcoin &&
         transactionInfo.direction == TransactionDirection.outgoing) {
+      final descriptionKey = '${transactionInfo.txHash}_${wallet.walletAddresses.primaryAddress}';
+      final description = transactionDescriptionBox.values
+          .firstWhereOrNull((val) => val.id == descriptionKey || val.id == transactionInfo.txHash);
+
+      if (RegExp(AddressValidator.silentPaymentAddressPatternMainnet)
+          .hasMatch(description?.recipientAddress ?? "")) {
+        canReplaceByFee = false;
+        return;
+      }
+
       rawTransaction = await bitcoin!.canReplaceByFee(wallet, tx);
       if (rawTransaction != null) {
         canReplaceByFee = true;


### PR DESCRIPTION
# Description

Disable RBF for Silent Payments

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
