### PR TITLE
move to forked version of modal_bottom_sheet

### DIFF
--- a/pubspec_base.yaml
+++ b/pubspec_base.yaml
@@ -20,7 +20,11 @@ dependencies:
       ref: 69b3276b090fa6ac01b4483ca3adca93a8e615be
   http: ^1.1.0
   path_provider: ^2.0.11
-  modal_bottom_sheet: ^3.0.0
+  modal_bottom_sheet:
+    git:
+      url: https://github.com/malik1004x/modal_bottom_sheet
+      ref: b1cca111c53d41b9f07123a8c67cfe06fb1b69bf
+      path: modal_bottom_sheet
   mobx: ^2.1.4
   flutter_mobx: 2.0.6+5
   flutter_slidable: ^3.0.1

--- a/pubspec_base.yaml
+++ b/pubspec_base.yaml
@@ -22,7 +22,7 @@ dependencies:
   path_provider: ^2.0.11
   modal_bottom_sheet:
     git:
-      url: https://github.com/malik1004x/modal_bottom_sheet
+      url: https://github.com/cake-tech/modal_bottom_sheet
       ref: b1cca111c53d41b9f07123a8c67cfe06fb1b69bf
       path: modal_bottom_sheet
   mobx: ^2.1.4


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

The `modal_bottom_sheet` package, used by the 6.0 UI to create the fancy iPhone-style modal sheets, has a few critical, performance-hindering bugs that cause rebuilds of both the background and the sheet content. This PR moves the app to a forked version of `modal_bottom_sheet` that fixes several key performance issues.

The original version of the package seems largely abandoned (last update was 20 months ago, and some changes have been made in GitHub but not in pub.dev) so the chance this'll require merging from upstream later is very low.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
