### PR TITLE
disable editing coin control from settings [cw-1431]

### DIFF
--- a/lib/di.dart
+++ b/lib/di.dart
@@ -1567,10 +1567,10 @@ Future<void> setup({
           unspentCoinsListViewModel:
               getIt.get<UnspentCoinsListViewModel>(param1: coinTypeToSpendFrom)));
 
-  getIt.registerFactoryParam<NewCoinControlPage, UnspentCoinType?, void>(
-          (coinTypeToSpendFrom, _) => NewCoinControlPage(
+  getIt.registerFactoryParam<NewCoinControlPage, UnspentCoinType?, bool?>(
+          (coinTypeToSpendFrom, canEdit) => NewCoinControlPage(
           unspentCoinsListViewModel:
-          getIt.get<UnspentCoinsListViewModel>(param1: coinTypeToSpendFrom))
+          getIt.get<UnspentCoinsListViewModel>(param1: coinTypeToSpendFrom), canEdit: canEdit ?? true,)
 
   );
 

--- a/lib/new-ui/pages/coin_control_page.dart
+++ b/lib/new-ui/pages/coin_control_page.dart
@@ -4,15 +4,25 @@ import 'package:cake_wallet/new-ui/widgets/modal_header.dart';
 import 'package:cake_wallet/new-ui/widgets/receive_page/receive_top_bar.dart';
 import 'package:cake_wallet/routes.dart';
 import 'package:cake_wallet/view_model/unspent_coins/unspent_coins_list_view_model.dart';
+import 'package:cw_core/unspent_coin_type.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import "package:cake_wallet/view_model/unspent_coins/unspent_coins_item.dart";
 
+class CoinControlPageArgs {
+  final bool canEdit;
+  final UnspentCoinType? coinTypeToSpendFrom;
+
+  const CoinControlPageArgs({required this.canEdit, this.coinTypeToSpendFrom});
+}
+
 class NewCoinControlPage extends StatefulWidget {
-  const NewCoinControlPage({super.key, required this.unspentCoinsListViewModel});
+  const NewCoinControlPage(
+      {super.key, required this.unspentCoinsListViewModel, required this.canEdit});
 
   final UnspentCoinsListViewModel unspentCoinsListViewModel;
+  final bool canEdit;
 
   @override
   State<NewCoinControlPage> createState() => _NewCoinControlPageState();
@@ -31,9 +41,9 @@ class _NewCoinControlPageState extends State<NewCoinControlPage> {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: !widget.unspentCoinsListViewModel.isSavingItems,
-      onPopInvokedWithResult: (didPop, result) async{
+      onPopInvokedWithResult: (didPop, result) async {
         await widget.unspentCoinsListViewModel.dispose();
-        if(!didPop && mounted) Navigator.of(context).pop();
+        if (!didPop && mounted) Navigator.of(context).pop();
       },
       child: Material(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
@@ -94,9 +104,9 @@ class _NewCoinControlPageState extends State<NewCoinControlPage> {
                                 child: ModalHeader(
                                     iconPath: "assets/new-ui/settings_row_icons/coin-control.svg",
                                     title: "Coin Control",
-                                    message: S.of(context).coin_control_desc),
+                                    message: widget.canEdit ? S.of(context).coin_control_desc : S.of(context).coin_control_desc_no_edit),
                               ),
-                              if (widget.unspentCoinsListViewModel.items.isNotEmpty)
+                              if (widget.unspentCoinsListViewModel.items.isNotEmpty && widget.canEdit)
                                 Padding(
                                   padding: const EdgeInsets.all(12.0),
                                   child: Row(
@@ -124,7 +134,7 @@ class _NewCoinControlPageState extends State<NewCoinControlPage> {
                                       )
                                     ],
                                   ),
-                                ),
+                                ) else SizedBox(height: 24,),
                               if (widget.unspentCoinsListViewModel.nonFrozenItems.isEmpty &&
                                   widget.unspentCoinsListViewModel.frozenItems.isEmpty) ...[
                                 SizedBox(height: 12),
@@ -144,6 +154,7 @@ class _NewCoinControlPageState extends State<NewCoinControlPage> {
                                     : Padding(
                                         padding: const EdgeInsets.symmetric(horizontal: 18.0),
                                         child: CoinControlListSection(
+                                          canEdit: widget.canEdit,
                                             items: widget.unspentCoinsListViewModel.nonFrozenItems,
                                             unspentCoinsListViewModel:
                                                 widget.unspentCoinsListViewModel),
@@ -170,6 +181,7 @@ class _NewCoinControlPageState extends State<NewCoinControlPage> {
                                                             .onSurfaceVariant),
                                                   ),
                                                   CoinControlListSection(
+                                                    canEdit: widget.canEdit,
                                                       items: widget
                                                           .unspentCoinsListViewModel.frozenItems,
                                                       unspentCoinsListViewModel:
@@ -194,9 +206,10 @@ class _NewCoinControlPageState extends State<NewCoinControlPage> {
 
 class CoinControlListSection extends StatelessWidget {
   const CoinControlListSection(
-      {super.key, required this.items, required this.unspentCoinsListViewModel});
+      {super.key, required this.items, required this.unspentCoinsListViewModel, required this.canEdit});
 
   final List<UnspentCoinsItem> items;
+  final bool canEdit;
   final UnspentCoinsListViewModel unspentCoinsListViewModel;
 
   @override
@@ -231,6 +244,7 @@ class CoinControlListSection extends StatelessWidget {
               isLoading: item.isBeingSaved,
               isFirst: index == 0,
               isLast: index == items.length - 1,
+              hasCheckbox: canEdit,
               onCheckBoxTap: item.isFrozen
                   ? null
                   : () async {

--- a/lib/new-ui/pages/send_page.dart
+++ b/lib/new-ui/pages/send_page.dart
@@ -516,7 +516,7 @@ class _NewSendPageState extends State<NewSendPage> {
                                             label: "Coin Control",
                                             onTap: () {
                                               showCupertinoModalBottomSheet(enableDrag: false, useRootNavigator: true, isDismissible: false, context: context, builder: (context){
-                                                  return NewCoinControlPage(unspentCoinsListViewModel: widget.sendViewModel.unspentCoinsListViewModel,);
+                                                  return NewCoinControlPage(unspentCoinsListViewModel: widget.sendViewModel.unspentCoinsListViewModel,canEdit: true);
                                               });
                                             }
                                           ),

--- a/lib/new-ui/widgets/coin_control_page/coin_control_list_item.dart
+++ b/lib/new-ui/widgets/coin_control_page/coin_control_list_item.dart
@@ -17,7 +17,7 @@ class CoinControlListItem extends StatelessWidget {
     required this.isFirst, 
     required this.isLast,
     required this.isLoading,
-    this.onCheckBoxTap,
+    this.onCheckBoxTap, required this.hasCheckbox,
   });
 
   final String note;
@@ -31,6 +31,7 @@ class CoinControlListItem extends StatelessWidget {
   final bool isFirst;
   final bool isLast;
   final bool isLoading;
+  final bool hasCheckbox;
   final Function()? onCheckBoxTap;
 
   @override
@@ -121,6 +122,10 @@ class CoinControlListItem extends StatelessWidget {
 
     if(isFrozen) {
       return CakeImageWidget(imageUrl:"assets/new-ui/frozen.svg");
+    }
+
+    if(!hasCheckbox) {
+      return SizedBox.shrink();
     }
 
     return NewSimpleCheckbox(value: isSending, onChanged: (value){onCheckBoxTap?.call();});

--- a/lib/new-ui/widgets/swap_page/swap_options_page.dart
+++ b/lib/new-ui/widgets/swap_page/swap_options_page.dart
@@ -102,7 +102,7 @@ class SwapOptionsPage extends StatelessWidget {
                             label: "Coin Control",
                             onTap: () {
                               showCupertinoModalBottomSheet(enableDrag: false, useRootNavigator: true, isDismissible: false, context: context, builder: (context){
-                                return NewCoinControlPage(unspentCoinsListViewModel: exchangeViewModel.unspentCoinsListViewModel,);
+                                return NewCoinControlPage(unspentCoinsListViewModel: exchangeViewModel.unspentCoinsListViewModel,canEdit: true,);
                               });
                             }),
                         ListItemSelector(

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -759,12 +759,9 @@ Route<dynamic> createRoute(RouteSettings settings) {
       );
 
     case Routes.unspentCoinsList:
-      final coinTypeToSpendFrom = settings.arguments as UnspentCoinType?;
-      return handleRouteWithPlatformAwareness(
-        (context) => FeatureFlag.hasNewUi
-            ? getIt.get<NewCoinControlPage>(param1: coinTypeToSpendFrom)
-            : getIt.get<UnspentCoinsListPage>(param1: coinTypeToSpendFrom),
-      );
+      final args = settings.arguments as CoinControlPageArgs?;
+      return handleRouteWithPlatformAwareness((context) =>
+          getIt.get<NewCoinControlPage>(param1: args?.coinTypeToSpendFrom, param2: args?.canEdit));
 
     case Routes.unspentCoinsDetails:
       final args = settings.arguments as List;

--- a/lib/src/screens/settings/privacy_page.dart
+++ b/lib/src/screens/settings/privacy_page.dart
@@ -1,6 +1,7 @@
 import 'package:cake_wallet/entities/new_ui_entities/list_item/list_item_regular_row.dart';
 import 'package:cake_wallet/entities/new_ui_entities/list_item/list_item_toggle.dart';
 import 'package:cake_wallet/generated/i18n.dart';
+import 'package:cake_wallet/new-ui/pages/coin_control_page.dart';
 import 'package:cake_wallet/new-ui/widgets/modal_header.dart';
 import 'package:cake_wallet/new-ui/widgets/modal_page_wrapper.dart';
 import 'package:cake_wallet/new-ui/widgets/receive_page/receive_top_bar.dart';
@@ -95,7 +96,7 @@ class PrivacyPage extends BasePage {
                           keyValue: "coin_control",
                           label: "Coin Control",
                           onTap: () =>
-                              Navigator.of(context).pushNamed(Routes.unspentCoinsList)),
+                              Navigator.of(context).pushNamed(Routes.unspentCoinsList, arguments: CoinControlPageArgs(canEdit: false, coinTypeToSpendFrom: null))),
                   ],
                 }
                 ),

--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -208,6 +208,7 @@
   "close": "Close",
   "coin_control": "Coin Control (optional)",
   "coin_control_desc": "Filter outputs for this transaction. The changes you make here will only reflect on the current transaction.",
+  "coin_control_desc_no_edit": "Freeze outputs if needed. The changes will be persistent across all transactions. You can also filter outputs for one transaction on the Send or Swap screens.",
   "coin_control_load_failed": "Failed to load unspent coins",
   "cold_or_recover_wallet": "Add an air-gapped cold wallet or recover a paper wallet.",
   "collection_address": "Collection Address",


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Editing Coin Control from Settings is inherently broken as the changes are reset once the Send or Swap screens are opened. This disables editing outputs while keeping the page accessible from Settings for display and freezing purposes.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
