### PR TITLE
feat(exchange): add TRX and USDT-on-Tron to Chainflip

### DIFF
--- a/lib/exchange/provider/chainflip_exchange_provider.dart
+++ b/lib/exchange/provider/chainflip_exchange_provider.dart
@@ -29,6 +29,8 @@ class ChainflipExchangeProvider extends ExchangeProvider {
     CryptoCurrency.arbEth,
     CryptoCurrency.usdcArb,
     CryptoCurrency.usdtArb,
+    CryptoCurrency.trx,
+    CryptoCurrency.usdttrc20,
     ];
 
   static const _baseURL = 'chainflip-broker.io';
@@ -315,6 +317,11 @@ class ChainflipExchangeProvider extends ExchangeProvider {
   }
 
   String _normalizeCurrency(CryptoCurrency currency) {
+    // Chainflip uses 'tron' as the network slug, but Cake uses tag 'TRX' (and null
+    // for native TRX), so these can't go through the generic title.tag logic below.
+    if (currency == CryptoCurrency.trx) return 'trx.tron';
+    if (currency == CryptoCurrency.usdttrc20) return 'usdt.tron';
+
     final tag = currency.tag?.toLowerCase();
     final title = currency.title.toLowerCase();
 
@@ -330,6 +337,7 @@ class ChainflipExchangeProvider extends ExchangeProvider {
       'ETHEREUM' => 'Ethereum',
       'ARBITRUM' => 'Arbitrum',
       'SOLANA' => 'Solana',
+      'TRON' => 'Tron',
       _ => name
     };
 
@@ -350,6 +358,8 @@ class ChainflipExchangeProvider extends ExchangeProvider {
       'eth.arb' => CryptoCurrency.arbEth,
       'usdc.arb' => CryptoCurrency.usdcArb,
       'usdt.arb' => CryptoCurrency.usdtArb,
+      'trx.tron' => CryptoCurrency.trx,
+      'usdt.tron' => CryptoCurrency.usdttrc20,
       _ => null
     };
 


### PR DESCRIPTION
## Description

Chainflip recently added Tron support — native TRX (asset id `trx.tron`) and USDT on Tron (asset id `usdt.tron`). This enables both for swaps in the Chainflip provider.

Tron needs explicit handling because Chainflip's network slug is `tron`, while Cake uses the `TRX` tag (and `null` for native TRX), so the generic `title.tag` normalization can't produce the correct asset ids.

## Changes

All in `lib/exchange/provider/chainflip_exchange_provider.dart`:

- **`_supported`** — add `CryptoCurrency.trx` and `CryptoCurrency.usdttrc20`
- **`_normalizeCurrency`** — special-case `trx` → `trx.tron`, `usdttrc20` → `usdt.tron`
- **`_normalizeNetworkName`** — add `TRON` → `Tron` (status lookup in `findTradeById`)
- **`_toCurrency`** — reverse-map `trx.tron` / `usdt.tron` for trade resolution

No new currency definitions needed — `trx` and `usdttrc20` already exist in `cw_core`.

## Testing

- Select Chainflip in the swap screen; confirm TRX and USDT (Tron) appear as from/to assets.
- Quote small swaps (e.g. BTC → USDT(Tron), TRX → ETH) — confirm non-zero rate and min limit.
- Create a Tron trade and reopen it — confirm `findTradeById` resolves the currency correctly.
