### PR TITLE
fix: always update key images

### DIFF
--- a/cw_monero/lib/monero_wallet.dart
+++ b/cw_monero/lib/monero_wallet.dart
@@ -435,9 +435,7 @@ abstract class MoneroWalletBase extends WalletBase<MoneroBalance,
       throw MoneroTransactionCreationException('The wallet is not synced.');
     }
 
-    if (unspentCoins.isEmpty) {
-      await updateUnspent();
-    }
+    await updateUnspent();
 
     for (final utx in unspentCoins) {
       if (utx.isSending) {

--- a/scripts/prepare_moneroc.sh
+++ b/scripts/prepare_moneroc.sh
@@ -16,7 +16,7 @@ fi
 # NOTE: Make sure to update monero_c prebuilds link in workflow files
 # https://github.com/MrCyjaneK/monero_c/releases/download/v0.18.4.6-RC2/release-bundle.zip
 git fetch -a
-git checkout 0b324fe33ff5709feb69e2892767c1be9349957d
+git checkout 5952bef2ec01b0b7e57c11613cbdc081dcd727c5
 git reset --hard
 git submodule update --init --force --recursive
 


### PR DESCRIPTION
This prevents `0100000000000000000000000000000000000000000000000000000000000000` from showing up and throwing during tx creation Also bump the monero_c to fix ubuntu26.04 build issue on arm64

Issue Number (if Applicable): Fixes #

# Description

Please include a summary of the changes and which issue is fixed / feature is added. 

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
