### PR TITLE
fix: update single coin route to use HardwareWalletViewModel

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -363,7 +363,7 @@ Route<dynamic> createRoute(RouteSettings settings) {
                   arguments: [availableWalletTypes.first, hardwareWalletType]),
               isReconnect: false,
             ),
-            getIt.get<LedgerViewModel>(),
+            getIt.get<HardwareWalletViewModel>(param1: hardwareWalletType),
           ),
         );
       }


### PR DESCRIPTION
# Description

Monero.com had a bug where it would only scan Ledger wallets even on the Trezor selection screen. Thios addressed that

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
