### PR TITLE
Use Silent Payment address for DFX buy flow

### DIFF
--- a/cw_bitcoin/lib/bitcoin_wallet_addresses.dart
+++ b/cw_bitcoin/lib/bitcoin_wallet_addresses.dart
@@ -150,6 +150,12 @@ abstract class BitcoinWalletAddressesBase extends ElectrumWalletAddresses with S
   }
 
   @override
+  String get addressForPrivateBuy {
+    if (silentAddress != null) return silentAddress.toString();
+    return addressForBuy;
+  }
+
+  @override
   String get addressForExchange {
     if (addressPageType == LightningAddressType.p2l) {
       final addresses = receiveAddresses

--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -2587,14 +2587,26 @@ abstract class ElectrumWalletBase
 
   @override
   Future<String> signMessage(String message, {String? address = null}) async {
+    // Silent Payment: sign with b_spend key
+    if (address != null && address.startsWith('sp1')) {
+      final spOwner = (walletAddresses as ElectrumWalletAddressesBase).silentAddress;
+      if (spOwner != null) {
+        return _signWithPrivateKey(spOwner.b_spend, message);
+      }
+    }
+
     final index = address != null
         ? walletAddresses.allAddresses.firstWhere((element) => element.address == address).index
         : null;
     final HD = index == null ? hd : hd.childKey(Bip32KeyIndex(index));
     final priv = ECPrivate.fromHex(HD.privateKey.privKey.toHex());
 
-    String messagePrefix = '\x18Bitcoin Signed Message:\n';
-    final hexEncoded = priv.signMessage(utf8.encode(message), messagePrefix: messagePrefix);
+    return _signWithPrivateKey(priv, message);
+  }
+
+  String _signWithPrivateKey(ECPrivate key, String message) {
+    const messagePrefix = '\x18Bitcoin Signed Message:\n';
+    final hexEncoded = key.signMessage(utf8.encode(message), messagePrefix: messagePrefix);
     final decodedSig = hex.decode(hexEncoded);
     return base64Encode(decodedSig);
   }
@@ -2618,7 +2630,7 @@ abstract class ElectrumWalletBase
           "signature must be 64 bytes without recover-id or 65 bytes with recover-id");
     }
 
-    String messagePrefix = '\x18Bitcoin Signed Message:\n';
+    const messagePrefix = '\x18Bitcoin Signed Message:\n';
     final messageHash = QuickCrypto.sha256Hash(
         BitcoinSignerUtils.magicMessage(utf8.encode(message), messagePrefix));
 

--- a/cw_core/lib/wallet_addresses.dart
+++ b/cw_core/lib/wallet_addresses.dart
@@ -41,6 +41,8 @@ abstract class WalletAddresses {
 
   String get addressForBuy => address;
 
+  String get addressForPrivateBuy => addressForBuy;
+
   Map<String, String> addressesMap;
   Map<String, String> allAddressesMap;
 

--- a/lib/buy/dfx/dfx_buy_provider.dart
+++ b/lib/buy/dfx/dfx_buy_provider.dart
@@ -353,7 +353,12 @@ class DFXBuyProvider extends BuyProvider {
     try {
       final actionType = isBuyAction ? '/buy' : '/sell';
 
-      final accessToken = await auth(cryptoCurrencyAddress);
+      // For Bitcoin buy: use Silent Payment address for privacy (BIP-352)
+      final effectiveAddress = (isBuyAction && wallet.type == WalletType.bitcoin)
+          ? wallet.walletAddresses.addressForPrivateBuy
+          : cryptoCurrencyAddress;
+
+      final accessToken = await auth(effectiveAddress);
 
       final uri = Uri.https('app.dfx.swiss', actionType, {
         'session': accessToken,


### PR DESCRIPTION
## Summary
- Add `addressForPrivateBuy` property to `WalletAddresses` base class (default: `addressForBuy`)
- Override in `BitcoinWalletAddresses` to return Silent Payment (`sp1`) address when available, fallback to P2WPKH
- `signMessage()` uses `b_spend` key when signing for an `sp1` address
- DFX provider uses `addressForPrivateBuy` for Bitcoin buy actions — other providers (MoonPay, Robinhood, Onramper) unaffected
- Hardware wallets: no `silentAddress` available → automatic fallback to P2WPKH

## Context
Companion PR to [DFXswiss/api#3426](https://github.com/DFXswiss/api/pull/3426) which adds `sp1` address recognition and signature verification on the DFX API side. Together they enable privacy-preserving Bitcoin payouts via BIP-352 Silent Payments.

## Changed files
- `cw_core/lib/wallet_addresses.dart` — new `addressForPrivateBuy` getter
- `cw_bitcoin/lib/bitcoin_wallet_addresses.dart` — SP override
- `cw_bitcoin/lib/electrum_wallet.dart` — `signMessage()` SP path
- `lib/buy/dfx/dfx_buy_provider.dart` — use `addressForPrivateBuy` for buy

## Test plan
- [x] Cross-verified SP address derivation: same seed produces same `sp1` address in Cake Wallet and DFX API
- [x] Signature from `b_spend` key verified by DFX API verification logic
- [ ] Manual: buy flow with DFX, verify SP address in auth request
- [ ] CI build passes