### PR TITLE
feat: ZIP-321 memo support and Zcash.me integration improvements

### DIFF
--- a/cw_zcash/lib/src/zcash_wallet.dart
+++ b/cw_zcash/lib/src/zcash_wallet.dart
@@ -175,8 +175,7 @@ abstract class ZcashWalletBase
       }
 
       final paymentUri = WarpApi.decodePaymentURI(coin, address);
-      // String memo = output.note ?? '';
-      String memo = '';
+      String memo = output.memo ?? '';
       if (paymentUri != null && paymentUri.address != null) {
         address = paymentUri.address!;
         if (memo.isEmpty && paymentUri.memo != null) {

--- a/lib/core/universal_address_detector.dart
+++ b/lib/core/universal_address_detector.dart
@@ -222,6 +222,12 @@ class UniversalAddressDetector {
         currency: CryptoCurrency.doge,
       ),
 
+      // Zcash (transparent t1/t3, Sapling zs, Unified u1)
+      _DetectionPattern(
+        pattern: RegExp(r'^(?:t1[0-9A-Za-z]{33}|t3[0-9A-Za-z]{33}|zs[a-z0-9]{76}|u1[a-z0-9]{1,300})$'),
+        currency: CryptoCurrency.zec,
+      ),
+
       // Solana (Base58 format)
       _DetectionPattern(
         pattern: RegExp(r'^[1-9A-HJ-NP-Za-km-z]{43,44}$'),

--- a/lib/entities/parse_address_from_domain.dart
+++ b/lib/entities/parse_address_from_domain.dart
@@ -226,7 +226,8 @@ class AddressResolver {
           if (result != null) {
             return ParsedAddress.zcashAddress(
               address: result['address'] as String,
-              name: result['display_name'] as String? ?? username,
+              name: username,
+              profileName: result['display_name'] as String? ?? username,
               addressVerified: result['address_verified'] as bool?,
             );
           }
@@ -240,7 +241,8 @@ class AddressResolver {
           if (result != null) {
             return ParsedAddress.zcashAddress(
               address: result['address'] as String,
-              name: result['display_name'] as String? ?? username,
+              name: username,
+              profileName: result['display_name'] as String? ?? username,
               addressVerified: result['address_verified'] as bool?,
             );
           }
@@ -254,7 +256,8 @@ class AddressResolver {
           if (result != null && result['address_verified'] == true) {
             return ParsedAddress.zcashAddress(
               address: result['address'] as String,
-              name: result['display_name'] as String? ?? username,
+              name: username,
+              profileName: result['display_name'] as String? ?? username,
               addressVerified: true,
             );
           }

--- a/lib/entities/parse_address_from_domain.dart
+++ b/lib/entities/parse_address_from_domain.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:cake_wallet/core/address_validator.dart';
 import 'package:cake_wallet/core/yat_service.dart';
 import 'package:cake_wallet/entities/emoji_string_extension.dart';
@@ -217,15 +218,15 @@ class AddressResolver {
   Future<ParsedAddress> resolve(BuildContext context, String text, CryptoCurrency currency) async {
     final ticker = currency.title;
     try {
-      if (text.startsWith("zcash.me")) {
+      if (text.startsWith("zcash.me/")) {
         final parts = text.split("/");
-        final handle = parts.last;
-        if (parts.length == 2 && handle.isNotEmpty) {
-          final extractZcashAddress = await _fetchZcashAddress(handle);
-          if (extractZcashAddress != null) {
+        final username = parts.last;
+        if (parts.length == 2 && username.isNotEmpty) {
+          final result = await _lookupZcashMe(username);
+          if (result != null) {
             return ParsedAddress.zcashAddress(
-              address: extractZcashAddress,
-              name: handle,
+              address: result['address'] as String,
+              name: result['display_name'] as String? ?? username,
             );
           }
         }
@@ -494,26 +495,21 @@ class AddressResolver {
     return ParsedAddress(addresses: [text]);
   }
 
-  Future<String?> _fetchZcashAddress(String handle) async {
-    final url = Uri.parse('https://zcash.me/$handle');
+  Future<Map<String, dynamic>?> _lookupZcashMe(String username) async {
+    final url = Uri.parse('https://zcash.me/api/lookup/$username');
 
     try {
       final response = await ProxyWrapper().get(clearnetUri: url);
 
       if (response.statusCode == 200) {
-        final addressRegex = RegExp(
-          r'(t1[0-9A-Za-z]{33}|t3[0-9A-Za-z]{33}|zs[a-z0-9]{76}|u1[a-z0-9]{1,300})',
-          caseSensitive: true,
-        );
-
-        final match = addressRegex.firstMatch(response.body);
-
-        if (match != null) {
-          return match.group(0);
+        final json = jsonDecode(response.body) as Map<String, dynamic>;
+        final address = json['address'] as String?;
+        if (address != null && address.isNotEmpty) {
+          return json;
         }
       }
     } catch (e) {
-      printV('Error fetching zcash.me profile: $e');
+      printV('Error looking up zcash.me/$username: $e');
     }
     return null;
   }

--- a/lib/entities/parse_address_from_domain.dart
+++ b/lib/entities/parse_address_from_domain.dart
@@ -227,6 +227,7 @@ class AddressResolver {
             return ParsedAddress.zcashAddress(
               address: result['address'] as String,
               name: result['display_name'] as String? ?? username,
+              addressVerified: result['address_verified'] as bool?,
             );
           }
         }
@@ -240,6 +241,7 @@ class AddressResolver {
             return ParsedAddress.zcashAddress(
               address: result['address'] as String,
               name: result['display_name'] as String? ?? username,
+              addressVerified: result['address_verified'] as bool?,
             );
           }
         }
@@ -253,6 +255,7 @@ class AddressResolver {
             return ParsedAddress.zcashAddress(
               address: result['address'] as String,
               name: result['display_name'] as String? ?? username,
+              addressVerified: true,
             );
           }
         }

--- a/lib/entities/parse_address_from_domain.dart
+++ b/lib/entities/parse_address_from_domain.dart
@@ -231,6 +231,32 @@ class AddressResolver {
           }
         }
       }
+
+      if (text.startsWith("/") && !text.contains(" ")) {
+        final username = text.substring(1);
+        if (username.isNotEmpty) {
+          final result = await _lookupZcashMe(username);
+          if (result != null) {
+            return ParsedAddress.zcashAddress(
+              address: result['address'] as String,
+              name: result['display_name'] as String? ?? username,
+            );
+          }
+        }
+      }
+
+      if (text.endsWith(".zcash") && !text.contains("/")) {
+        final username = text.substring(0, text.length - 6);
+        if (username.isNotEmpty) {
+          final result = await _lookupZcashMe(username);
+          if (result != null && result['address_verified'] == true) {
+            return ParsedAddress.zcashAddress(
+              address: result['address'] as String,
+              name: result['display_name'] as String? ?? username,
+            );
+          }
+        }
+      }
       // twitter handle example: @username
       if (text.startsWith('@') && !text.substring(1).contains('@')) {
         if (currency == CryptoCurrency.zano && settingsStore.lookupsZanoAlias) {

--- a/lib/entities/parsed_address.dart
+++ b/lib/entities/parsed_address.dart
@@ -28,6 +28,7 @@ class ParsedAddress {
     this.profileName = '',
     this.parseFrom = ParseFrom.notParsed,
     this.bip353DnsProof,
+    this.addressVerified,
   });
 
   factory ParsedAddress.fetchEmojiAddress({
@@ -168,11 +169,12 @@ class ParsedAddress {
     );
   }
 
-  factory ParsedAddress.zcashAddress({required String address, required String name}) {
+  factory ParsedAddress.zcashAddress({required String address, required String name, bool? addressVerified}) {
     return ParsedAddress(
       addresses: [address],
       name: name,
       parseFrom: ParseFrom.zcashAddress,
+      addressVerified: addressVerified,
     );
   }
 
@@ -191,4 +193,5 @@ class ParsedAddress {
   final String profileName;
   final ParseFrom parseFrom;
   final String? bip353DnsProof;
+  final bool? addressVerified;
 }

--- a/lib/entities/parsed_address.dart
+++ b/lib/entities/parsed_address.dart
@@ -169,10 +169,11 @@ class ParsedAddress {
     );
   }
 
-  factory ParsedAddress.zcashAddress({required String address, required String name, bool? addressVerified}) {
+  factory ParsedAddress.zcashAddress({required String address, required String name, String profileName = '', bool? addressVerified}) {
     return ParsedAddress(
       addresses: [address],
       name: name,
+      profileName: profileName,
       parseFrom: ParseFrom.zcashAddress,
       addressVerified: addressVerified,
     );

--- a/lib/src/screens/send/widgets/extract_address_from_parsed.dart
+++ b/lib/src/screens/send/widgets/extract_address_from_parsed.dart
@@ -75,8 +75,12 @@ Future<String> extractAddressFromParsed(
       break;
     case ParseFrom.zcashAddress:
       title = S.of(context).address_detected;
-      content = S.of(context).extracted_address_content('${parsedAddress.name} (Zcash.me)');
       address = parsedAddress.addresses.first;
+      if (parsedAddress.addressVerified == true) {
+        content = S.of(context).extracted_address_content('${parsedAddress.name} (Zcash.me ✓ Verified)');
+      } else {
+        content = S.of(context).extracted_address_content('${parsedAddress.name} (Zcash.me ⚠ Unverified)');
+      }
       break;
     case ParseFrom.bip353:
       title = S.of(context).address_detected;

--- a/lib/src/screens/send/widgets/extract_address_from_parsed.dart
+++ b/lib/src/screens/send/widgets/extract_address_from_parsed.dart
@@ -3,6 +3,7 @@ import 'package:cake_wallet/src/widgets/alert_with_one_action.dart';
 import 'package:cake_wallet/utils/show_pop_up.dart';
 import 'package:flutter/material.dart';
 import 'package:cake_wallet/generated/i18n.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'choose_yat_address_alert.dart';
 
 Future<String> extractAddressFromParsed(
@@ -15,6 +16,8 @@ Future<String> extractAddressFromParsed(
   var address = '';
   var profileImageUrl = '';
   var profileName = '';
+  String? profileLink;
+  String? profileLinkText;
 
   switch (parsedAddress.parseFrom) {
     case ParseFrom.unstoppableDomains:
@@ -77,10 +80,12 @@ Future<String> extractAddressFromParsed(
       title = S.of(context).address_detected;
       address = parsedAddress.addresses.first;
       if (parsedAddress.addressVerified == true) {
-        content = S.of(context).extracted_address_content('${parsedAddress.name} (Zcash.me ✓ Verified)');
+        content = '${parsedAddress.profileName} is verified ✓\nAre you sure you want to send to ${parsedAddress.profileName}?';
       } else {
-        content = S.of(context).extracted_address_content('${parsedAddress.name} (Zcash.me ⚠ Unverified)');
+        content = '${parsedAddress.profileName} is not verified ⚠\nAre you sure you want to send to ${parsedAddress.profileName}?';
       }
+      profileLink = 'https://zcash.me/${parsedAddress.name}';
+      profileLinkText = 'zcash.me/${parsedAddress.name}';
       break;
     case ParseFrom.bip353:
       title = S.of(context).address_detected;
@@ -137,6 +142,18 @@ Future<String> extractAddressFromParsed(
       alertContent: content,
       buttonText: S.of(context).ok,
       buttonAction: () => Navigator.of(context).pop(),
+      alertWidget: profileLink != null
+          ? TextButton(
+              onPressed: () => launchUrl(Uri.parse(profileLink!), mode: LaunchMode.externalApplication),
+              child: Text(
+                profileLinkText!,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.primary,
+                  decoration: TextDecoration.underline,
+                ),
+              ),
+            )
+          : null,
     ),
   );
 

--- a/lib/src/screens/send/widgets/extract_address_from_parsed.dart
+++ b/lib/src/screens/send/widgets/extract_address_from_parsed.dart
@@ -80,9 +80,9 @@ Future<String> extractAddressFromParsed(
       title = S.of(context).address_detected;
       address = parsedAddress.addresses.first;
       if (parsedAddress.addressVerified == true) {
-        content = '${parsedAddress.profileName} is verified ✓\nAre you sure you want to send to ${parsedAddress.profileName}?';
+        content = '${parsedAddress.profileName} may not be the person you think. Are you sure you want to send to ${parsedAddress.profileName}?';
       } else {
-        content = '${parsedAddress.profileName} is not verified ⚠\nAre you sure you want to send to ${parsedAddress.profileName}?';
+        content = '${parsedAddress.profileName} may not be the person you think. Are you sure you want to send to ${parsedAddress.profileName}?';
       }
       profileLink = 'https://zcash.me/${parsedAddress.name}';
       profileLinkText = 'zcash.me/${parsedAddress.name}';

--- a/lib/src/screens/send/widgets/extract_address_from_parsed.dart
+++ b/lib/src/screens/send/widgets/extract_address_from_parsed.dart
@@ -140,7 +140,7 @@ Future<String> extractAddressFromParsed(
       headerTitleText: profileName.isEmpty ? null : profileName,
       headerImageProfileUrl: profileImageUrl.isEmpty ? null : profileImageUrl,
       alertContent: content,
-      buttonText: S.of(context).ok,
+      buttonText: S.of(context).confirm,
       buttonAction: () => Navigator.of(context).pop(),
       alertWidget: profileLink != null
           ? TextButton(

--- a/lib/src/screens/send/widgets/send_card.dart
+++ b/lib/src/screens/send/widgets/send_card.dart
@@ -90,6 +90,7 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
         cryptoAmountController = TextEditingController(),
         fiatAmountController = TextEditingController(),
         noteController = TextEditingController(),
+        memoController = TextEditingController(),
         extractedAddressController = TextEditingController(),
         addressFocusNode = FocusNode();
 
@@ -107,6 +108,7 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
   final TextEditingController cryptoAmountController;
   final TextEditingController fiatAmountController;
   final TextEditingController noteController;
+  final TextEditingController memoController;
   final TextEditingController extractedAddressController;
   final FocusNode addressFocusNode;
 
@@ -147,6 +149,7 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
     cryptoAmountController.dispose();
     fiatAmountController.dispose();
     noteController.dispose();
+    memoController.dispose();
     extractedAddressController.dispose();
     addressFocusNode.dispose();
     super.dispose();
@@ -499,6 +502,10 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
       cryptoAmountController.text = paymentRequest.amount;
     }
     noteController.text = paymentRequest.note;
+    if (paymentRequest.memo != null) {
+      output.memo = paymentRequest.memo;
+      memoController.text = paymentRequest.memo!;
+    }
   }
 
   Future<void> _handleSwapFlow(
@@ -774,6 +781,27 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
                       ),
                 ),
               ),
+              if (sendViewModel.walletType == WalletType.zcash)
+                Padding(
+                  padding: EdgeInsets.only(top: 20),
+                  child: BaseTextFormField(
+                    hasUnderlineBorder: true,
+                    contentPadding: EdgeInsets.symmetric(vertical: 8),
+                    fillColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+                    key: ValueKey('send_page_memo_textfield_key'),
+                    controller: memoController,
+                    keyboardType: TextInputType.multiline,
+                    maxLines: null,
+                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                          fontWeight: FontWeight.w500,
+                        ),
+                    hintText: S.of(context).memo_optional,
+                    placeholderTextStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                          fontWeight: FontWeight.w500,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                  ),
+                ),
               if (sendViewModel.feesViewModel.hasFees)
                 Observer(
                   builder: (_) => GestureDetector(
@@ -933,6 +961,7 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
     }
     fiatAmountController.text = output.fiatAmount;
     noteController.text = output.note;
+    memoController.text = output.memo ?? '';
     extractedAddressController.text = output.extractedAddress;
 
     cryptoAmountController.addListener(() {
@@ -961,6 +990,15 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
 
       if (note != output.note) {
         output.note = note;
+      }
+    });
+
+    memoController.addListener(() {
+      final memo = memoController.text;
+      final currentMemo = output.memo ?? '';
+
+      if (memo != currentMemo) {
+        output.memo = memo.isEmpty ? null : memo;
       }
     });
 
@@ -1013,6 +1051,13 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
       }
     });
 
+    reaction((_) => output.memo, (String? memo) {
+      final memoText = memo ?? '';
+      if (memoText != memoController.text) {
+        memoController.text = memoText;
+      }
+    });
+
     addressFocusNode.addListener(() async {
       if (!addressFocusNode.hasFocus && addressController.text.isNotEmpty) {
         final current = addressController.text.trim();
@@ -1061,6 +1106,10 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
       addressController.text = initialPaymentRequest!.address;
       cryptoAmountController.text = initialPaymentRequest!.amount;
       noteController.text = initialPaymentRequest!.note;
+      if (initialPaymentRequest!.memo != null) {
+        output.memo = initialPaymentRequest!.memo;
+        memoController.text = initialPaymentRequest!.memo!;
+      }
     }
 
     reaction((_) => sendViewModel.isReadyForSend, (bool isReadyForSend) {

--- a/lib/src/screens/send/widgets/send_card.dart
+++ b/lib/src/screens/send/widgets/send_card.dart
@@ -561,27 +561,30 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
     //     child: Text('Send Card'),
     //   ),
     // );
-    return Container(
-      decoration: responsiveLayoutUtil.shouldRenderMobileUI
-          ? BoxDecoration(
-              borderRadius: BorderRadius.only(
-                bottomLeft: Radius.circular(24),
-                bottomRight: Radius.circular(24),
-              ),
-              color: Theme.of(context).colorScheme.surfaceContainer,
-            )
-          : null,
-      child: Padding(
-        padding: EdgeInsets.fromLTRB(
-          24,
-          responsiveLayoutUtil.shouldRenderMobileUI ? 110 : 55,
-          24,
-          responsiveLayoutUtil.shouldRenderMobileUI ? 32 : 0,
-        ),
-        child: Observer(
-          builder: (_) => Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          decoration: responsiveLayoutUtil.shouldRenderMobileUI
+              ? BoxDecoration(
+                  borderRadius: BorderRadius.only(
+                    bottomLeft: Radius.circular(24),
+                    bottomRight: Radius.circular(24),
+                  ),
+                  color: Theme.of(context).colorScheme.surfaceContainer,
+                )
+              : null,
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              24,
+              responsiveLayoutUtil.shouldRenderMobileUI ? 110 : 55,
+              24,
+              responsiveLayoutUtil.shouldRenderMobileUI ? 32 : 0,
+            ),
+            child: Observer(
+              builder: (_) => Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
               Observer(builder: (_) {
                 final validator = output.isParsedAddress
                     ? sendViewModel.textValidator
@@ -761,26 +764,27 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
                   allAmountButton: false,
                 ),
               Divider(height: 1, color: Theme.of(context).colorScheme.outlineVariant),
-              Padding(
-                padding: EdgeInsets.only(top: 20),
-                child: BaseTextFormField(
-                  hasUnderlineBorder: true,
-                  contentPadding: EdgeInsets.symmetric(vertical: 8),
-                  fillColor: Theme.of(context).colorScheme.surfaceContainerHighest,
-                  key: ValueKey('send_page_note_textfield_key'),
-                  controller: noteController,
-                  keyboardType: TextInputType.multiline,
-                  maxLines: null,
-                  textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        fontWeight: FontWeight.w500,
-                      ),
-                  hintText: S.of(context).note_optional,
-                  placeholderTextStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        fontWeight: FontWeight.w500,
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
+              if (sendViewModel.walletType != WalletType.zcash)
+                Padding(
+                  padding: EdgeInsets.only(top: 20),
+                  child: BaseTextFormField(
+                    hasUnderlineBorder: true,
+                    contentPadding: EdgeInsets.symmetric(vertical: 8),
+                    fillColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+                    key: ValueKey('send_page_note_textfield_key'),
+                    controller: noteController,
+                    keyboardType: TextInputType.multiline,
+                    maxLines: null,
+                    textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                          fontWeight: FontWeight.w500,
+                        ),
+                    hintText: S.of(context).note_optional,
+                    placeholderTextStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                          fontWeight: FontWeight.w500,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                  ),
                 ),
-              ),
               if (sendViewModel.walletType == WalletType.zcash)
                 Padding(
                   padding: EdgeInsets.only(top: 20),
@@ -941,10 +945,40 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
                     ),
                   ),
                 ),
-            ],
+                ],
+              ),
+            ),
           ),
         ),
-      ),
+        if (sendViewModel.walletType == WalletType.zcash)
+          Container(
+            margin: EdgeInsets.only(top: 16),
+            padding: EdgeInsets.fromLTRB(24, 16, 24, 16),
+            decoration: responsiveLayoutUtil.shouldRenderMobileUI
+                ? BoxDecoration(
+                    borderRadius: BorderRadius.circular(24),
+                    color: Theme.of(context).colorScheme.surfaceContainer,
+                  )
+                : null,
+            child: BaseTextFormField(
+              hasUnderlineBorder: true,
+              contentPadding: EdgeInsets.symmetric(vertical: 8),
+              fillColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+              key: ValueKey('send_page_note_textfield_key'),
+              controller: noteController,
+              keyboardType: TextInputType.multiline,
+              maxLines: null,
+              textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+              hintText: 'Internal note',
+              placeholderTextStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                    fontWeight: FontWeight.w500,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+      ],
     );
   }
 

--- a/lib/src/screens/send/widgets/send_card.dart
+++ b/lib/src/screens/send/widgets/send_card.dart
@@ -971,7 +971,7 @@ class SendCardState extends State<SendCard> with AutomaticKeepAliveClientMixin<S
               textStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
                     fontWeight: FontWeight.w500,
                   ),
-              hintText: 'Internal note',
+              hintText: 'Internal Note (Optional)',
               placeholderTextStyle: Theme.of(context).textTheme.bodyMedium!.copyWith(
                     fontWeight: FontWeight.w500,
                     color: Theme.of(context).colorScheme.onSurfaceVariant,

--- a/lib/src/widgets/alert_with_one_action.dart
+++ b/lib/src/widgets/alert_with_one_action.dart
@@ -11,6 +11,7 @@ class AlertWithOneAction extends BaseAlertDialog {
     this.headerTitleText,
     this.headerImageProfileUrl,
     this.buttonKey,
+    this.alertWidget,
     Key? key,
   });
 
@@ -22,12 +23,31 @@ class AlertWithOneAction extends BaseAlertDialog {
   final String? headerTitleText;
   final String? headerImageProfileUrl;
   final Key? buttonKey;
+  final Widget? alertWidget;
 
   @override
   String get titleText => alertTitle;
 
   @override
   String get contentText => alertContent;
+
+  @override
+  Widget? get contentTextWidget => alertWidget != null
+      ? Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              alertContent,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontSize: 16,
+                decoration: TextDecoration.none,
+              ),
+            ),
+            alertWidget!,
+          ],
+        )
+      : null;
 
   @override
   bool get barrierDismissible => alertBarrierDismissible;

--- a/lib/utils/payment_request.dart
+++ b/lib/utils/payment_request.dart
@@ -1,9 +1,10 @@
+import 'dart:convert';
 import 'package:cake_wallet/core/payment_uris.dart';
 import 'package:cake_wallet/nano/nano.dart';
 
 class PaymentRequest {
   PaymentRequest(this.address, this.amount, this.note, this.scheme, this.pjUri,
-      {this.callbackUrl, this.callbackMessage, this.contractAddress});
+      {this.callbackUrl, this.callbackMessage, this.contractAddress, this.memo});
 
   factory PaymentRequest.fromUri(Uri? uri) {
     var address = "";
@@ -15,6 +16,7 @@ class PaymentRequest {
     String? callbackMessage;
     String? pjUri;
     String? contractAddress;
+    String? memo;
 
     if (uri != null) {
       if (uri.queryParameters['pj'] != null) {
@@ -35,6 +37,17 @@ class PaymentRequest {
         address = paymentUri.address;
         amount = paymentUri.amount;
         contractAddress = paymentUri.contractAddress;
+      }
+
+      if (scheme == "zcash") {
+        final memoParam = uri.queryParameters['memo'];
+        if (memoParam != null && memoParam.isNotEmpty) {
+          try {
+            memo = utf8.decode(base64Url.decode(base64Url.normalize(memoParam)));
+          } catch (_) {
+            memo = memoParam;
+          }
+        }
       }
     }
 
@@ -63,6 +76,7 @@ class PaymentRequest {
       callbackUrl: callbackUrl,
       callbackMessage: callbackMessage,
       contractAddress: contractAddress,
+      memo: memo,
     );
   }
 
@@ -74,6 +88,7 @@ class PaymentRequest {
   final String? callbackUrl;
   final String? callbackMessage;
   final String? contractAddress;
+  final String? memo;
 
   /// Checks if the amount string is already in a usable format (e.g., "123.45") and doesn't need to be converted from raw format.
   ///

--- a/lib/view_model/send/output.dart
+++ b/lib/view_model/send/output.dart
@@ -83,6 +83,7 @@ abstract class OutputBase with Store {
   @observable
   String extractedAddress;
 
+  @observable
   String? memo;
 
   @computed

--- a/lib/zcash/cw_zcash.dart
+++ b/lib/zcash/cw_zcash.dart
@@ -55,6 +55,7 @@ class CWZcash extends Zcash {
               cryptoAmount: out.cryptoAmount,
               address: out.address,
               note: out.note,
+              memo: out.memo,
               sendAll: out.sendAll,
               extractedAddress: out.extractedAddress,
               isParsedAddress: out.isParsedAddress,

--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -517,6 +517,7 @@
   "max_amount": "Max: ${value}",
   "max_value": "Max: ${value} ${currency}",
   "memo": "Memo",
+  "memo_optional": "Memo (optional)",
   "message": "Message",
   "message_verified": "The message was successfully verified",
   "messages": "Messages",

--- a/test/utils/payment_request_test.dart
+++ b/test/utils/payment_request_test.dart
@@ -57,5 +57,68 @@ void main() {
         expect(paymentRequest.amount, "");
       });
     });
+
+    group('Zcash ZIP-321 URIs', () {
+      test('extract address and amount from basic zcash URI', () {
+        final uri = Uri.parse('zcash:u1abc123?amount=1.5');
+        final paymentRequest = PaymentRequest.fromUri(uri);
+
+        expect(paymentRequest.scheme, 'zcash');
+        expect(paymentRequest.address, 'u1abc123');
+        expect(paymentRequest.amount, '1.5');
+        expect(paymentRequest.memo, isNull);
+      });
+
+      test('decode base64url memo from zcash URI', () {
+        // "Hello World" in base64url = SGVsbG8gV29ybGQ=
+        final uri = Uri.parse('zcash:u1addr?amount=0.001&memo=SGVsbG8gV29ybGQ=');
+        final paymentRequest = PaymentRequest.fromUri(uri);
+
+        expect(paymentRequest.scheme, 'zcash');
+        expect(paymentRequest.address, 'u1addr');
+        expect(paymentRequest.amount, '0.001');
+        expect(paymentRequest.memo, 'Hello World');
+      });
+
+      test('decode base64url memo without padding', () {
+        // "Hello" in base64url = SGVsbG8 (no padding)
+        final uri = Uri.parse('zcash:u1addr?memo=SGVsbG8');
+        final paymentRequest = PaymentRequest.fromUri(uri);
+
+        expect(paymentRequest.memo, 'Hello');
+      });
+
+      test('memo and message are separate fields', () {
+        final uri = Uri.parse('zcash:u1addr?amount=1.0&memo=SGVsbG8&message=local+note');
+        final paymentRequest = PaymentRequest.fromUri(uri);
+
+        expect(paymentRequest.memo, 'Hello');
+        expect(paymentRequest.note, 'local note');
+      });
+
+      test('empty memo param results in null memo', () {
+        final uri = Uri.parse('zcash:u1addr?memo=');
+        final paymentRequest = PaymentRequest.fromUri(uri);
+
+        expect(paymentRequest.memo, isNull);
+      });
+
+      test('non-zcash scheme does not parse memo', () {
+        final uri = Uri.parse('bitcoin:bc1abc?memo=SGVsbG8');
+        final paymentRequest = PaymentRequest.fromUri(uri);
+
+        expect(paymentRequest.memo, isNull);
+      });
+
+      test('decode unicode memo (UTF-8 encoded)', () {
+        // "Zcash !" base64url encoded
+        // dart: base64Url.encode(utf8.encode("Zcash ❤️!")) = WmNhc2gg4p2k77iPIQ==
+        // Let's use a simpler example: "café" = Y2Fmw6k=
+        final uri = Uri.parse('zcash:u1addr?memo=Y2Fmw6k=');
+        final paymentRequest = PaymentRequest.fromUri(uri);
+
+        expect(paymentRequest.memo, 'café');
+      });
+    });
   });
 }


### PR DESCRIPTION
Closes https://github.com/cake-tech/cake_wallet/issues/3038

## Summary
- Parse ZIP-321 `memo` param from `zcash:` URIs (base64url decoded)
- Separate on-chain Memo field from local-only Internal Note for Zcash send screen
- Replace zcash.me HTML scraping with public lookup API
- Support `/username` and `username.zcash` resolution formats
- Surface address verification state in confirmation popup
- Add clickable zcash.me profile link in address detection modal
- Add Zcash address detection (t1/t3/zs/u1) to UniversalAddressDetector
- UI: "OK" → "Confirm" button, improved hint text

## Test plan
- [ ] Send ZEC using a `zcash:` URI with a `memo` parameter — verify memo appears in Memo field
- [ ] Enter a zcash.me username (via `zcash.me/user`, `/user`, or `user.zcash`) — verify address resolves and verification state shows
- [ ] Tap profile link in address detection popup — verify it opens in browser
- [ ] Confirm Internal Note and Memo are separate fields on Zcash send screen
- [ ] Verify non-Zcash wallets still show the standard Note field
- [ ] Run `dart test test/utils/payment_request_test.dart` — all ZIP-321 tests pass