### PR TITLE
fix: close modal after transaction commitment in Send ViewModel

### DIFF
--- a/lib/new-ui/pages/send_page.dart
+++ b/lib/new-ui/pages/send_page.dart
@@ -580,6 +580,9 @@ class _NewSendPageState extends State<NewSendPage> {
                     sendViewModel: widget.sendViewModel,
                   );
                 }).then((value) async {
+              if (widget.sendViewModel.state is TransactionCommitted) {
+                Navigator.of(context, rootNavigator: true).pop();
+              }
               widget.sendViewModel.dismissTransaction();
             });
           } else {


### PR DESCRIPTION

# Description

close modal after transaction commitment in Send ViewModel

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
