### PR TITLE
Add support for Zcash address detection and amount logic refactor

### DIFF
--- a/lib/new-ui/pages/receive_page.dart
+++ b/lib/new-ui/pages/receive_page.dart
@@ -14,6 +14,7 @@ import 'package:cake_wallet/view_model/dashboard/dashboard_view_model.dart';
 import 'package:cake_wallet/view_model/dashboard/receive_option_view_model.dart';
 import 'package:cake_wallet/view_model/wallet_address_list/wallet_address_list_item.dart';
 import 'package:cake_wallet/zcash/zcash.dart';
+import 'package:cw_core/crypto_currency.dart';
 import 'package:cw_core/payment_uris.dart';
 import 'package:cw_core/receive_page_option.dart';
 import 'package:cw_core/utils/print_verbose.dart';
@@ -64,6 +65,7 @@ class _NewReceivePageState extends State<NewReceivePage> {
       if (widget.lightningMode) {
         widget.receiveOptionViewModel.selectReceiveOption(widget.receiveOptionViewModel.options
             .firstWhere((item) => item.value.contains("Lightning")));
+        widget.addressListViewModel.setTokenCurrency(CryptoCurrency.btcln);
       } else if (widget.addressListViewModel.wallet.type == WalletType.bitcoin) {
         widget.receiveOptionViewModel.selectReceiveOption(
             bitcoin!.getSelectedAddressType(widget.addressListViewModel.wallet));
@@ -268,9 +270,8 @@ class _NewReceivePageState extends State<NewReceivePage> {
                     ),
                   ),
                   ReceiveLargeAmountPreview(
-                      amount: widget.addressListViewModel.amount,
-                      currency: widget.addressListViewModel.tokenCurrency?.title.toUpperCase() ??
-                          widget.addressListViewModel.wallet.currency.name.toUpperCase(),
+                      amount: widget.addressListViewModel.displayAmount,
+                      currency: widget.addressListViewModel.cryptoCurrencySymbol,
                       largeQrMode: _largeQrMode),
                   if (infobox != null)
                     ClipRect(

--- a/lib/new-ui/widgets/receive_page/receive_amount_display.dart
+++ b/lib/new-ui/widgets/receive_page/receive_amount_display.dart
@@ -1,4 +1,3 @@
-import 'package:cake_wallet/entities/fiat_currency.dart';
 import 'package:cake_wallet/view_model/wallet_address_list/wallet_address_list_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
@@ -19,11 +18,11 @@ class ReceiveAmountDisplay extends StatelessWidget {
           AnimatedOpacity(
             duration: Duration(milliseconds: 300),
             curve: Curves.easeOutCubic,
-            opacity: largeQrMode || walletAddressListViewModel.amount.isEmpty ? 0 : 1,
+            opacity: largeQrMode || walletAddressListViewModel.displayAmount.isEmpty ? 0 : 1,
             child: AnimatedAlign(
               duration: Duration(milliseconds: 300),
               curve: Curves.easeOutCubic,
-              heightFactor: largeQrMode || walletAddressListViewModel.amount.isEmpty ? 0 : 1,
+              heightFactor: largeQrMode || walletAddressListViewModel.displayAmount.isEmpty ? 0 : 1,
               alignment: Alignment.topCenter,
               child: Container(
                 width: double.infinity,
@@ -46,12 +45,11 @@ class ReceiveAmountDisplay extends StatelessWidget {
                         child: Row(
                           spacing: 8.0,
                           children: [
-                            Text(walletAddressListViewModel.amount, style: TextStyle(color: Theme
+                            Text(walletAddressListViewModel.displayAmount, style: TextStyle(color: Theme
                                 .of(context)
                                 .colorScheme
                                 .primary, fontSize: 16, fontWeight: FontWeight.w500),),
-                            Text(walletAddressListViewModel.tokenCurrency?.title.toUpperCase() ??
-                                walletAddressListViewModel.wallet.currency.name.toUpperCase(),
+                            Text(walletAddressListViewModel.cryptoCurrencySymbol,
                                 style: TextStyle(color: Theme
                                     .of(context)
                                     .colorScheme

--- a/lib/new-ui/widgets/receive_page/receive_amount_modal.dart
+++ b/lib/new-ui/widgets/receive_page/receive_amount_modal.dart
@@ -6,7 +6,6 @@ import 'package:cake_wallet/src/screens/exchange/widgets/currency_picker.dart';
 import 'package:cake_wallet/utils/show_pop_up.dart';
 import 'package:cake_wallet/view_model/wallet_address_list/wallet_address_list_view_model.dart';
 import 'package:cw_core/crypto_currency.dart';
-import 'package:cw_core/utils/print_verbose.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_svg/svg.dart';
@@ -31,9 +30,8 @@ class _ReceiveAmountModalState extends State<ReceiveAmountModal> {
     if(widget.walletAddressListViewModel.selectedCurrency is FiatCurrency) {
       _amountController.text = widget.walletAddressListViewModel.fiatAmount;
     } else {
-      _amountController.text = widget.walletAddressListViewModel.amount;
+      _amountController.text = widget.walletAddressListViewModel.displayAmount;
     }
-
   }
 
   @override
@@ -63,7 +61,7 @@ class _ReceiveAmountModalState extends State<ReceiveAmountModal> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   spacing: 12,
                   children: [
-                    if (widget.walletAddressListViewModel.tokenCurrencies.length > 1) ...[
+                    if (widget.walletAddressListViewModel.hasTokensList) ...[
                       Text("Token"),
                       GestureDetector(
                           onTap: () {
@@ -135,21 +133,22 @@ class _ReceiveAmountModalState extends State<ReceiveAmountModal> {
                               textAlignVertical: TextAlignVertical.center,
                               controller: _amountController,
                               keyboardType:
-                                  TextInputType.numberWithOptions(signed: false, decimal: true),
+                                  TextInputType.numberWithOptions(signed: false, decimal: !widget.walletAddressListViewModel.useSatoshi),
                               decoration: InputDecoration(
-                                  hint: Text(
-                                    "0.00000000",
-                                    textAlign: TextAlign.left,
-                                    style: TextStyle(
-                                      fontSize: 16,
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.onSurface.withValues(alpha: 0.5),
-                                    ),
+                                hint: Text(
+                                  widget.walletAddressListViewModel.useSatoshi ? "0" : "0.00000000",
+                                  textAlign: TextAlign.left,
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurface.withValues(alpha: 0.5),
                                   ),
-                                  border: InputBorder.none,
-                                  filled: true,
-                                  fillColor: Colors.transparent),
+                                ),
+                                border: InputBorder.none,
+                                filled: true,
+                                fillColor: Colors.transparent,
+                              ),
                               style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
                             ),
                           ),
@@ -177,14 +176,7 @@ class _ReceiveAmountModalState extends State<ReceiveAmountModal> {
                                 children: [
                                   Observer(
                                     builder: (_) => Text(
-                                      widget.walletAddressListViewModel.selectedCurrency
-                                              is CryptoCurrency
-                                          ? (widget.walletAddressListViewModel.selectedCurrency
-                                                  as CryptoCurrency)
-                                              .title
-                                              .toUpperCase()
-                                          : widget.walletAddressListViewModel.selectedCurrency.name
-                                              .toUpperCase(),
+                                      widget.walletAddressListViewModel.selectedCurrencySymbol,
                                       style: TextStyle(
                                         color: Theme.of(context).colorScheme.onSurface,
                                       ),

--- a/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
+++ b/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
@@ -68,7 +68,6 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
   final AppStore _appStore;
 
   double? _fiatRate;
-  String _rawAmount = '';
 
   List<Currency> get currencies =>
       [tokenCurrency ?? wallet.currency, ...FiatCurrency.all];
@@ -126,10 +125,8 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
   String _amount = '';
 
   @computed
-  String get displayAmount => selectedCurrency is CryptoCurrency
-      ? _appStore.amountParsingProxy
-          .getDisplayCryptoAmount(_amount, selectedCurrency as CryptoCurrency)
-      : _amount;
+  String get displayAmount => _appStore.amountParsingProxy
+      .getDisplayCryptoAmount(_amount, tokenCurrency ?? wallet.currency);
 
   // NOT PRECISE! just for display purposes.
   @computed
@@ -641,7 +638,6 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
 
   @action
   void changeAmount(String amount) {
-    this._rawAmount = amount;
     if (selectedCurrency is FiatCurrency) {
       this._amount = amount;
       _convertAmountToCrypto();

--- a/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
+++ b/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
@@ -78,6 +78,10 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
   @observable
   CryptoCurrency? tokenCurrency;
 
+  @computed
+  String get cryptoCurrencySymbol =>
+      _appStore.amountParsingProxy.getCryptoSymbol(tokenCurrency ?? wallet.currency);
+
   void setTokenCurrency(Currency curr) {
     tokenCurrency = curr as CryptoCurrency;
     if (selectedCurrency is CryptoCurrency) {
@@ -97,6 +101,11 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
   Currency selectedCurrency;
 
   @computed
+  String get selectedCurrencySymbol => selectedCurrency is CryptoCurrency
+      ? _appStore.amountParsingProxy.getCryptoSymbol(selectedCurrency as CryptoCurrency)
+      : selectedCurrency.name.toUpperCase();
+
+  @computed
   int get selectedCurrencyDecimals => useSatoshi ? 0 : selectedCurrency.decimals;
 
   @computed
@@ -114,21 +123,28 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
   int get tokenCurrencyIndex => tokenCurrency == null ? 0 : tokenCurrencies.indexOf(tokenCurrency!);
 
   @observable
-  String amount = '';
+  String _amount = '';
+
+  @computed
+  String get displayAmount => selectedCurrency is CryptoCurrency
+      ? _appStore.amountParsingProxy
+          .getDisplayCryptoAmount(_amount, selectedCurrency as CryptoCurrency)
+      : _amount;
 
   // NOT PRECISE! just for display purposes.
   @computed
   String get fiatAmount {
-    if (amount.isEmpty) return "";
-    if (!fiatConversionStore.prices.containsKey(tokenCurrency ?? wallet.currency)) return "";
-    return (double.parse(amount) * fiatConversionStore.prices[tokenCurrency ?? wallet.currency]!)
-        .toStringAsFixed(2);
+    if (_amount.isEmpty) return "";
+    var cryptoCurrency = tokenCurrency ?? wallet.currency;
+    if (cryptoCurrency == CryptoCurrency.btcln) cryptoCurrency = CryptoCurrency.btc;
+    if (!fiatConversionStore.prices.containsKey(cryptoCurrency)) return "";
+    return (double.parse(_amount) * fiatConversionStore.prices[cryptoCurrency]!).toStringAsFixed(2);
   }
 
   @computed
   String get selectedCurrencyFiatAmount {
     if (_fiatRate == null) return "";
-    return (double.parse(amount) * _fiatRate!).toStringAsFixed(2);
+    return (double.parse(_amount) * _fiatRate!).toStringAsFixed(2);
   }
 
   @action
@@ -166,11 +182,11 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
       return ERC681URI(
           chainId: wallet.chainId ?? 1,
           address: wallet.walletAddresses.address,
-          amount: amount,
+          amount: _amount,
           contractAddress: (tokenCurrency as Erc20Token).contractAddress);
     }
     if (_lnPaymentRequest != null) return _lnPaymentRequest!;
-    return wallet.walletAddresses.getPaymentUri(amount);
+    return wallet.walletAddresses.getPaymentUri(_amount);
   }
 
   bool get isPayjoinAvailable => !isPayjoinUnavailable && !isSilentPayments && !isLightning;
@@ -625,14 +641,17 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
 
   @action
   void changeAmount(String amount) {
-    this.amount = amount;
     this._rawAmount = amount;
     if (selectedCurrency is FiatCurrency) {
+      this._amount = amount;
       _convertAmountToCrypto();
+    } else if (selectedCurrency is CryptoCurrency) {
+      this._amount = _appStore.amountParsingProxy
+          .getCanonicalCryptoAmount(amount, selectedCurrency as CryptoCurrency);
     }
     if (isLightning) {
       wallet.walletAddresses
-          .getPaymentRequestUri(this.amount)
+          .getPaymentRequestUri(this._amount)
           .then((uri) => _lnPaymentRequest = uri);
     }
   }
@@ -644,12 +663,13 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
 
   @action
   void _convertAmountToCrypto() {
-    final cryptoCurrency = wallet.currency;
+    var cryptoCurrency = tokenCurrency ?? wallet.currency;
+    if (cryptoCurrency == CryptoCurrency.btcln) cryptoCurrency = CryptoCurrency.btc;
     final fiatRate = _fiatRate ?? (fiatConversionStore.prices[cryptoCurrency] ?? 0.0);
 
     if (fiatRate <= 0.0) {
       dev.log("Invalid Fiat Rate $fiatRate");
-      amount = '';
+      _amount = '';
       return;
     }
 
@@ -657,11 +677,11 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
       final crypto = double.parse(_rawAmount.replaceAll(',', '.')) / fiatRate;
       final cryptoAmountTmp = _appStore.amountParsingProxy
           .getDisplayCryptoAmount(crypto.toStringAsFixed(8), cryptoCurrency);
-      if (amount != cryptoAmountTmp) {
-        amount = cryptoAmountTmp;
+      if (_amount != cryptoAmountTmp) {
+        _amount = cryptoAmountTmp;
       }
     } catch (e) {
-      amount = '';
+      _amount = '';
     }
   }
 

--- a/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
+++ b/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
@@ -188,8 +188,6 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
 
   bool get isPayjoinAvailable => !isPayjoinUnavailable && !isSilentPayments && !isLightning;
 
-
-
   @computed
   ObservableList<ListItem> get items => ObservableList<ListItem>()
     ..addAll(_baseItems)
@@ -432,7 +430,7 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
         WalletType.decred,
         WalletType.dogecoin,
         WalletType.zcash
-      ].contains(wallet.type) && !isLightning;
+      ].contains(wallet.type) && !isLightning && isZCashTransparent;
 
   @computed
   bool get hasAddressRotation => [
@@ -547,6 +545,10 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
 
   @computed
   bool get isLightning => wallet.type == WalletType.bitcoin && (uri is LightningPaymentRequest);
+
+  @computed
+  bool get isZCashTransparent =>
+      wallet.type == WalletType.zcash && zcash!.hasSelectedTransparentAddress(wallet);
 
   @computed
   bool get isBitcoinViewOnly =>
@@ -670,11 +672,9 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
     }
 
     try {
-      final crypto = double.parse(_rawAmount.replaceAll(',', '.')) / fiatRate;
-      final cryptoAmountTmp = _appStore.amountParsingProxy
-          .getDisplayCryptoAmount(crypto.toStringAsFixed(8), cryptoCurrency);
-      if (_amount != cryptoAmountTmp) {
-        _amount = cryptoAmountTmp;
+      final crypto = (double.parse(_amount.replaceAll(',', '.')) / fiatRate).toStringAsFixed(8);
+      if (_amount != crypto) {
+        _amount = crypto;
       }
     } catch (e) {
       _amount = '';

--- a/lib/zcash/cw_zcash.dart
+++ b/lib/zcash/cw_zcash.dart
@@ -175,6 +175,14 @@ class CWZcash extends Zcash {
   }
 
   @override
+  bool hasSelectedTransparentAddress(Object wallet) {
+    print(getSelectedAddressType(wallet));
+    print(getSelectedAddressType(wallet) == ZcashReceivePageOption.transparentRotated);
+    return getSelectedAddressType(wallet) == ZcashReceivePageOption.transparentRotated;
+  }
+
+
+  @override
   dynamic getZcashAddressType(ReceivePageOption option) {
     switch (option) {
       case ZcashReceivePageOption.unified:
@@ -189,6 +197,8 @@ class CWZcash extends Zcash {
         throw Exception("Unknown ReceivePageOption!");
     }
   }
+
+  @override
   Future<void> setAddressType(Object wallet, dynamic option) async {
     final zcashWallet = wallet as ZcashWallet;
     await (zcashWallet.walletAddresses as ZcashWalletAddresses).setAddressType(option as ZcashAddressType);

--- a/tool/configure.dart
+++ b/tool/configure.dart
@@ -1649,6 +1649,7 @@ abstract class Zcash {
   List<TransactionPriority> getTransactionPriorities();
   ReceivePageOption getSelectedAddressType(Object wallet);
   dynamic getZcashAddressType(ReceivePageOption option);
+  bool hasSelectedTransparentAddress(Object wallet);
   Future<void> setAddressType(Object wallet, dynamic option);
   dynamic getOptionToType(ReceivePageOption option);
   void unlockDatabase(String password);


### PR DESCRIPTION
# Description

- Added support for Zcash transparent address detection in the display settings.
- Simplified logic for cryptocurrency amount representation (`displayAmount`) and removed unused `_rawAmount` property.
- Consolidated cryptocurrency amount handling, optimized token currency management, and improved fiat conversion logic.
- Introduced UI updates for the Zcash card in settings and enhanced swap action handling.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed  