### PR TITLE
Integrate Lightning wallet transaction syncing and history fetching

### DIFF
--- a/cw_bitcoin/lib/bitcoin_wallet.dart
+++ b/cw_bitcoin/lib/bitcoin_wallet.dart
@@ -346,7 +346,11 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
   @override
   Future<Map<String, ElectrumTransactionInfo>> fetchTransactions() async {
     if (lightningWallet != null) {
-      lightningWallet!.getTransactionHistory().then((lnHistory) async {
+      final existingTx = transactionHistory.transactions.values
+          .where((e) => (e.additionalInfo["isLightning"] as bool?) == true)
+          .lastOrNull;
+
+      lightningWallet!.getTransactionHistory(fromDate: existingTx?.date).then((lnHistory) async {
         transactionHistory.addMany(lnHistory);
         await transactionHistory.save();
       }).onError((_, __) {});

--- a/cw_bitcoin/lib/electrum_transaction_history.dart
+++ b/cw_bitcoin/lib/electrum_transaction_history.dart
@@ -1,15 +1,13 @@
 import 'dart:convert';
-import 'package:cw_core/encryption_file_utils.dart';
+
 
 import 'package:cw_bitcoin/electrum_transaction_info.dart';
+import 'package:cw_core/encryption_file_utils.dart';
 import 'package:cw_core/pathForWallet.dart';
 import 'package:cw_core/transaction_history.dart';
-import 'package:cw_core/utils/file.dart';
 import 'package:cw_core/utils/print_verbose.dart';
 import 'package:cw_core/wallet_info.dart';
 import 'package:mobx/mobx.dart';
-import 'package:cw_core/transaction_history.dart';
-import 'package:cw_bitcoin/electrum_transaction_info.dart';
 
 part 'electrum_transaction_history.g.dart';
 

--- a/cw_bitcoin/lib/electrum_transaction_info.dart
+++ b/cw_bitcoin/lib/electrum_transaction_info.dart
@@ -209,7 +209,7 @@ class ElectrumTransactionInfo extends TransactionInfo {
     return ElectrumTransactionInfo(
       type,
       id: data['id'] as String,
-      height: data['height'] as int,
+      height: data['height'] as int?,
       amount: data['amount'] as int,
       fee: data['fee'] as int,
       direction: parseTransactionDirectionFromInt(data['direction'] as int),

--- a/cw_bitcoin/lib/electrum_wallet_addresses.dart
+++ b/cw_bitcoin/lib/electrum_wallet_addresses.dart
@@ -776,13 +776,11 @@ abstract class ElectrumWalletAddressesBase extends WalletAddresses with Store {
     late final String username;
 
     if (newAddress.isEmpty) {
-      if (lightningAddress == null) {
+      if (lightningAddress != null) return;
+
         final randomNumber = Random.secure().nextInt(9999);
         final randomName = await generateName();
         username = "${randomName.replaceAll(" ", "")}$randomNumber".toLowerCase();
-      } else {
-        return;
-      }
     } else {
       username = newAddress;
     }

--- a/cw_bitcoin/lib/lightning/lightning_wallet.dart
+++ b/cw_bitcoin/lib/lightning/lightning_wallet.dart
@@ -212,10 +212,12 @@ class LightningWallet {
     throw UnimplementedError();
   }
 
-  Future<Map<String, ElectrumTransactionInfo>> getTransactionHistory() async {
+  Future<Map<String, ElectrumTransactionInfo>> getTransactionHistory({DateTime? fromDate}) async {
     final request = ListPaymentsRequest(
       typeFilter: [PaymentType.send, PaymentType.receive],
       // statusFilter: [PaymentStatus.completed],
+      fromTimestamp:
+          fromDate != null ? BigInt.from((fromDate.millisecondsSinceEpoch / 1000).round()) : null,
       assetFilter: AssetFilter.bitcoin(),
       offset: 0,
       limit: 50,


### PR DESCRIPTION
# Description

This pull request introduces improvements to Lightning wallet functionality, including:
- Nullable `height` in `ElectrumTransactionInfo` to handle optional data.
- Support for `fromDate` in filtered Lightning transaction history retrieval.
- Streamlined logic for handling Lightning wallet addresses.
- Optimized syncing of Lightning transactions using the last transaction date.
- Minor code improvements, such as cleaning up imports in `electrum_transaction_history.dart`.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 