### PR TITLE
fix: show close button for cake pay filters popup

### DIFF
--- a/lib/src/screens/dashboard/widgets/filter_widget.dart
+++ b/lib/src/screens/dashboard/widgets/filter_widget.dart
@@ -34,14 +34,11 @@ class _FilterWidgetState extends State<FilterWidget> {
       child: Column(
         children: [
           const Expanded(child: SizedBox()),
-          Expanded(
-            flex: responsiveLayoutUtil.shouldRenderTabletUI ? 16 : 8,
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                double availableHeight = constraints.maxHeight;
-                return _buildFilterContent(context, availableHeight);
-              },
-            ),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              double availableHeight = constraints.maxHeight;
+              return _buildFilterContent(context, availableHeight);
+            },
           ),
           Expanded(
             child: AlertCloseButton(
@@ -50,7 +47,6 @@ class _FilterWidgetState extends State<FilterWidget> {
               onTap: widget.onClose,
             ),
           ),
-          const SizedBox(height: 24),
         ],
       ),
     );


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Fix the close button for the filters selector on the Cake Pay page. Allows closing the page on platforms without a Back button.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
