### PR TITLE
fix: stabilize android build by increasing jvm heap size

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx4096M
+org.gradle.jvmargs=-Xmx6144M
 android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
# Description

This fixes random android CI fails due to JVM heap size exceeded

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
