### PR TITLE
feat(ios): add iPhone Action Button support for QR scanner

### DIFF
--- a/ios/Runner/AppShortcutsProvider.swift
+++ b/ios/Runner/AppShortcutsProvider.swift
@@ -1,0 +1,17 @@
+import AppIntents
+
+@available(iOS 16.4, *)
+struct CakeWalletShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: ScanQRIntent(),
+            phrases: [
+                "Scan QR with \(.applicationName)",
+                "Pay with \(.applicationName)",
+                "Scan payment with \(.applicationName)"
+            ],
+            shortTitle: "Scan QR Code",
+            systemImageName: "qrcode.viewfinder"
+        )
+    }
+}

--- a/ios/Runner/ScanQRIntent.swift
+++ b/ios/Runner/ScanQRIntent.swift
@@ -1,0 +1,14 @@
+import AppIntents
+import UIKit
+
+@available(iOS 16.0, *)
+struct ScanQRIntent: AppIntent {
+    static var title: LocalizedStringResource = "Scan QR Code"
+    static var description = IntentDescription("Open Cake Wallet to scan a QR code for payment")
+    static var openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+        await UIApplication.shared.open(URL(string: "cakewallet://quickaction/scan")!)
+        return .result()
+    }
+}

--- a/lib/new-ui/pages/send_page.dart
+++ b/lib/new-ui/pages/send_page.dart
@@ -42,6 +42,7 @@ import 'package:cake_wallet/src/widgets/bottom_sheet/payment_confirmation_bottom
 import 'package:cake_wallet/src/widgets/bottom_sheet/swap_confirmation_bottom_sheet.dart';
 import 'package:cake_wallet/src/widgets/bottom_sheet/wallet_switcher_bottom_sheet.dart';
 import 'package:cake_wallet/src/widgets/primary_button.dart';
+import 'package:cake_wallet/entities/qr_scanner.dart';
 import 'package:cake_wallet/utils/payment_request.dart';
 import 'package:cake_wallet/utils/show_pop_up.dart';
 import 'package:cake_wallet/view_model/payment/payment_view_model.dart';
@@ -145,12 +146,14 @@ class SendPageParams {
   final SendPageModes mode;
   final CryptoCurrency? initialCurrency;
   final UnspentCoinType unspentCoinType;
+  final bool autoOpenScanner;
 
   SendPageParams({
     this.initialPaymentRequest,
     SendPageModes? mode,
     this.unspentCoinType = UnspentCoinType.any,
     this.initialCurrency,
+    this.autoOpenScanner = false,
   }) : mode = mode ?? SendPageModes.normal;
 }
 
@@ -164,7 +167,8 @@ class NewSendPage extends StatefulWidget {
       required this.authService,
       required SendPageParams params})
       : initialPaymentRequest = params.initialPaymentRequest,
-        mode = params.mode {
+        mode = params.mode,
+        autoOpenScanner = params.autoOpenScanner {
     if (params.initialCurrency != null) {
       sendViewModel.selectedCryptoCurrency = params.initialCurrency!;
     }
@@ -177,6 +181,7 @@ class NewSendPage extends StatefulWidget {
   final AuthService authService;
   final PaymentRequest? initialPaymentRequest;
   final SendPageModes mode;
+  final bool autoOpenScanner;
 
   @override
   State<NewSendPage> createState() => _NewSendPageState();
@@ -259,6 +264,22 @@ class _NewSendPageState extends State<NewSendPage> {
         });
       }
     });
+
+    if (widget.autoOpenScanner) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _autoScanQR();
+      });
+    }
+  }
+
+  Future<void> _autoScanQR() async {
+    final result = await presentQRScanner(context);
+    if (result != null) {
+      final output = widget.sendViewModel.outputs[_selectedOutput];
+      output.resetParsedAddress();
+      await output.fetchParsedAddress(context);
+      await _handlePaymentFlow(result, PaymentRequest.fromString(result));
+    }
   }
 
   @override

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -437,11 +437,16 @@ Route<dynamic> createRoute(RouteSettings settings) {
       final args = settings.arguments as Map<String, dynamic>?;
       final initialPaymentRequest = args?['paymentRequest'] as PaymentRequest?;
       final coinTypeToSpendFrom = args?['coinTypeToSpendFrom'] as UnspentCoinType?;
+      final autoOpenScanner = args?['autoOpenScanner'] as bool? ?? false;
 
       return handleRouteWithPlatformAwareness(
         (context) => Material(
           child: getIt.get<NewSendPage>(
-            param1: SendPageParams(initialPaymentRequest: initialPaymentRequest,unspentCoinType: coinTypeToSpendFrom ?? UnspentCoinType.any),
+            param1: SendPageParams(
+              initialPaymentRequest: initialPaymentRequest,
+              unspentCoinType: coinTypeToSpendFrom ?? UnspentCoinType.any,
+              autoOpenScanner: autoOpenScanner,
+            ),
           ),
         ),
         settings: settings,

--- a/lib/view_model/link_view_model.dart
+++ b/lib/view_model/link_view_model.dart
@@ -48,6 +48,8 @@ class LinkViewModel {
           return Routes.send;
         case 'receive':
           return Routes.addressPage;
+        case 'scan':
+          return Routes.send;
         default:
           return null;
       }
@@ -81,6 +83,10 @@ class LinkViewModel {
     }
 
     if (isQuickActionLink) {
+      final action = currentLink!.pathSegments.isNotEmpty ? currentLink!.pathSegments.first : null;
+      if (action == 'scan') {
+        return {'autoOpenScanner': true};
+      }
       return null;
     }
 


### PR DESCRIPTION
# Description

Adds support for the iPhone Action Button (iPhone 15 Pro+) to open the QR scanner directly in Cake Wallet. This reduces the steps to scan a payment QR from: unlock → find app → open → tap send → tap scan, down to a single Action Button press.

**⚠️ Note: This PR is untested and should be treated as inspiration/proof-of-concept, not merge-ready code. It has not been manually verified on a real device. Review of logic and integration is welcome before any actual implementation.**

## Changes

- **`ios/Runner/ScanQRIntent.swift`** (new) — `AppIntent` struct that opens the app via `cakewallet://quickaction/scan`
- **`ios/Runner/AppShortcutsProvider.swift`** (new) — Registers the intent as an `AppShortcut`, making it discoverable in Action Button settings, the Shortcuts app, and Spotlight (requires iOS 16.4+)
- **`lib/view_model/link_view_model.dart`** — Adds `scan` case to route and args resolution for the deep link handler
- **`lib/router.dart`** — Passes `autoOpenScanner` arg from deep link into `SendPageParams`
- **`lib/new-ui/pages/send_page.dart`** — Adds `autoOpenScanner` field to `SendPageParams` and `NewSendPage`; triggers a post-frame QR scanner open when set

## Flow

```
Action Button press
  → iOS runs ScanQRIntent.perform()
  → Opens cakewallet://quickaction/scan
  → uni_links delivers URI → auth check (PIN/biometric)
  → LinkViewModel routes to Send page with {autoOpenScanner: true}
  → Post-frame callback opens QR scanner
  → Scanned result populates address/amount fields
```

## Known gaps / TODOs for a real implementation

- The two Swift files need to be added to the Runner Xcode target manually
- `_autoScanQR` currently uses a stub — the scanned URI handling needs to be wired to the same logic as `NewSendAddressInput.onURIScanned`
- Needs testing on a physical device (iOS 16.4+) for Action Button assignment
- Cold-start and background-resume scenarios untested
- Existing quick actions (send/receive from Home Screen) should be regression-tested

# Pull Request - Checklist

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed