### PR TITLE
fix: only throw on deserialize if kDebugMode is true

### DIFF
--- a/cw_bitcoin/lib/bitcoin_transaction_priority.dart
+++ b/cw_bitcoin/lib/bitcoin_transaction_priority.dart
@@ -1,4 +1,5 @@
 import 'package:cw_core/transaction_priority.dart';
+import 'package:flutter/foundation.dart';
 
 class BitcoinTransactionPriority extends TransactionPriority {
   const BitcoinTransactionPriority({required String title, required int raw})
@@ -25,7 +26,10 @@ class BitcoinTransactionPriority extends TransactionPriority {
       case 3:
         return custom;
       default:
-        throw Exception('Unexpected token: $raw for BitcoinTransactionPriority deserialize');
+        if (kDebugMode) {
+          throw Exception('Unexpected token: $raw for BitcoinTransactionPriority deserialize');
+        }
+        return medium;
     }
   }
 
@@ -82,7 +86,10 @@ class LitecoinTransactionPriority extends BitcoinTransactionPriority {
       case 2:
         return fast;
       default:
-        throw Exception('Unexpected token: $raw for LitecoinTransactionPriority deserialize');
+        if (kDebugMode) {
+          throw Exception('Unexpected token: $raw for LitecoinTransactionPriority deserialize');
+        }
+        return medium;
     }
   }
 
@@ -132,7 +139,10 @@ class BitcoinCashTransactionPriority extends BitcoinTransactionPriority {
       case 2:
         return fast;
       default:
-        throw Exception('Unexpected token: $raw for BitcoinCashTransactionPriority deserialize');
+        if (kDebugMode) {
+          throw Exception('Unexpected token: $raw for BitcoinCashTransactionPriority deserialize');
+        }
+        return medium;
     }
   }
 

--- a/cw_core/lib/monero_transaction_priority.dart
+++ b/cw_core/lib/monero_transaction_priority.dart
@@ -1,4 +1,5 @@
 import 'package:cw_core/transaction_priority.dart';
+import 'package:flutter/foundation.dart';
 
 class MoneroTransactionPriority extends TransactionPriority {
   const MoneroTransactionPriority({required String title, required int raw})
@@ -30,7 +31,10 @@ class MoneroTransactionPriority extends TransactionPriority {
       case 4:
         return fastest;
       default:
-        throw Exception('Unexpected token: $raw for MoneroTransactionPriority deserialize');
+        if (kDebugMode) {
+          throw Exception('Unexpected token: $raw for MoneroTransactionPriority deserialize');
+        }
+        return medium;
     }
   }
 

--- a/cw_decred/lib/transaction_priority.dart
+++ b/cw_decred/lib/transaction_priority.dart
@@ -1,4 +1,5 @@
 import 'package:cw_core/transaction_priority.dart';
+import 'package:flutter/foundation.dart';
 
 class DecredTransactionPriority extends TransactionPriority {
   const DecredTransactionPriority({required String title, required int raw})
@@ -19,7 +20,10 @@ class DecredTransactionPriority extends TransactionPriority {
       case 2:
         return fast;
       default:
-        throw Exception('Unexpected token: $raw for DecredTransactionPriority deserialize');
+        if (kDebugMode) {
+          throw Exception('Unexpected token: $raw for DecredTransactionPriority deserialize');
+        }
+        return medium;
     }
   }
 

--- a/cw_dogecoin/lib/src/dogecoin_transaction_priority.dart
+++ b/cw_dogecoin/lib/src/dogecoin_transaction_priority.dart
@@ -1,4 +1,5 @@
 import 'package:cw_bitcoin/bitcoin_transaction_priority.dart';
+import 'package:flutter/foundation.dart';
 
 class DogecoinTransactionPriority extends BitcoinTransactionPriority {
   const DogecoinTransactionPriority({required String title, required int raw})
@@ -21,7 +22,10 @@ class DogecoinTransactionPriority extends BitcoinTransactionPriority {
       case 2:
         return fast;
       default:
-        throw Exception('Unexpected token: $raw for DogecoinTransactionPriority deserialize');
+        if (kDebugMode) {
+          throw Exception('Unexpected token: $raw for DogecoinTransactionPriority deserialize');
+        }
+        return medium;
     }
   }
 

--- a/cw_evm/lib/evm_chain_transaction_priority.dart
+++ b/cw_evm/lib/evm_chain_transaction_priority.dart
@@ -1,4 +1,5 @@
 import 'package:cw_core/transaction_priority.dart';
+import 'package:flutter/foundation.dart';
 
 class EVMChainTransactionPriority extends TransactionPriority {
   final int tip;
@@ -23,7 +24,10 @@ class EVMChainTransactionPriority extends TransactionPriority {
       case 2:
         return fast;
       default:
-        throw Exception('Unexpected token: $raw for EVMChainTransactionPriority deserialize');
+        if (kDebugMode) {
+          throw Exception('Unexpected token: $raw for EVMChainTransactionPriority deserialize');
+        }
+        return medium;
     }
   }
 

--- a/lib/entities/list_order_mode.dart
+++ b/lib/entities/list_order_mode.dart
@@ -1,5 +1,6 @@
 import 'package:cake_wallet/generated/i18n.dart';
 import 'package:cw_core/enumerable_item.dart';
+import 'package:flutter/foundation.dart';
 
 class ListOrderMode extends EnumerableItem<int> with Serializable<int> {
   const ListOrderMode({required String title, required int raw}) : super(title: title, raw: raw);
@@ -16,7 +17,10 @@ class ListOrderMode extends EnumerableItem<int> with Serializable<int> {
       case 1:
         return descending;
       default:
-        throw Exception('Unexpected token: $raw for ListOrderMode deserialize');
+        if (kDebugMode) {
+          throw Exception('Unexpected token: $raw for ListOrderMode deserialize');
+        }
+        return descending;
     }
   }
 


### PR DESCRIPTION
# Description

This closes #2972, in debug mode we will still catch these issues but if somehow that happens on production it will fallback to safe default

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
