### PR TITLE
Add focus management and validate external addresses in send forms

### DIFF
--- a/cw_bitcoin/lib/bitcoin_wallet.dart
+++ b/cw_bitcoin/lib/bitcoin_wallet.dart
@@ -349,7 +349,7 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
       lightningWallet!.getTransactionHistory().then((lnHistory) async {
         transactionHistory.addMany(lnHistory);
         await transactionHistory.save();
-      });
+      }).onError((_, __) {});
     }
 
     return super.fetchTransactions();

--- a/lib/new-ui/pages/send_page.dart
+++ b/lib/new-ui/pages/send_page.dart
@@ -192,6 +192,7 @@ class _NewSendPageState extends State<NewSendPage> {
   List<TextEditingController> _amountControllers = [];
   List<TextEditingController> _addressControllers = [];
   final _formKey = GlobalKey<FormState>();
+  final _addressFocusNode = FocusNode();
   BuildContext? loadingBottomSheetContext;
   BuildContext? dialogContext;
   ContactRecord? newContactAddress;
@@ -238,11 +239,21 @@ class _NewSendPageState extends State<NewSendPage> {
         },
       );
     }
+
+    _addressFocusNode.addListener(() async {
+      if (!_addressFocusNode.hasFocus && _addressControllers[_selectedOutput].text.isNotEmpty) {
+        final output = widget.sendViewModel.outputs[_selectedOutput];
+        output.fetchParsedAddress(context).then((val){
+          if(_addressControllers[_selectedOutput].text != output.extractedAddress) {
+            _addressControllers[_selectedOutput].text = output.extractedAddress;
+          }
+        });
+      }
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-
 
     return Observer(
       builder: (_) {
@@ -335,6 +346,7 @@ class _NewSendPageState extends State<NewSendPage> {
                                               ? widget.sendViewModel.textValidator
                                               : widget.sendViewModel.addressValidator,
                                           addressController: _addressControllers[_selectedOutput],
+                                        focusNode: _addressFocusNode,
                                         onURIScanned: (uri) async {
                                           output.resetParsedAddress();
                                           await output.fetchParsedAddress(context);

--- a/lib/new-ui/widgets/coins_page/action_row/coin_action_row.dart
+++ b/lib/new-ui/widgets/coins_page/action_row/coin_action_row.dart
@@ -49,7 +49,7 @@ class CoinActionRow extends StatelessWidget {
                 final sendPage = getIt.get<NewSendPage>(
                   param1: SendPageParams(
                     unspentCoinType:
-                        lightningMode ? UnspentCoinType.lightning : UnspentCoinType.any,
+                        lightningMode ? UnspentCoinType.lightning : UnspentCoinType.nonMweb,
                   ),
                 );
 

--- a/lib/new-ui/widgets/send_page/send_address_input.dart
+++ b/lib/new-ui/widgets/send_page/send_address_input.dart
@@ -10,7 +10,19 @@ import 'package:flutter/services.dart';
 import "package:permission_handler_platform_interface/permission_handler_platform_interface.dart";
 
 class NewSendAddressInput extends StatelessWidget {
-  const NewSendAddressInput({super.key, required this.addressController, this.onURIScanned, this.onPushPasteButton, required this.selectedCurrency, this.onSelectedContact, this.onPushAddressBookButton, required this.onEditingComplete, this.bottomPadding=false, this.validator});
+  const NewSendAddressInput({
+    super.key,
+    required this.addressController,
+    this.onURIScanned,
+    this.onPushPasteButton,
+    required this.selectedCurrency,
+    this.onSelectedContact,
+    this.onPushAddressBookButton,
+    required this.onEditingComplete,
+    this.bottomPadding = false,
+    this.validator,
+    this.focusNode,
+  });
 
   final TextEditingController addressController;
   final Function(Uri)? onURIScanned;
@@ -21,9 +33,7 @@ class NewSendAddressInput extends StatelessWidget {
   final VoidCallback onEditingComplete;
   final bool bottomPadding;
   final FormFieldValidator<String>? validator;
-
-
-
+  final FocusNode? focusNode;
 
   @override
   Widget build(BuildContext context) {
@@ -40,13 +50,19 @@ class NewSendAddressInput extends StatelessWidget {
         child: Row(
           children: [
             Expanded(
-                child: TextFormField(
-                    // onSubmitted: (val)=> FocusScope.of(context).unfocus(),
-                    validator: validator,
-                    onEditingComplete: onEditingComplete,
-                    controller: addressController,
-                    decoration: InputDecoration(
-                        hintText: S.of(context).search_or_enter, errorMaxLines: 3))),
+              child: TextFormField(
+                focusNode: focusNode,
+                // onSubmitted: (val)=> FocusScope.of(context).unfocus(),
+                validator: validator,
+                onEditingComplete: onEditingComplete,
+                onTapOutside: (_) => onEditingComplete.call(),
+                controller: addressController,
+                decoration: InputDecoration(
+                  hintText: S.of(context).search_or_enter,
+                  errorMaxLines: 3,
+                ),
+              ),
+            ),
             Row(
               spacing: 12,
               children: [


### PR DESCRIPTION
# Description

- Introduced `focusNode` to `NewSendAddressInput` for enhanced input handling.
- Improved address validation by aligning with parsed external address values.
- Adjusted logic for non-MWEB unspent coin types in send actions.
- Reduced unnecessary exception logs for Bitcoin wallet transactions.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 