### PR TITLE
change sync status display mode on long-press

### DIFF
--- a/lib/src/screens/dashboard/widgets/sync_indicator.dart
+++ b/lib/src/screens/dashboard/widgets/sync_indicator.dart
@@ -1,4 +1,3 @@
-import 'package:cake_wallet/entities/sync_status_display_mode.dart';
 import 'package:flutter/material.dart';
 import 'package:cake_wallet/view_model/dashboard/dashboard_view_model.dart';
 import 'package:cake_wallet/core/sync_status_title.dart';
@@ -34,13 +33,7 @@ class SyncIndicator extends StatelessWidget {
           borderRadius: BorderRadius.all(Radius.circular(15)),
           child: GestureDetector(
             onTap: onTap,
-            onLongPress: (){
-              if(dashboardViewModel.settingsStore.syncStatusDisplayMode == SyncStatusDisplayMode.eta) {
-                dashboardViewModel.settingsStore.syncStatusDisplayMode = SyncStatusDisplayMode.blocksRemaining;
-              } else {
-                dashboardViewModel.settingsStore.syncStatusDisplayMode = SyncStatusDisplayMode.eta;
-              }
-            },
+            onLongPress: dashboardViewModel.toggleSwitchStatusDisplayMode,
             child: Container(
               height: 30,
               width: syncIndicatorWidth,

--- a/lib/view_model/dashboard/dashboard_view_model.dart
+++ b/lib/view_model/dashboard/dashboard_view_model.dart
@@ -10,6 +10,7 @@ import 'package:cake_wallet/entities/balance_display_mode.dart';
 import 'package:cake_wallet/entities/exchange_api_mode.dart';
 import 'package:cake_wallet/entities/preferences_key.dart';
 import 'package:cake_wallet/entities/service_status.dart';
+import 'package:cake_wallet/entities/sync_status_display_mode.dart';
 import 'package:cake_wallet/exchange/exchange_provider_description.dart';
 import 'package:cake_wallet/generated/i18n.dart';
 import 'package:cake_wallet/monero/monero.dart';
@@ -608,6 +609,17 @@ abstract class DashboardViewModelBase with Store {
     final resp = await FlutterDaemon().getBackgroundSyncStatus();
     backgroundSyncEnabled = resp;
     return resp;
+  }
+
+  @action
+  void toggleSwitchStatusDisplayMode() {
+    if (status is SyncingSyncStatus && !((status as SyncingSyncStatus).shouldShowBlocksRemaining())) {
+      if (settingsStore.syncStatusDisplayMode == SyncStatusDisplayMode.eta) {
+        settingsStore.syncStatusDisplayMode = SyncStatusDisplayMode.blocksRemaining;
+      } else {
+        settingsStore.syncStatusDisplayMode = SyncStatusDisplayMode.eta;
+      }
+    }
   }
 
   @observable


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description
Simple shortcut to change sync status display mode – long-press on the sync indicator.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
