### PR TITLE
Add cached Lightning address handling for improved performance

### DIFF
--- a/cw_bitcoin/lib/bitcoin_wallet.dart
+++ b/cw_bitcoin/lib/bitcoin_wallet.dart
@@ -71,6 +71,7 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
     int initialSilentAddressIndex = 0,
     bool? alwaysScan,
     bool? useLightning,
+    String? cachedLightningAddress,
   }) : super(
           mnemonic: mnemonic,
           passphrase: passphrase,
@@ -107,6 +108,7 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
           seedBytes: seedBytes,
           apiKey: secrets.breezApiKey,
           lnurlDomain: "cake.cash",
+          cachedAddress: cachedLightningAddress,
         );
       } catch (e) {
         printV(e);
@@ -321,6 +323,7 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
         networkParam: network,
         alwaysScan: snp?.alwaysScan,
         useLightning: snp?.useLightning,
+        cachedLightningAddress: snp?.cachedLightningAddress,
         payjoinBox: payjoinBox,
     );
   }

--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -1480,6 +1480,7 @@ abstract class ElectrumWalletBase
         'mweb_addresses': walletAddresses.mwebAddresses.map((addr) => addr.toJSON()).toList(),
         'alwaysScan': alwaysScan,
         'useLightning': useLightning,
+        'cachedLightningAddress': walletAddresses.lightningAddress
       });
 
   int feeRate(TransactionPriority priority) {

--- a/cw_bitcoin/lib/electrum_wallet_snapshot.dart
+++ b/cw_bitcoin/lib/electrum_wallet_snapshot.dart
@@ -25,6 +25,7 @@ class ElectrumWalletSnapshot {
     required this.mwebAddresses,
     required this.alwaysScan,
     required this.useLightning,
+    this.cachedLightningAddress,
     this.passphrase,
     this.derivationType,
     this.derivationPath,
@@ -50,6 +51,7 @@ class ElectrumWalletSnapshot {
   List<BitcoinAddressRecord> mwebAddresses;
   bool alwaysScan;
   bool useLightning;
+  String? cachedLightningAddress;
 
   ElectrumBalance balance;
   ElectrumBalance? lightningBalance;
@@ -88,6 +90,7 @@ class ElectrumWalletSnapshot {
 
     final alwaysScan = data['alwaysScan'] as bool? ?? false;
     final useLightning = data['useLightning'] as bool? ?? true;
+    final cachedLightningAddress = data['cachedLightningAddress'] as String?;
 
     final balance = ElectrumBalance.fromJSON(data['balance'] as String?) ??
         ElectrumBalance(confirmed: 0, unconfirmed: 0, frozen: 0);
@@ -137,6 +140,7 @@ class ElectrumWalletSnapshot {
       mwebAddresses: mwebAddresses,
       alwaysScan: alwaysScan,
       useLightning: useLightning,
+      cachedLightningAddress: cachedLightningAddress,
     );
   }
 }

--- a/cw_bitcoin/lib/lightning/lightning_wallet.dart
+++ b/cw_bitcoin/lib/lightning/lightning_wallet.dart
@@ -21,6 +21,8 @@ class LightningWallet {
   final Network network;
   late BreezSdk sdk;
 
+  String? cachedAddress;
+
   static int MAX_RETRIES = 10;
 
   LightningWallet({
@@ -30,6 +32,7 @@ class LightningWallet {
     required this.apiKey,
     required this.lnurlDomain,
     this.network = Network.mainnet,
+    this.cachedAddress
   });
 
   StreamSubscription<SdkEvent>? _eventSubscription;
@@ -101,12 +104,16 @@ class LightningWallet {
       try {
         final address = (await sdk.getLightningAddress())?.lightningAddress;
 
-        if (address != null) return address;
+        if (address != null) {
+          cachedAddress = address;
+          return address;
+        }
       } catch (_) {} // No need to log here since it should be in the lightning log
       retries++;
       await Future.delayed(Duration(milliseconds: 500));
     }
-    return null;
+
+    return cachedAddress;
   }
 
   Future<String> getDepositAddress() async => (await sdk.receivePayment(


### PR DESCRIPTION
# Description

Added support for caching the last fetched Lightning address to improve performance. This includes:
- A `cachedAddress` field to store and reuse the previously fetched Lightning address.
- Updates to the `getLightningAddress` method to fallback on the cached value when no new address is available.
- Modifications to wallet constructors and snapshots to ensure `cachedLightningAddress` is persisted.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 