### PR TITLE
properly pass hardwareWalletType for all credentials

### DIFF
--- a/cw_bitcoin/lib/bitcoin_wallet_creation_credentials.dart
+++ b/cw_bitcoin/lib/bitcoin_wallet_creation_credentials.dart
@@ -78,6 +78,7 @@ class LitecoinWalletFromKeysCredentials extends WalletCredentials {
     required this.scanSecret,
     required this.spendPubkey,
     WalletInfo? walletInfo,
+    super.hardwareWalletType
   }) : super(name: name, password: password, walletInfo: walletInfo);
 
   final String xpub;

--- a/cw_monero/lib/monero_wallet_service.dart
+++ b/cw_monero/lib/monero_wallet_service.dart
@@ -79,6 +79,7 @@ class MoneroRestoreWalletFromKeysCredentials extends WalletCredentials {
       required this.address,
       required this.viewKey,
       required this.spendKey,
+      super.hardwareWalletType,
       int height = 0})
       : super(name: name, password: password, height: height);
 

--- a/lib/bitcoin/cw_bitcoin.dart
+++ b/lib/bitcoin/cw_bitcoin.dart
@@ -35,6 +35,7 @@ class CWBitcoin extends Bitcoin {
     required String xpub,
     required String scanSecret,
     required String spendPubkey,
+    HardwareWalletType? hardwareWalletType,
   }) =>
       LitecoinWalletFromKeysCredentials(
         name: name,
@@ -42,6 +43,7 @@ class CWBitcoin extends Bitcoin {
         xpub: xpub,
         scanSecret: scanSecret,
         spendPubkey: spendPubkey,
+        hardwareWalletType: hardwareWalletType,
       );
 
   @override

--- a/lib/monero/cw_monero.dart
+++ b/lib/monero/cw_monero.dart
@@ -219,6 +219,7 @@ class CWMonero extends Monero {
           required String address,
           required String password,
           required String language,
+          HardwareWalletType? hardwareWalletType,
           required int height}) =>
       MoneroRestoreWalletFromKeysCredentials(
           name: name,
@@ -227,6 +228,7 @@ class CWMonero extends Monero {
           address: address,
           password: password,
           language: language,
+          hardwareWalletType: hardwareWalletType,
           height: height);
 
   @override

--- a/lib/view_model/wallet_restore_view_model.dart
+++ b/lib/view_model/wallet_restore_view_model.dart
@@ -250,6 +250,7 @@ abstract class WalletRestoreViewModelBase extends WalletCreationVM with Store {
             xpub: viewKey!,
             scanSecret: scanSecret!,
             spendPubkey: spendPubkey!,
+            hardwareWalletType: hardwareWalletType,
           );
 
         case WalletType.monero:
@@ -261,6 +262,7 @@ abstract class WalletRestoreViewModelBase extends WalletCreationVM with Store {
             address: address!,
             password: password,
             language: 'English',
+            hardwareWalletType: hardwareWalletType
           );
 
         case WalletType.nano:

--- a/tool/configure.dart
+++ b/tool/configure.dart
@@ -191,7 +191,7 @@ abstract class Bitcoin {
   });
   WalletCredentials createBitcoinRestoreWalletFromWIFCredentials({required String name, required String password, required String wif, WalletInfo? walletInfo});
   WalletCredentials createBitcoinWalletFromKeys({required String name, required String password, required String xpub, HardwareWalletType? hardwareWalletType});
-  WalletCredentials createLitecoinWalletFromKeys({required String name, required String password, required String xpub, required String scanSecret, required String spendPubkey});
+  WalletCredentials createLitecoinWalletFromKeys({required String name, required String password, required String xpub, required String scanSecret, required String spendPubkey, HardwareWalletType? hardwareWalletType});
   WalletCredentials createBitcoinNewWalletCredentials({required String name, WalletInfo? walletInfo, String? password, String? passphrase, String? mnemonic});
   WalletCredentials createBitcoinHardwareWalletCredentials({required String name, required HardwareAccountData accountData, WalletInfo? walletInfo});
   List<String> getWordList();
@@ -456,6 +456,7 @@ abstract class Monero {
     required String address,
     required String password,
     required String language,
+    HardwareWalletType? hardwareWalletType,
     required int height});
   WalletCredentials createMoneroRestoreWalletFromSeedCredentials({required String name, required String password, required String passphrase, required int height, required String mnemonic});
   WalletCredentials createMoneroRestoreWalletFromHardwareCredentials({required String name, required String password, required int height, required ledger.LedgerConnection ledgerConnection});


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Fixes issues with hardware wallet info (namely Cupcake) not being saved on restoration.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
