### PR TITLE
Fix support for sats amount input on send screen

### DIFF
--- a/lib/core/amount_validator.dart
+++ b/lib/core/amount_validator.dart
@@ -11,10 +11,14 @@ class AmountValidator extends TextValidator {
     bool isAutovalidate = false,
     String? minValue,
     String? maxValue,
+    this.useSatoshi = false,
   }) {
     symbolsAmountValidator =
         SymbolsAmountValidator(isAutovalidate: isAutovalidate);
-    decimalAmountValidator = DecimalAmountValidator(currency: currency,isAutovalidate: isAutovalidate);
+    decimalAmountValidator = DecimalAmountValidator(
+        currency: currency,
+        isAutovalidate: isAutovalidate,
+        useSatoshi: useSatoshi);
 
     amountMinValidator = AmountMinValidator(
       minValue: minValue,
@@ -38,6 +42,8 @@ class AmountValidator extends TextValidator {
   late final SymbolsAmountValidator symbolsAmountValidator;
 
   late final DecimalAmountValidator decimalAmountValidator;
+
+  final bool useSatoshi;
 
   String? call(String? value) {
     if (value == null || value.isEmpty) {
@@ -69,17 +75,27 @@ class SymbolsAmountValidator extends TextValidator {
 }
 
 class DecimalAmountValidator extends TextValidator {
-  DecimalAmountValidator({required Currency currency, required bool isAutovalidate})
+  DecimalAmountValidator(
+      {required Currency currency,
+      required bool isAutovalidate,
+      this.useSatoshi = false})
       : super(
           errorMessage: S.current.decimal_places_error,
-          pattern: _pattern(currency),
+          pattern: _pattern(currency, useSatoshi),
           isAutovalidate: isAutovalidate,
           minLength: 0,
           maxLength: 0,
         );
 
-  static String _pattern(Currency currency) =>
-      '^([0-9]+([.\,][0-9]{1,${currency.decimals}})?|[.\,][0-9]{1,${currency.decimals}})\$';
+  final bool useSatoshi;
+
+  static String _pattern(Currency currency, bool useSatoshi) {
+    if (useSatoshi) {
+      return r'^\d+$';
+    }
+    final decimals = currency.decimals;
+    return '^([0-9]+([.\,][0-9]{1,$decimals})?|[.\,][0-9]{1,$decimals})\$';
+  }
 }
 
 class AllAmountValidator extends TextValidator {

--- a/lib/new-ui/pages/send_page.dart
+++ b/lib/new-ui/pages/send_page.dart
@@ -449,9 +449,12 @@ class _NewSendPageState extends State<NewSendPage> {
                                         onSwitchButtonPressed: () {
                                           setState(() {
                                             if(!_fiatInputMode) {
+                                              final canonicalAmount = widget.sendViewModel.amountParsingProxy
+                                                  .getCanonicalCryptoAmount(
+                                                      _amountControllers[_selectedOutput].text.replaceAll(",", "."),
+                                                      widget.sendViewModel.selectedCryptoCurrency);
                                               widget.sendViewModel.outputs[_selectedOutput]
-                                                      .cryptoAmount =
-                                                  _amountControllers[_selectedOutput].text;
+                                                      .setCryptoAmount(canonicalAmount);
                                             }
                                             _fiatInputMode = !_fiatInputMode;
                                             _amountControllers[_selectedOutput].text =

--- a/lib/view_model/send/send_view_model.dart
+++ b/lib/view_model/send/send_view_model.dart
@@ -275,6 +275,7 @@ abstract class SendViewModelBase extends WalletChangeListenerViewModel with Stor
   Validator<String> amountValidator(Output output) => AmountValidator(
         currency: wallet.currency,
         amountParsingProxy: _appStore.amountParsingProxy,
+        useSatoshi: output.useSatoshi,
         minValue: isSendToSilentPayments(output)
             ?
             //  TODO: get from server


### PR DESCRIPTION
A small bug I found in a QA pass was that satoshis don't seem to be properly supported in the send page modal

Issue Number (if Applicable): Fixes #

# Description

Please include a summary of the changes and which issue is fixed / feature is added. 

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
