### PR TITLE
fix: switch zano alias resolution to https

### DIFF
--- a/lib/entities/zano_alias.dart
+++ b/lib/entities/zano_alias.dart
@@ -6,7 +6,7 @@ import 'package:cw_core/utils/proxy_wrapper.dart';
 class ZanoAlias {
   static Future<String?> fetchZanoAliasAddress(String alias) async {
     try {
-      final uri = Uri.parse("http://37.27.100.59:10500/json_rpc");
+      final uri = Uri.parse("https://37.27.100.59:10500/json_rpc");
       final response = await ProxyWrapper().post(
         clearnetUri: uri,
         body: json.encode({


### PR DESCRIPTION
fixes zano mitm vulnerability.

changes:
- updates 'cake_wallet/lib/entities/zano_alias.dart' to use 'https'.

notes:
server '37.27.100.59' must support ssl for this to work.
currently ios allows insecure http globally via 'NSAllowsArbitraryLoads'. this patch secures the endpoint call.

fixes #2863

--
if you find this usefull here is my xmr address:
49MVkGpPjfzboSoH1iRXY6ZBJZo8abkdgKvguRaP5oQzd1gQ2PyTWW5NPXTrnkiRAJZJd1qbYL3nGYtcLB7VhKykMGh6T9E