### PR TITLE
LTC MWEB: detect hogex inputs and only require 6 confs if so

### DIFF
--- a/cw_bitcoin/lib/bitcoin_unspent.dart
+++ b/cw_bitcoin/lib/bitcoin_unspent.dart
@@ -25,6 +25,7 @@ class BitcoinUnspent extends Unspent {
   }
 
   final BaseBitcoinAddressRecord bitcoinAddressRecord;
+  bool? isPegOut;
 }
 
 class BitcoinSilentPaymentsUnspent extends BitcoinUnspent {

--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -1740,6 +1740,7 @@ abstract class ElectrumWalletBase
         final tx = await fetchTransactionInfo(hash: coin.hash);
         coin.isChange = address.isHidden;
         coin.confirmations = tx?.confirmations;
+        coin.isPegOut = tx?.isHogEx;
 
         updatedUnspentCoins.add(coin);
       } catch (_) {}

--- a/cw_bitcoin/lib/litecoin_wallet.dart
+++ b/cw_bitcoin/lib/litecoin_wallet.dart
@@ -1214,21 +1214,14 @@ abstract class LitecoinWalletBase extends ElectrumWallet with Store {
         } else {
           // check if any of the inputs of this transaction are hog-ex:
           // this list is only non-mweb inputs:
-          bool isHogEx = true;
-
           final coin = unspentCoins
               .firstWhere((coin) => coin.hash == utxo.utxo.txHash && coin.vout == utxo.utxo.vout);
-
-          // TODO: detect actual hog-ex inputs
-
-          if (!isHogEx) {
-            continue;
-          }
+          if (coin.isPegOut != true) continue;
 
           int confirmations = coin.confirmations ?? 0;
           if (confirmations < 6) {
             throw Exception(
-                "A transaction input has less than 6 confirmations, please try again later.");
+                "A transaction input is an MWEB peg-out and has less than 6 confirmations, please try again later.");
           }
         }
       }


### PR DESCRIPTION
Currently non-MWEB LTC inputs require 6 confs before becoming spendable. Strictly speaking this only applies to peg-outs. This PR adds detection for peg-outs and only requires 6 confs if an input is a peg-out.