### PR TITLE
fix: move sqlite migrations to sqlite.dart

### DIFF
--- a/cw_core/lib/balance_card_style_settings.dart
+++ b/cw_core/lib/balance_card_style_settings.dart
@@ -21,14 +21,15 @@ class BalanceCardStyleSettings {
   static const tableName = "BalanceCardStyleSettings";
 
   Map<String, dynamic> toJson() {
-    return {
+    final ret = {
       "walletInfoId": walletInfoId,
       "accountIndex": accountIndex,
       "gradientIndex": gradientIndex,
-      "useSpecialDesign": useSpecialDesign,
+      "useSpecialDesign": useSpecialDesign ? 1 : 0,
       "backgroundImagePath": backgroundImagePath,
       "cardOrder": cardOrder,
     };
+    return ret;
   }
 
   static BalanceCardStyleSettings fromJson(Map<String, dynamic> json) {
@@ -56,7 +57,7 @@ class BalanceCardStyleSettings {
   }
 
   static Future<BalanceCardStyleSettings?> get(int walletInfoId, int accountIndex) async {
-    final json = await db.query(
+    final json = await db!.query(
       tableName,
       where: "walletInfoId = ? AND accountIndex = ?",
       whereArgs: [walletInfoId, accountIndex],
@@ -70,7 +71,7 @@ class BalanceCardStyleSettings {
   }
 
   static Future<List<BalanceCardStyleSettings>> getAll(int walletInfoId) async {
-    final json = await db.query(
+    final json = await db!.query(
       tableName,
       where: "walletInfoId = ?",
       whereArgs: [walletInfoId],
@@ -79,6 +80,6 @@ class BalanceCardStyleSettings {
   }
 
   Future<void> insert() async {
-    db.insert(tableName, toJson(), conflictAlgorithm: ConflictAlgorithm.replace);
+    db!.insert(tableName, toJson(), conflictAlgorithm: ConflictAlgorithm.replace);
   }
 }

--- a/cw_core/lib/db/sqlite.dart
+++ b/cw_core/lib/db/sqlite.dart
@@ -2,9 +2,26 @@
 import 'dart:io';
 
 import 'package:cw_core/root_dir.dart';
+import 'package:cw_core/utils/print_verbose.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
-late Database db;
+Database? db;
+
+Future<void> _addColumnIfNotExists(
+  Database db, {
+  required String table,
+  required String column,
+  required String definition,
+}) async {
+  final result = await db.rawQuery("PRAGMA table_info($table)");
+  final columnExists = result.any((row) => row['name'] == column);
+
+  if (!columnExists) {
+    await db.execute(
+      'ALTER TABLE $table ADD COLUMN $column $definition;',
+    );
+  }
+}
 
 Future<void> initDb({String? pathOverride}) async {
   if (Platform.isLinux || Platform.isWindows) {
@@ -21,9 +38,10 @@ Future<void> initDb({String? pathOverride}) async {
       dbFileOld.deleteSync();
     }
   }
-
-  db = await openDatabase(dbFile.path, version: 2,
+  await db?.close();
+  db = await openDatabase(dbFile.path, version: 3,
     onUpgrade: (Database db, int oldVersion, int newVersion) async {
+      printV("migrating: $oldVersion, $newVersion");
       if (oldVersion <= 1) {
         await db.execute('''
 DELETE FROM WalletInfo
@@ -36,6 +54,32 @@ WHERE walletInfoId NOT IN (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_walletinfo_id_unique
 ON WalletInfo (id);
 ''');
+      }
+      if (oldVersion <= 2) {
+        await db.execute('''
+CREATE TABLE IF NOT EXISTS BalanceCardStyleSettings (
+  walletInfoId INTEGER,
+  accountIndex INTEGER DEFAULT -1,
+  gradientIndex INTEGER DEFAULT -1,
+  useSpecialDesign BOOLEAN DEFAULT FALSE,
+  backgroundImagePath TEXT DEFAULT "",
+  PRIMARY KEY (walletInfoId, accountIndex),
+  FOREIGN KEY (walletInfoId) REFERENCES WalletInfo(walletInfoId)
+);
+''');
+        await _addColumnIfNotExists(
+          db,
+          table: 'WalletInfo',
+          column: 'receiveInfoboxDismissed',
+          definition: 'BOOLEAN DEFAULT FALSE',
+        );
+
+        await _addColumnIfNotExists(
+          db,
+          table: 'BalanceCardStyleSettings',
+          column: 'cardOrder',
+          definition: 'INTEGER DEFAULT 0',
+        );
       }
     },
     onCreate: (Database db, int version) async {
@@ -62,7 +106,8 @@ CREATE TABLE WalletInfo (
   parentAddress TEXT,
   hashedWalletIdentifier TEXT,
   isNonSeedWallet INTEGER DEFAULT (0) NOT NULL,
-  sortOrder INTEGER DEFAULT (0) NOT NULL
+  sortOrder INTEGER DEFAULT (0) NOT NULL,
+  receiveInfoboxDismissed DEFAULT FALSE
 );
 ''');
 
@@ -119,6 +164,18 @@ CREATE TABLE "WalletInfoAddressMap" (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_walletinfo_id_unique
 ON WalletInfo (id);
 ''');
+      await db.execute('''
+CREATE TABLE BalanceCardStyleSettings (
+  walletInfoId INTEGER,
+  accountIndex INTEGER DEFAULT -1,
+  gradientIndex INTEGER DEFAULT -1,
+  useSpecialDesign BOOLEAN DEFAULT FALSE,
+  backgroundImagePath TEXT DEFAULT "",
+  cardOrder INTEGER DEFAULT 0,
+  PRIMARY KEY (walletInfoId, accountIndex),
+  FOREIGN KEY (walletInfoId) REFERENCES WalletInfo(walletInfoId)
+);
+        ''');
     }
   );
 }
@@ -140,10 +197,10 @@ Future<List<String>> _getTableNames(Database db) async {
 }
 
 Future<Map<String, dynamic>> _dumpDb() async {
-  final tableNames = await _getTableNames(db);
+  final tableNames = await _getTableNames(db!);
   final ret = <String, dynamic>{};
   for (final tableName in tableNames) {
-    ret[tableName] = await db.query(tableName);
+    ret[tableName] = await db!.query(tableName);
   }
   return ret;
 }

--- a/cw_core/lib/db/sqlite.dart
+++ b/cw_core/lib/db/sqlite.dart
@@ -107,7 +107,7 @@ CREATE TABLE WalletInfo (
   hashedWalletIdentifier TEXT,
   isNonSeedWallet INTEGER DEFAULT (0) NOT NULL,
   sortOrder INTEGER DEFAULT (0) NOT NULL,
-  receiveInfoboxDismissed DEFAULT FALSE
+  receiveInfoboxDismissed BOOLEAN DEFAULT FALSE
 );
 ''');
 

--- a/cw_core/lib/wallet_info.dart
+++ b/cw_core/lib/wallet_info.dart
@@ -75,12 +75,12 @@ class WalletInfoAddressInfo {
   static String get selfIdColumn => "${tableName}Id";
 
   static Future<List<WalletInfoAddressInfo>> selectList(int walletInfoId) async {
-    final query = await db.query(tableName, where: 'walletInfoId = ?', whereArgs: [walletInfoId]);
+    final query = await db!.query(tableName, where: 'walletInfoId = ?', whereArgs: [walletInfoId]);
     return List.generate(query.length, (index) => WalletInfoAddressInfo.fromJson(query[index]));
   }
 
   static Future<int> deleteByWalletInfoId(int walletInfoId) async {
-    return await db.delete(tableName, where: 'walletInfoId = ?', whereArgs: [walletInfoId]);
+    return await db!.delete(tableName, where: 'walletInfoId = ?', whereArgs: [walletInfoId]);
   }
 
   static Future<int> insert({
@@ -90,7 +90,7 @@ class WalletInfoAddressInfo {
     required String address,
     required String label,
   }) async {
-    return await db.insert(tableName, {
+    return await db!.insert(tableName, {
       "walletInfoId": walletInfoId,
       "mapKey": mapKey,
       "mapValueAccountIndex": accountIndex,
@@ -140,16 +140,16 @@ class WalletInfoAddressMap {
   static String get selfIdColumn => "${tableName}Id";
 
   static Future<List<WalletInfoAddressMap>> selectList(int walletInfoId) async {
-    final query = await db.query(tableName, where: 'walletInfoId = ?', whereArgs: [walletInfoId]);
+    final query = await db!.query(tableName, where: 'walletInfoId = ?', whereArgs: [walletInfoId]);
     return List.generate(query.length, (index) => WalletInfoAddressMap.fromJson(query[index]));
   }
 
   static Future<int> deleteByWalletInfoId(int walletInfoId) async {
-    return await db.delete(tableName, where: 'walletInfoId = ?', whereArgs: [walletInfoId]);
+    return await db!.delete(tableName, where: 'walletInfoId = ?', whereArgs: [walletInfoId]);
   }
 
   static Future<int> insert(int walletInfoId, String addressKey, String addressValue) async {
-    return await db.insert(tableName, {
+    return await db!.insert(tableName, {
       "walletInfoId": walletInfoId,
       "addressKey": addressKey,
       "addressValue": addressValue,
@@ -194,31 +194,31 @@ class WalletInfoAddress {
 
   static Future<List<WalletInfoAddress>> selectList(
       int walletInfoId, WalletInfoAddressType type) async {
-    final query = await db.query(tableName,
+    final query = await db!.query(tableName,
         where: 'walletInfoId = ? AND type = ?', whereArgs: [walletInfoId, type.index]);
     return List.generate(query.length, (index) => WalletInfoAddress.fromJson(query[index]));
   }
 
   static Future<int> deleteByAddress(
       int walletInfoId, WalletInfoAddressType type, String address) async {
-    return await db.delete(tableName,
+    return await db!.delete(tableName,
         where: 'walletInfoId = ? AND type = ? AND address = ?',
         whereArgs: [walletInfoId, type.index, address]);
   }
 
   static Future<int> deleteByType(int walletInfoId, WalletInfoAddressType type) async {
-    return await db.delete(tableName,
+    return await db!.delete(tableName,
         where: 'walletInfoId = ? AND type = ?', whereArgs: [walletInfoId, type.index]);
   }
 
   static Future<int> insert(int walletInfoId, WalletInfoAddressType type, String address) async {
-    final select = await db.query(tableName,
+    final select = await db!.query(tableName,
         where: 'walletInfoId = ? AND type = ? AND address = ?',
         whereArgs: [walletInfoId, type.index, address]);
     if (select.isNotEmpty) {
       return select[0][selfIdColumn] as int;
     }
-    return await db.insert(tableName, {
+    return await db!.insert(tableName, {
       "walletInfoId": walletInfoId,
       "type": type.index,
       "address": address,
@@ -271,7 +271,7 @@ class DerivationInfo {
   String? description;
 
   static Future<List<DerivationInfo>> selectList(String where, List<dynamic> whereArgs) async {
-    final query = await db.query(
+    final query = await db!.query(
       tableName,
       columns: [
         selfIdColumn,
@@ -320,7 +320,7 @@ class DerivationInfo {
     if (json[selfIdColumn] == 0) {
       json[selfIdColumn] = null;
     }
-    id = await db.insert(tableName, json, conflictAlgorithm: ConflictAlgorithm.replace);
+    id = await db!.insert(tableName, json, conflictAlgorithm: ConflictAlgorithm.replace);
     return id;
   }
 }
@@ -617,17 +617,17 @@ class WalletInfo {
     if (_derivationInfo != null) {
       derivationInfoId = await _derivationInfo!.save();
     }
-    internalId = await db.insert(tableName, json, conflictAlgorithm: ConflictAlgorithm.replace);
+    internalId = await db!.insert(tableName, json, conflictAlgorithm: ConflictAlgorithm.replace);
     return internalId;
   }
 
   static Future<int> delete(WalletInfo walletInfo) async {
-    return await db.delete(tableName, where: 'id = ?', whereArgs: [walletInfo.id]);
+    return await db!.delete(tableName, where: 'id = ?', whereArgs: [walletInfo.id]);
   }
 
   static Future<List<WalletInfo>> selectList(String where, List<dynamic> whereArgs,
       {String orderBy = 'sortOrder'}) async {
-    final list = await db.query(
+    final list = await db!.query(
       tableName,
       where: where.isNotEmpty ? where : "1 = 1",
       whereArgs: whereArgs.isNotEmpty ? whereArgs : null,

--- a/lib/core/auth_service.dart
+++ b/lib/core/auth_service.dart
@@ -260,7 +260,7 @@ Future<void> _handleDuressLogin(
 
   // Wipe wallet-related database tables
   try {
-    await db.transaction((txn) async {
+    await db!.transaction((txn) async {
       await txn.delete(WalletInfoAddressInfo.tableName);
       await txn.delete(WalletInfoAddressMap.tableName);
       await txn.delete(WalletInfoAddress.tableName);

--- a/lib/core/backup_service_v3.dart
+++ b/lib/core/backup_service_v3.dart
@@ -8,6 +8,7 @@ import 'package:cake_wallet/.secrets.g.dart' as secrets;
 import 'package:cake_backup/backup.dart' as cake_backup;
 import 'package:cake_wallet/utils/package_info.dart';
 import 'package:crypto/crypto.dart';
+import 'package:cw_core/db/sqlite.dart';
 import 'package:cw_core/root_dir.dart';
 import 'package:cw_core/utils/print_verbose.dart';
 import 'package:cw_core/wallet_info.dart';
@@ -314,6 +315,7 @@ class BackupServiceV3 extends $BackupService {
 
     // Delete decrypted data file
     decryptedData.deleteSync();
+    await initDb();
   }
 
   Future<void> verifyHardwareWallets(String password,

--- a/lib/entities/default_settings_migration.dart
+++ b/lib/entities/default_settings_migration.dart
@@ -590,28 +590,11 @@ Future<void> defaultSettingsMigration(
             currentNodePreferenceKey: PreferencesKey.currentBscNodeIdKey,
           );
           break;
-        case 58:
-          await db.execute('''
-            CREATE TABLE BalanceCardStyleSettings (
-              walletInfoId INTEGER,
-              accountIndex INTEGER DEFAULT -1,
-              gradientIndex INTEGER DEFAULT -1,
-              useSpecialDesign BOOLEAN DEFAULT FALSE,
-              backgroundImagePath TEXT DEFAULT "",
-              PRIMARY KEY (walletInfoId, accountIndex),
-              FOREIGN KEY (walletInfoId) REFERENCES WalletInfo(walletInfoId)
-            );
-            ''');
-          break;
-        case 59:
-          await db.execute('''
-ALTER TABLE WalletInfo ADD COLUMN receiveInfoboxDismissed DEFAULT FALSE;
-          ''');
-          break;
-        case 60:
-          await db.execute('''
-ALTER TABLE BalanceCardStyleSettings ADD COLUMN cardOrder INTEGER DEFAULT 0;          
-          ''');
+        case 58: // BalanceCardStyleSettings no-op (handled in sqlite.dart)
+        case 59: // WalletInfo.receiveInfoboxDismissed no-op (handled in sqlite.dart)
+        case 60: // BalanceCardStyleSettings.cardOrder no-op (handled in sqlite.dart)
+        // Do not migrate SQLite here, do that in sqlite.dart in order to prevent runtime
+        // errors, missing row and missing tables.
           break;
         default:
           break;


### PR DESCRIPTION
# Description

sqlite.dart is the preferred place for migrations, it prevents runtime DB issues (especially the ones during initial migration) and ensures correctness.

fix: backup restore not initializing SQL properly

# Checklist

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
