### PR TITLE
add missing mutex in monero

### DIFF
--- a/cw_monero/lib/api/subaddress_list.dart
+++ b/cw_monero/lib/api/subaddress_list.dart
@@ -65,7 +65,8 @@ int lastWptr = 0;
 int lastTxCount = 0;
 List<TinyTransactionDetails> ttDetails = [];
 
-List<Subaddress> getAllSubaddresses() {
+Future<List<Subaddress>> getAllSubaddresses() async {
+  await txHistoryMutex.acquire();
   txhistory = currentWallet!.history();
   final txCount = txhistory!.count();
   if (lastTxCount != txCount && lastWptr != currentWallet!.ffiAddress()) {
@@ -85,6 +86,7 @@ List<Subaddress> getAllSubaddresses() {
     ttDetails.clear();
     ttDetails.addAll(newttDetails);
   }
+  txHistoryMutex.release();
   final size = currentWallet!.numSubaddresses(accountIndex: subaddress!.accountIndex);
   final list = List.generate(size, (index) {
     final ttDetailsLocal = ttDetails.where((element) {

--- a/cw_monero/lib/api/subaddress_list.dart
+++ b/cw_monero/lib/api/subaddress_list.dart
@@ -66,27 +66,33 @@ int lastTxCount = 0;
 List<TinyTransactionDetails> ttDetails = [];
 
 Future<List<Subaddress>> getAllSubaddresses() async {
-  await txHistoryMutex.acquire();
-  txhistory = currentWallet!.history();
-  final txCount = txhistory!.count();
-  if (lastTxCount != txCount && lastWptr != currentWallet!.ffiAddress()) {
-    final List<TinyTransactionDetails> newttDetails = [];
-    lastTxCount = txCount;
-    lastWptr = currentWallet!.ffiAddress();
-    for (var i = 0; i < txCount; i++) {
-      final tx = txhistory!.transaction(i);
-      if (tx.direction() == TransactionInfo_Direction.Out.index) continue;
-      final subaddrs = tx.subaddrIndex().split(",");
-      final account = tx.subaddrAccount();
-      newttDetails.add(TinyTransactionDetails(
-        address: List.generate(subaddrs.length, (index) => getAddress(accountIndex: account, addressIndex: int.tryParse(subaddrs[index])??0)),
-        amount: tx.amount(),
-      ));
+  try {
+    await txHistoryMutex.acquire();
+    txhistory = currentWallet!.history();
+    final txCount = txhistory!.count();
+    if (lastTxCount != txCount && lastWptr != currentWallet!.ffiAddress()) {
+      final List<TinyTransactionDetails> newttDetails = [];
+      lastTxCount = txCount;
+      lastWptr = currentWallet!.ffiAddress();
+      for (var i = 0; i < txCount; i++) {
+        final tx = txhistory!.transaction(i);
+        if (tx.direction() == TransactionInfo_Direction.Out.index) continue;
+        final subaddrs = tx.subaddrIndex().split(",");
+        final account = tx.subaddrAccount();
+        newttDetails.add(TinyTransactionDetails(
+          address: List.generate(
+              subaddrs.length,
+              (index) => getAddress(
+                  accountIndex: account, addressIndex: int.tryParse(subaddrs[index]) ?? 0)),
+          amount: tx.amount(),
+        ));
+      }
+      ttDetails.clear();
+      ttDetails.addAll(newttDetails);
     }
-    ttDetails.clear();
-    ttDetails.addAll(newttDetails);
+  } finally {
+    txHistoryMutex.release();
   }
-  txHistoryMutex.release();
   final size = currentWallet!.numSubaddresses(accountIndex: subaddress!.accountIndex);
   final list = List.generate(size, (index) {
     final ttDetailsLocal = ttDetails.where((element) {

--- a/cw_monero/lib/monero_subaddress_list.dart
+++ b/cw_monero/lib/monero_subaddress_list.dart
@@ -2,7 +2,7 @@ import 'package:cw_core/subaddress.dart';
 import 'package:cw_core/utils/print_verbose.dart';
 import 'package:cw_monero/api/coins_info.dart';
 import 'package:cw_monero/api/subaddress_list.dart' as subaddress_list;
-import 'package:cw_monero/api/wallet.dart';
+
 import 'package:flutter/services.dart';
 import 'package:mobx/mobx.dart';
 
@@ -24,7 +24,7 @@ abstract class MoneroSubaddressListBase with Store {
   bool _isRefreshing;
   bool _isUpdating;
 
-  void update({required int accountIndex}) {
+  Future<void> update({required int accountIndex}) async {
     refreshCoins(accountIndex);
 
     if (_isUpdating) {
@@ -35,7 +35,7 @@ abstract class MoneroSubaddressListBase with Store {
       _isUpdating = true;
       refresh(accountIndex: accountIndex);
       subaddresses.clear();
-      subaddresses.addAll(getAll());
+      subaddresses.addAll(await getAll());
       _isUpdating = false;
     } catch (e) {
       _isUpdating = false;
@@ -43,8 +43,8 @@ abstract class MoneroSubaddressListBase with Store {
     }
   }
 
-  List<Subaddress> getAll() {
-    var subaddresses = subaddress_list.getAllSubaddresses();
+  Future<List<Subaddress>> getAll() async {
+    var subaddresses = await  subaddress_list.getAllSubaddresses();
 
     if (subaddresses.length > 2) {
       final primary = subaddresses.first;
@@ -122,7 +122,7 @@ abstract class MoneroSubaddressListBase with Store {
 
   Future<List<Subaddress>> _getAllUnusedAddresses(
       {required int accountIndex, required String label}) async {
-    final allAddresses = subaddress_list.getAllSubaddresses();
+    final allAddresses = await subaddress_list.getAllSubaddresses();
     // first because addresses come in reversed order.
     if (allAddresses.isEmpty || _usedAddresses.contains(allAddresses.first.address)) {
       final isAddressUnused = await _newSubaddress(accountIndex: accountIndex, label: label);
@@ -151,12 +151,9 @@ abstract class MoneroSubaddressListBase with Store {
   Future<bool> _newSubaddress({required int accountIndex, required String label}) async {
     await subaddress_list.addSubaddress(accountIndex: accountIndex, label: label);
 
-    return subaddress_list
-        .getAllSubaddresses()
-        .where((s) {
-          final address = s.address;
-          return !_usedAddresses.contains(address);
-        })
-        .isNotEmpty;
+    return (await subaddress_list.getAllSubaddresses()).where((s) {
+      final address = s.address;
+      return !_usedAddresses.contains(address);
+    }).isNotEmpty;
   }
 }

--- a/lib/monero/cw_monero.dart
+++ b/lib/monero/cw_monero.dart
@@ -89,10 +89,10 @@ class CWMoneroSubaddressList extends MoneroSubaddressList {
   }
 
   @override
-  List<Subaddress> getAll(Object wallet) {
+  Future<List<Subaddress>> getAll(Object wallet) async {
     final moneroWallet = wallet as MoneroWallet;
-    return moneroWallet.walletAddresses.subaddressList
-        .getAll()
+    return (await moneroWallet.walletAddresses.subaddressList
+        .getAll())
         .map((sub) => Subaddress(
           id: sub.id,
           label: sub.label,

--- a/lib/view_model/dashboard/dashboard_view_model.dart
+++ b/lib/view_model/dashboard/dashboard_view_model.dart
@@ -772,7 +772,7 @@ abstract class DashboardViewModelBase with Store {
       // if (wallet.seed == "") "wallet seed is empty",
       // if (monero!.getSubaddressList(wallet).getAll(wallet)[0].address ==
       //     "41d7FXjswpK1111111111111111111111111111111111111111111111111111111111111111111111111111112KhNi4")
-        "primary address is invalid, you won't be able to receive / spend funds",
+        // "primary address is invalid, you won't be able to receive / spend funds",
     ];
     return errors;
   }

--- a/lib/view_model/dashboard/dashboard_view_model.dart
+++ b/lib/view_model/dashboard/dashboard_view_model.dart
@@ -770,8 +770,8 @@ abstract class DashboardViewModelBase with Store {
         "public view key is 0",
       // if (wallet.seed == null) "wallet seed is null",
       // if (wallet.seed == "") "wallet seed is empty",
-      if (monero!.getSubaddressList(wallet).getAll(wallet)[0].address ==
-          "41d7FXjswpK1111111111111111111111111111111111111111111111111111111111111111111111111111112KhNi4")
+      // if (monero!.getSubaddressList(wallet).getAll(wallet)[0].address ==
+      //     "41d7FXjswpK1111111111111111111111111111111111111111111111111111111111111111111111111111112KhNi4")
         "primary address is invalid, you won't be able to receive / spend funds",
     ];
     return errors;

--- a/tool/configure.dart
+++ b/tool/configure.dart
@@ -492,7 +492,7 @@ abstract class MoneroSubaddressList {
   ObservableList<Subaddress> get subaddresses;
   void update(Object wallet, {required int accountIndex});
   void refresh(Object wallet, {required int accountIndex});
-  List<Subaddress> getAll(Object wallet);
+  Future<List<Subaddress>> getAll(Object wallet);
   Future<void> addSubaddress(Object wallet, {required int accountIndex, required String label});
   Future<void> setLabelSubaddress(Object wallet,
       {required int accountIndex, required int addressIndex, required String label});


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Add a missing mutex in getAllSubaddresses which may occasionally cause a segfault when retrieving transaction info.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
