### PR TITLE
Fix async handling in Lightning transaction history

### DIFF
--- a/cw_bitcoin/lib/bitcoin_wallet.dart
+++ b/cw_bitcoin/lib/bitcoin_wallet.dart
@@ -346,9 +346,10 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
   @override
   Future<Map<String, ElectrumTransactionInfo>> fetchTransactions() async {
     if (lightningWallet != null) {
-      final lnHistory = await lightningWallet!.getTransactionHistory();
-      transactionHistory.addMany(lnHistory);
-      await transactionHistory.save();
+      lightningWallet!.getTransactionHistory().then((lnHistory) async {
+        transactionHistory.addMany(lnHistory);
+        await transactionHistory.save();
+      });
     }
 
     return super.fetchTransactions();


### PR DESCRIPTION
# Description

The `fetchTransactions` method was updated to resolve async handling issues related to Lightning transaction history. This ensures smoother and more reliable transaction data retrieval.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 