### PR TITLE
Disable Lightning switcher for hardware wallets

### DIFF
--- a/cw_core/lib/wallet_base.dart
+++ b/cw_core/lib/wallet_base.dart
@@ -69,6 +69,8 @@ abstract class WalletBase<BalanceType extends Balance, HistoryType extends Trans
 
   bool get isHardwareWallet => walletInfo.isHardwareWallet;
 
+  bool get isSoftwareWallet => walletInfo.hardwareWalletType == null;
+
   HardwareWalletType? get hardwareWalletType => walletInfo.hardwareWalletType;
 
   bool get hasRescan => false;

--- a/lib/new-ui/widgets/coins_page/top_bar_widget/top_bar.dart
+++ b/lib/new-ui/widgets/coins_page/top_bar_widget/top_bar.dart
@@ -31,7 +31,7 @@ class TopBar extends StatelessWidget {
           spacing: 12,
           children: [
             (dashboardViewModel.wallet.type == WalletType.bitcoin &&
-                    !dashboardViewModel.wallet.isHardwareWallet)
+                    dashboardViewModel.wallet.isSoftwareWallet)
                 ? LightningSwitcher(
                     lightningMode: lightningMode,
                     onLightningSwitchPress: onLightningSwitchPress,

--- a/lib/new-ui/widgets/coins_page/top_bar_widget/top_bar.dart
+++ b/lib/new-ui/widgets/coins_page/top_bar_widget/top_bar.dart
@@ -30,7 +30,8 @@ class TopBar extends StatelessWidget {
         builder: (_) => Row(
           spacing: 12,
           children: [
-            (dashboardViewModel.wallet.type == WalletType.bitcoin)
+            (dashboardViewModel.wallet.type == WalletType.bitcoin &&
+                    !dashboardViewModel.wallet.isHardwareWallet)
                 ? LightningSwitcher(
                     lightningMode: lightningMode,
                     onLightningSwitchPress: onLightningSwitchPress,

--- a/lib/view_model/exchange/exchange_view_model.dart
+++ b/lib/view_model/exchange/exchange_view_model.dart
@@ -261,7 +261,7 @@ abstract class ExchangeViewModelBase extends WalletChangeListenerViewModel with 
 
   bool useSameWalletAddress(CryptoCurrency currency) =>
       currency == wallet.currency ||
-      (currency == CryptoCurrency.btcln && wallet.currency == CryptoCurrency.btc && !wallet.isHardwareWallet) ||
+      (currency == CryptoCurrency.btcln && wallet.currency == CryptoCurrency.btc && wallet.isSoftwareWallet) ||
       (currency.tag != null && currency.tag == wallet.currency.tag) ||
       currency.tag == wallet.currency.title;
 

--- a/lib/view_model/exchange/exchange_view_model.dart
+++ b/lib/view_model/exchange/exchange_view_model.dart
@@ -261,7 +261,7 @@ abstract class ExchangeViewModelBase extends WalletChangeListenerViewModel with 
 
   bool useSameWalletAddress(CryptoCurrency currency) =>
       currency == wallet.currency ||
-      currency == CryptoCurrency.btcln && wallet.currency == CryptoCurrency.btc ||
+      (currency == CryptoCurrency.btcln && wallet.currency == CryptoCurrency.btc && !wallet.isHardwareWallet) ||
       (currency.tag != null && currency.tag == wallet.currency.tag) ||
       currency.tag == wallet.currency.title;
 


### PR DESCRIPTION
# Description

This pull request disables the Lightning switcher for hardware wallets to ensure compatibility and prevent potential issues during operation.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed