### PR TITLE
Add copy-to-clipboard for transaction amounts and fix typo

### DIFF
--- a/lib/new-ui/widgets/coins_page/assets_history/transaction_details_modal.dart
+++ b/lib/new-ui/widgets/coins_page/assets_history/transaction_details_modal.dart
@@ -40,6 +40,8 @@ class _TransactionDetailsModalState extends State<TransactionDetailsModal> {
 
   @override
   Widget build(BuildContext context) {
+    final transactionInfoAmount = widget.transactionDetailsViewModel.transactionInfo.amount;
+
     return DraggableScrollableSheet(
         expand: false,
         initialChildSize: 0.9,
@@ -80,10 +82,14 @@ class _TransactionDetailsModalState extends State<TransactionDetailsModal> {
                                       widget.transactionDetailsViewModel.formattedStatus,
                                   style: TextStyle(fontSize: 20, fontWeight: FontWeight.w500),
                                 ),
-                                Text(
-                                  widget.transactionDetailsViewModel.transactionInfo.amount
-                                      .toStringWithSymbol(),
-                                  style: TextStyle(fontSize: 28),
+                                GestureDetector(
+                                  onLongPress: () => Clipboard.setData(ClipboardData(
+                                    text: transactionInfoAmount.toString(),
+                                  )),
+                                  child: Text(
+                                    transactionInfoAmount.toStringWithSymbol(),
+                                    style: TextStyle(fontSize: 28),
+                                  ),
                                 ),
                                 Padding(
                                   padding: const EdgeInsets.all(16.0),
@@ -107,7 +113,7 @@ class _TransactionDetailsModalState extends State<TransactionDetailsModal> {
                                                   label: item.title,
                                                   trailingWidget: shouldBuildBottomWidget
                                                       ? null
-                                                      : _buildTrailingWIdget(item),
+                                                      : _buildTrailingWidget(item),
                                                   bottomWidget: shouldBuildBottomWidget
                                                       ? _buildBottomWidget(item)
                                                       : null);
@@ -188,7 +194,7 @@ class _TransactionDetailsModalState extends State<TransactionDetailsModal> {
             ));
   }
 
-  Widget _buildTrailingWIdget(TransactionDetailsListItem item) {
+  Widget _buildTrailingWidget(TransactionDetailsListItem item) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4.0),
       child: switch (item.runtimeType) {


### PR DESCRIPTION
# Description

Added a feature to copy transaction amounts to the clipboard for better user convenience. Also fixed a typo in the trailing widget method name for better code clarity.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 