### PR TITLE
fix: Windows file save dialog appearing behind app window

### DIFF
--- a/lib/src/screens/backup/backup_page.dart
+++ b/lib/src/screens/backup/backup_page.dart
@@ -172,10 +172,15 @@ class BackupPage extends BasePage {
 
   Future<void> _saveFile(BackupExportFile backup) async {
     String? outputFile = await FilePicker.platform
-        .saveFile(dialogTitle: 'Save Your File to desired location', fileName: backup.name);
+        .saveFile(
+            dialogTitle: 'Save Your File to desired location',
+            fileName: backup.name,
+            lockParentWindow: true);
+
+    if (outputFile == null) return;
 
     try {
-      await backup.file.copy(outputFile!);
+      await backup.file.copy(outputFile);
     } catch (exception, stackTrace) {
       await ExceptionHandler.onError(FlutterErrorDetails(
         exception: exception,

--- a/lib/src/screens/seed/wallet_seed_page.dart
+++ b/lib/src/screens/seed/wallet_seed_page.dart
@@ -158,6 +158,7 @@ class WalletSeedPage extends BasePage {
         final path = await FilePicker.platform.saveFile(
           dialogTitle: "Save seed as",
           fileName: "${walletSeedViewModel.name}-seed.txt",
+          lockParentWindow: true,
         );
         if(path != null) {
           final file = File(path);

--- a/lib/src/screens/settings/mweb_logs_page.dart
+++ b/lib/src/screens/settings/mweb_logs_page.dart
@@ -104,12 +104,17 @@ class MwebLogsPage extends BasePage {
 
   Future<void> _saveFile() async {
     String? outputFile = await FilePicker.platform
-        .saveFile(dialogTitle: 'Save Your File to desired location', fileName: "debug.log");
+        .saveFile(
+            dialogTitle: 'Save Your File to desired location',
+            fileName: "debug.log",
+            lockParentWindow: true);
+
+    if (outputFile == null) return;
 
     try {
       final filePath = (await getApplicationSupportDirectory()).path + "/debug.log";
       File debugLogFile = File(filePath);
-      await debugLogFile.copy(outputFile!);
+      await debugLogFile.copy(outputFile);
     } catch (exception, stackTrace) {
       ExceptionHandler.onError(FlutterErrorDetails(
         exception: exception,

--- a/lib/src/screens/settings/silent_payments_logs_page.dart
+++ b/lib/src/screens/settings/silent_payments_logs_page.dart
@@ -106,12 +106,17 @@ class SilentPaymentsLogPage extends BasePage {
 
   Future<void> _saveFile() async {
     String? outputFile = await FilePicker.platform
-        .saveFile(dialogTitle: 'Save Your File to desired location', fileName: "debug.log");
+        .saveFile(
+            dialogTitle: 'Save Your File to desired location',
+            fileName: "debug.log",
+            lockParentWindow: true);
+
+    if (outputFile == null) return;
 
     try {
       final filePath = (await getApplicationSupportDirectory()).path + "/debug.log";
       File debugLogFile = File(filePath);
-      await debugLogFile.copy(outputFile!);
+      await debugLogFile.copy(outputFile);
     } catch (exception, stackTrace) {
       ExceptionHandler.onError(FlutterErrorDetails(
         exception: exception,


### PR DESCRIPTION
## Summary

Fixes #3107  Backup export on Windows does not prompt for save location.

## Root Cause

The Win32 save file dialog was opening **behind** the Flutter window, making it invisible to users. This happened because `FilePicker.platform.saveFile()` defaults `lockParentWindow` to `false`, so when the dialog is spawned in a separate Dart isolate, it has no parent window handle and appears behind the app.

## Changes

- Added `lockParentWindow: true` to all `FilePicker.platform.saveFile()` calls, which sets the Flutter window as the dialog's owner so it appears in front of the application
- Replaced force-unwrap (`outputFile!`) with a null check + early return, so user cancellation is handled gracefully instead of throwing an unhandled exception

### Files changed

- `lib/src/screens/backup/backup_page.dart`  primary fix (backup export)
- `lib/src/screens/settings/mweb_logs_page.dart`  same latent bug
- `lib/src/screens/settings/silent_payments_logs_page.dart`  same latent bug
- `lib/src/screens/seed/wallet_seed_page.dart`  same latent bug (already had null check, just needed `lockParentWindow`)

## Testing

1. Build on Windows  Create Backup  Export Backup  save dialog now appears in front of the app
2. Cancel the dialog  no crash, returns gracefully
3. Complete the save  file is written to chosen location