### PR TITLE
fix: prevent off by one error in ensureMwebAddressUpToIndexExists

### DIFF
--- a/cw_bitcoin/lib/litecoin_wallet_addresses.dart
+++ b/cw_bitcoin/lib/litecoin_wallet_addresses.dart
@@ -73,7 +73,8 @@ abstract class LitecoinWalletAddressesBase extends ElectrumWalletAddresses with 
     return List.from(super.allAddresses)..addAll(mwebAddresses);
   }
 
-  Future<void> ensureMwebAddressUpToIndexExists(int index) async {
+  Future<void> ensureMwebAddressUpToIndexExists(int _index) async {
+    final index = _index + 1;
     if (Platform.isLinux || Platform.isMacOS || Platform.isWindows) {
       return null;
     }


### PR DESCRIPTION
# Description

prevents getAddress to fail (`return hd == sideHd ? mwebAddrs[0] : mwebAddrs[index + 1];`) if we generate more addresses.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
