### PR TITLE
Fix QR scanner to accept fountain coding for BC-UR codes

### DIFF
--- a/lib/entities/qr_scanner.dart
+++ b/lib/entities/qr_scanner.dart
@@ -121,10 +121,10 @@ class _BarcodeScannerSimpleState extends State<BarcodeScannerSimple> {
             onDetect: _handleBarcode,
             controller: ctrl,
           ),
-          if (decoder.processedPartsCount() != 0)
+          if (decoder.expectedPartCount() != null)
             Center(
               child: Text(
-                "${decoder.processedPartsCount()}/${decoder.expectedPartCount()}",
+                "${decoder.processedPartsCount()}/${decoder.expectedPartCount()!}",
                 style: Theme.of(context)
                     .textTheme
                     .displayLarge
@@ -139,9 +139,9 @@ class _BarcodeScannerSimpleState extends State<BarcodeScannerSimple> {
                 child: CustomPaint(
                   painter: ProgressPainter(
                     urQrProgress: URQrProgress(
-                      expectedPartCount: decoder.expectedPartCount(),
+                      expectedPartCount: decoder.expectedPartCount()!,
                       processedPartsCount: decoder.processedPartsCount(),
-                      receivedPartIndexes: decoder.receivedPartIndexes(),
+                      receivedPartIndexes: decoder.receivedPartIndexes().toList(),
                       percentage: decoder.estimatedPercentComplete(),
                     ),
                   ),

--- a/lib/entities/qr_scanner.dart
+++ b/lib/entities/qr_scanner.dart
@@ -7,6 +7,7 @@ import 'package:cw_core/utils/print_verbose.dart';
 import 'package:fast_scanner/fast_scanner.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:ur/ur_decoder.dart';
 
 var isQrScannerShown = false;
 
@@ -42,6 +43,7 @@ class _BarcodeScannerSimpleState extends State<BarcodeScannerSimple> {
 
   List<String> urCodes = [];
   late var ur = URQRToURQRData(urCodes);
+  final decoder = URDecoder();
 
   void _handleBarcode(BarcodeCapture barcodes) {
     try {
@@ -70,11 +72,12 @@ class _BarcodeScannerSimpleState extends State<BarcodeScannerSimple> {
       if (barcode.rawValue?.trim().isEmpty ?? false == false) continue;
       if (barcode.rawValue!.startsWith("ur:")) {
         if (urCodes.contains(barcode.rawValue)) continue;
+        decoder.receivePart(barcode.rawValue!);
         setState(() {
           urCodes.add(barcode.rawValue!);
           ur = URQRToURQRData(urCodes);
         });
-        if (ur.progress == 1) {
+        if (decoder.estimatedPercentComplete() == 1) {
           setState(() {
             popped = true;
           });
@@ -118,10 +121,10 @@ class _BarcodeScannerSimpleState extends State<BarcodeScannerSimple> {
             onDetect: _handleBarcode,
             controller: ctrl,
           ),
-          if (ur.inputs.length != 0)
+          if (decoder.processedPartsCount() != 0)
             Center(
               child: Text(
-                "${ur.inputs.length}/${ur.count}",
+                "${decoder.processedPartsCount()}/${decoder.expectedPartCount()}",
                 style: Theme.of(context)
                     .textTheme
                     .displayLarge
@@ -136,10 +139,10 @@ class _BarcodeScannerSimpleState extends State<BarcodeScannerSimple> {
                 child: CustomPaint(
                   painter: ProgressPainter(
                     urQrProgress: URQrProgress(
-                      expectedPartCount: ur.count - 1,
-                      processedPartsCount: ur.inputs.length,
-                      receivedPartIndexes: _urParts(),
-                      percentage: ur.progress,
+                      expectedPartCount: decoder.expectedPartCount(),
+                      processedPartsCount: decoder.processedPartsCount(),
+                      receivedPartIndexes: decoder.receivedPartIndexes(),
+                      percentage: decoder.estimatedPercentComplete(),
                     ),
                   ),
                 ),

--- a/lib/entities/qr_scanner.dart
+++ b/lib/entities/qr_scanner.dart
@@ -139,7 +139,7 @@ class _BarcodeScannerSimpleState extends State<BarcodeScannerSimple> {
                 child: CustomPaint(
                   painter: ProgressPainter(
                     urQrProgress: URQrProgress(
-                      expectedPartCount: decoder.expectedPartCount()!,
+                      expectedPartCount: decoder.expectedPartCount() ?? 0,
                       processedPartsCount: decoder.processedPartsCount(),
                       receivedPartIndexes: decoder.receivedPartIndexes().toList(),
                       percentage: decoder.estimatedPercentComplete(),

--- a/lib/src/screens/ur/widgets/urqr.dart
+++ b/lib/src/screens/ur/widgets/urqr.dart
@@ -11,9 +11,6 @@ import 'package:cw_core/wallet_type.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:ur/ur.dart';
-import 'package:ur/ur_decoder.dart';
-import 'package:ur/ur_encoder.dart';
 
 class URQR extends StatefulWidget {
   const URQR({super.key, required this.urqr, required this.walletType, this.hardwareWalletType});
@@ -69,23 +66,6 @@ class _URQRState extends State<URQR> {
   void _nextFrame() => setState(() => frame++);
 
 
-  UREncoder? encoder;
-
-  String getNextFrame() {
-    if (_getCurrentFormatName().startsWith('Cupcake')) {
-      if (encoder == null) {
-        final decoder = URDecoder();
-        for (final frame in frames) {
-          decoder.receivePart(frame);
-        }
-        encoder = UREncoder(decoder.result as UR, 120);
-      }
-      return encoder!.nextPart();
-    }
-    return frames[frame % frames.length];
-  }
-
-
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -97,7 +77,7 @@ class _URQRState extends State<URQR> {
             padding: const EdgeInsets.all(24.0),
             child: Container(
               child: QrImage(
-                data: getNextFrame(),
+                data: frames[frame % frames.length],
                 version: -1,
                 size: null,
               ),

--- a/lib/src/screens/ur/widgets/urqr.dart
+++ b/lib/src/screens/ur/widgets/urqr.dart
@@ -11,6 +11,9 @@ import 'package:cw_core/wallet_type.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:ur/ur.dart';
+import 'package:ur/ur_decoder.dart';
+import 'package:ur/ur_encoder.dart';
 
 class URQR extends StatefulWidget {
   const URQR({super.key, required this.urqr, required this.walletType, this.hardwareWalletType});
@@ -66,6 +69,23 @@ class _URQRState extends State<URQR> {
   void _nextFrame() => setState(() => frame++);
 
 
+  UREncoder? encoder;
+
+  String getNextFrame() {
+    if (_getCurrentFormatName().startsWith('Cupcake')) {
+      if (encoder == null) {
+        final decoder = URDecoder();
+        for (final frame in frames) {
+          decoder.receivePart(frame);
+        }
+        encoder = UREncoder(decoder.result as UR, 120);
+      }
+      return encoder!.nextPart();
+    }
+    return frames[frame % frames.length];
+  }
+
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -77,7 +97,7 @@ class _URQRState extends State<URQR> {
             padding: const EdgeInsets.all(24.0),
             child: Container(
               child: QrImage(
-                data: frames[frame % frames.length],
+                data: getNextFrame(),
                 version: -1,
                 size: null,
               ),


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Basically, the current BC-UR decoder assumes it is receiving a fixed set of frames. Each frame starts with `ur:psbt/m-n/` where n is the total number of frames and m is the sequence number of the frame. The current assumption is that the encoder produces the n frames and then shows them in sequence, cycling back to the first frame when it reaches the end of the sequence. The receiver must receive all n frames to decode the message.

The disadvantage of this process as described is that if the scanner misses a frame in the sequence, it needs to wait for the animation to cycle back to that frame. If the number of frames is large, this could take a while, maybe several seconds. Even if only one frame is missed, you still need to wait for the animation to reach the end and loop back to the beginning, until the frame is shown again.

But there is a better way. The designers of the UR codes knew about this, so they designed the code to be a "fountain coding". What this means is that, instead of only producing the fixed set of n frames, it keeps producing frames which are XOR combinations of the original fragments. There is encoded redundancy but that also allows you to work out missing frames in the main sequence, using the XOR frames. You may need to receive a number of frames greater than n to work out all the n frames. But the advantage is that you don't need to wait for the animation to cycle back to the start. Each successfully received frame in the fountain code allows you to make progress with a high degree of probability. Much faster than waiting for the animation to cycle back round.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
