### PR TITLE
ensure wallet is saved after walletInfo is created

### DIFF
--- a/lib/view_model/wallet_creation_vm.dart
+++ b/lib/view_model/wallet_creation_vm.dart
@@ -131,6 +131,7 @@ abstract class WalletCreationVMBase with Store {
       credentials.walletInfo!.hashedWalletIdentifier = createHashedWalletIdentifier(wallet);
       credentials.walletInfo!.address = wallet.walletAddresses.address;
       await credentials.walletInfo!.save();
+      await wallet.save();
       await _appStore.changeCurrentWallet(wallet);
       _appStore.authenticationStore.allowedCreate();
       state = ExecutedSuccessfullyState();


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Explicitly saves a wallet after its relevant walletInfo was created, instead of relying on autosave. This fixes issues with wallet data being stored with walletInfoId of 0 if wallet was exited before fully synced.
# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
