### PR TITLE
Fix minor issue in French translation

### DIFF
--- a/res/values/strings_fr.arb
+++ b/res/values/strings_fr.arb
@@ -1174,7 +1174,7 @@
   "you_will_receive_estimated_amount": "Vous recevrez ( estimé )",
   "you_will_send": "Convertir depuis",
   "youCanGoBackToYourDapp": "Vous pouvez retourner à votre Dapp maintenant",
-  "your": "Ton",
+  "your": "Votre",
   "yy": "AA",
   "zcash_card_description": "Si vous ne voyez pas votre solde complet, Cake Wallet peut tenter de récupérer des fonds à partir d'adresses de modification internes utilisées par certains portefeuilles.",
   "zcash_card_dismiss": "Rejeter",


### PR DESCRIPTION
I checked the language quality for NL, DE, FR and ES. The French translation is very good. The only thing I'm correcting here is a single use of the informal possessive pronoun, while formal pronouns are used in all other strings.