### PR TITLE
prevent trade.from saving as null + fallback when it does

### DIFF
--- a/lib/exchange/provider/near_Intents_exchange_provider.dart
+++ b/lib/exchange/provider/near_Intents_exchange_provider.dart
@@ -280,8 +280,8 @@ class NearIntentsExchangeProvider extends ExchangeProvider {
       final trade = Trade(
         id: depositAddress,
         // Using deposit address as trade ID
-        from: from,
-        to: to,
+        from: request.fromCurrency,
+        to: request.toCurrency,
         provider: description,
         providerName: title,
         state: TradeState.created,

--- a/lib/new-ui/widgets/coins_page/assets_history/history_section.dart
+++ b/lib/new-ui/widgets/coins_page/assets_history/history_section.dart
@@ -101,9 +101,6 @@ class HistorySection extends StatelessWidget {
                         final trade = item.trade;
                         final tradeFrom = trade.from;
                         final tradeTo = trade.to;
-                        if (tradeFrom == null || tradeTo == null) {
-                          return const SizedBox.shrink();
-                        }
 
                         return GestureDetector(
                           onTap: () => Navigator.of(context)

--- a/lib/new-ui/widgets/coins_page/assets_history/history_trade_tile.dart
+++ b/lib/new-ui/widgets/coins_page/assets_history/history_trade_tile.dart
@@ -15,13 +15,13 @@ class HistoryTradeTile extends StatelessWidget {
       required this.roundedTop,
       required this.roundedBottom,
       required this.bottomSeparator,
-      required this.from,
-      required this.to,
+      this.from,
+      this.to,
       required this.swapState,
       required this.provider});
 
-  final CryptoCurrency from;
-  final CryptoCurrency to;
+  final CryptoCurrency? from;
+  final CryptoCurrency? to;
   final ExchangeProviderDescription provider;
   final String date;
   final String amount;
@@ -32,6 +32,11 @@ class HistoryTradeTile extends StatelessWidget {
   final TradeState swapState;
 
   Widget _getLeadingStack(BuildContext context) {
+    if (from == null || to == null) {
+      return SizedBox(width: 50, height: 50);
+    }
+
+
     double currencyIconSize = 22.0;
 
     return SizedBox(
@@ -40,7 +45,7 @@ class HistoryTradeTile extends StatelessWidget {
       child: Stack(
         children: [
           CakeImageWidget(
-              imageUrl: _getIconPath(from), width: currencyIconSize, height: currencyIconSize),
+              imageUrl: _getIconPath(from!), width: currencyIconSize, height: currencyIconSize),
           Positioned(
             top: currencyIconSize / 2,
             left: currencyIconSize / 2,
@@ -50,7 +55,7 @@ class HistoryTradeTile extends StatelessWidget {
                       Border.all(width: 2, color: Theme.of(context).colorScheme.surfaceContainer),
                   shape: BoxShape.circle),
               child: CakeImageWidget(
-                imageUrl: _getIconPath(to),
+                imageUrl: _getIconPath(to!),
                 width: currencyIconSize,
                 height: currencyIconSize,
               ),
@@ -85,8 +90,8 @@ class HistoryTradeTile extends StatelessWidget {
               style: TextStyle(
                   color: Theme.of(context).colorScheme.onSurfaceVariant,
                   fontWeight: FontWeight.w500)),
-          Text(from.title, style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant)),
-          if (fromChainIcon.isNotEmpty)
+          if(from?.title != null) Text(from!.title, style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant)),
+          if (fromChainIcon?.isNotEmpty ?? false)
             CakeImageWidget(
               imageUrl: fromChainIcon,
               width: 12,
@@ -106,10 +111,11 @@ class HistoryTradeTile extends StatelessWidget {
             receiveAmount.withMaxDecimals(8),
             style: TextStyle(fontWeight: FontWeight.w500),
           ),
+          if(to!=null)
           Text(
-            to.title,
+            to!.title,
           ),
-          if (toChainIcon.isNotEmpty) CakeImageWidget(imageUrl: toChainIcon, width: 12, height: 12)
+          if (toChainIcon?.isNotEmpty ?? false) CakeImageWidget(imageUrl: toChainIcon, width: 12, height: 12)
         ],
       ),
       leadingIcon: _getLeadingStack(context),
@@ -137,7 +143,8 @@ class HistoryTradeTile extends StatelessWidget {
     return "";
   }
 
-  String _getChainIcon(CryptoCurrency currency) {
+  String? _getChainIcon(CryptoCurrency? currency) {
+    if(currency == null) return null;
     try {
       if (currency.title.isNotEmpty) {
         final parsedCurrency = CryptoCurrency.safeParseCurrencyFromString(currency.title, tag: currency.tag);

--- a/lib/src/screens/dev/moneroc_cache_debug.dart
+++ b/lib/src/screens/dev/moneroc_cache_debug.dart
@@ -9,6 +9,7 @@ import 'package:cw_core/root_dir.dart';
 import 'package:cw_core/wallet_type.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:path/path.dart' as path;
 
 class DevMoneroWalletCacheDebugPage extends StatelessWidget {
@@ -263,6 +264,7 @@ class _JsonExplorerState extends State<JsonExplorer> {
                   ),
                 )
               : ListView.builder(
+                  controller: ModalScrollController.of(context),
                   itemCount: _filteredItems.length,
                   itemBuilder: (context, index) {
                     final item = _filteredItems[index];

--- a/lib/view_model/exchange/exchange_view_model.dart
+++ b/lib/view_model/exchange/exchange_view_model.dart
@@ -1242,6 +1242,12 @@ abstract class ExchangeViewModelBase extends WalletChangeListenerViewModel with 
               trade.walletId = wallet.id;
               trade.chainId = wallet.chainId;
               trade.fromWalletAddress = wallet.walletAddresses.address;
+              if(trade.from == null) {
+                trade.from = depositCurrency;
+              }
+              if(trade.to == null) {
+                trade.to = receiveCurrency;
+              }
 
               final canCreateTrade = await isCanCreateTrade(trade);
               if (!canCreateTrade.result) {


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

The Trade object has nullable fields for the trade currencies, occasionally resulting in null values in the database and the trades not getting displayed later. This adds conditions that prevent that and adds a UI fallback to still show the trade even if currency info is not present.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
