### PR TITLE
add KeyboardHideOverlay to cake pay pages

### DIFF
--- a/lib/cake_pay/src/cards/cake_pay_buy_card_page.dart
+++ b/lib/cake_pay/src/cards/cake_pay_buy_card_page.dart
@@ -14,6 +14,7 @@ import 'package:cake_wallet/cake_pay/src/widgets/three_checkbox_alert_content_wi
 import 'package:cake_wallet/core/execution_state.dart';
 import 'package:cake_wallet/entities/parsed_address.dart';
 import 'package:cake_wallet/generated/i18n.dart';
+import 'package:cake_wallet/new-ui/widgets/keyboard_hide_overlay.dart';
 import 'package:cake_wallet/routes.dart';
 import 'package:cake_wallet/src/screens/base_page.dart';
 import 'package:cake_wallet/src/widgets/alert_with_one_action.dart';
@@ -67,6 +68,9 @@ class CakePayBuyCardPage extends BasePage {
   bool get gradientAll => true;
 
   @override
+  bool get resizeToAvoidBottomInset => false;
+
+  @override
   AppBarStyle get appBarStyle => AppBarStyle.completelyTransparent;
 
   @override
@@ -103,20 +107,9 @@ class CakePayBuyCardPage extends BasePage {
     final card = cakePayBuyCardViewModel.card;
     final vendor = cakePayBuyCardViewModel.vendor;
 
-    return KeyboardActions(
-      disableScroll: true,
-      config: KeyboardActionsConfig(
-          keyboardActionsPlatform: KeyboardActionsPlatform.IOS,
-          keyboardBarColor: Theme.of(context).primaryColor,
-          nextFocus: false,
-          actions: [
-            KeyboardActionsItem(
-              focusNode: _amountFieldFocus,
-              toolbarButtons: [(_) => KeyboardDoneButton()],
-            ),
-          ]),
-      child: Container(
-        color: Colors.transparent,
+    return Container(
+      color: Colors.transparent,
+      child: KeyboardHideOverlay(
         child: Column(
           children: [
             RoundedOverlayCards(

--- a/lib/cake_pay/src/cards/cake_pay_cards_page.dart
+++ b/lib/cake_pay/src/cards/cake_pay_cards_page.dart
@@ -4,6 +4,7 @@ import 'package:cake_wallet/cake_pay/src/widgets/cake_pay_search_bar_widget.dart
 import 'package:cake_wallet/cake_pay/src/widgets/user_card_item.dart';
 import 'package:cake_wallet/entities/country.dart';
 import 'package:cake_wallet/generated/i18n.dart';
+import 'package:cake_wallet/new-ui/widgets/keyboard_hide_overlay.dart';
 import 'package:cake_wallet/routes.dart';
 import 'package:cake_wallet/src/screens/base_page.dart';
 import 'package:cake_wallet/cake_pay/src/widgets/card_item.dart';
@@ -91,7 +92,7 @@ class CakePayCardsPage extends BasePage {
 
   @override
   Widget body(BuildContext context) {
-    return CakePayCardsPageBody(cardsListViewModel: _cardsListViewModel, titleColor: titleColor);
+    return KeyboardHideOverlay(child:CakePayCardsPageBody(cardsListViewModel: _cardsListViewModel, titleColor: titleColor));
   }
 }
 


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Wraps Cake Pay pages in KeyboardHideOverlay to prevent issues with closing the keyboard on iOS.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
