### PR TITLE
Update RBF nsequence to 0xFFFFFFFD

### DIFF
--- a/cw_bitcoin/lib/psbt/transaction_builder.dart
+++ b/cw_bitcoin/lib/psbt/transaction_builder.dart
@@ -25,7 +25,7 @@ class PSBTTransactionBuild {
 
       psbt.setInputPreviousTxId(i, Uint8List.fromList(hex.decode(input.utxo.txHash).reversed.toList()));
       psbt.setInputOutputIndex(i, input.utxo.vout);
-      psbt.setInputSequence(i, enableRBF ? 0x1 : 0xffffffff);
+      psbt.setInputSequence(i, enableRBF ? 0xfffffffd : 0xffffffff);
       
 
       if (input.utxo.isSegwit()) {


### PR DESCRIPTION
Technically `0x1` will signal opt-in RBF (since 0x1 ≤ 0xFFFFFFFD); however it also sets a relative timelock of 1 block. This seems like an unintended bug. It also fingerprints cake wallet since `0x1` is an abnormal value. This is especially harmful in collaborative settings e.g payjoin. Most wallets set `nsequence = 0xFFFFFFFD` to opt into RBF or just use full rbf which seems to be gaining more adoption.

Issue Number (if Applicable): Fixes #

# Description

Please include a summary of the changes and which issue is fixed / feature is added. 

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [X] Double check modified code and verify it with the feature/task requirements
- [X] Format code
- [X] Look for code duplication
- [X] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
