### PR TITLE
Remove broken feature request discussion link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Feature or Enhancement Request ✨
-    url: https://github.com/cake-tech/cake_wallet/discussions/new?category=feature-requests
-    about: Suggest an idea for Cake Wallet
   - name: Not sure where to start?
     url: https://docs.cakewallet.com
     about: Start by reading checking out the guides!


### PR DESCRIPTION
## Summary

Removes the duplicate "Feature or Enhancement Request" contact link from the GitHub issue template configuration.

<img width="1255" height="660" alt="feature-request-duplicate-cropped" src="https://github.com/user-attachments/assets/aeda033f-3643-491d-95d0-8e817f5f1a05" />

The repository already has a working `Feature request` issue template, while the removed contact link pointed to a broken GitHub Discussions URL:

`https://github.com/cake-tech/cake_wallet/discussions/new?category=feature-requests`

## Why

The issue creation modal showed two feature request options. One used the normal issue template and worked correctly, while the other linked to a Discussions category that no longer appears to be valid. This made the issue picker confusing and caused an error when selected.

## Changes

- Removed the broken Discussions contact link from `.github/ISSUE_TEMPLATE/config.yml`
- Kept the existing `Feature request` issue template as the single feature request path

## Testing

- Verified the removed link is no longer present in `.github/ISSUE_TEMPLATE`
- Ran `git diff --check`