### PR TITLE
fix: make receive actions usable on compact screens

### DIFF
--- a/lib/new-ui/pages/addresses_page.dart
+++ b/lib/new-ui/pages/addresses_page.dart
@@ -421,22 +421,32 @@ class AddressRow extends StatelessWidget {
                             ),
                           ],
                         ),
-                        Row(
-                          mainAxisSize: MainAxisSize.max,
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(
-                              "${S.of(context).transactions}: ${item.txCount}",
-                              style: TextStyle(
-                                  fontSize: 12,
-                                  color: Theme.of(context).colorScheme.onSurfaceVariant),
-                            ),
-                            Text("${hasReceived ? S.of(context).received : S.of(context).balance}: ${item.balance}",
-                                style: TextStyle(
-                                    fontSize: 12,
-                                    color: Theme.of(context).colorScheme.onSurfaceVariant)),
-                          ],
-                        )
+                        if (item.txCount != null || item.balance != null)
+                          Row(
+                            mainAxisSize: MainAxisSize.max,
+                            children: [
+                              if (item.txCount != null)
+                                Text(
+                                  "${S.of(context).transactions}: ${item.txCount}",
+                                  style: TextStyle(
+                                      fontSize: 12,
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurfaceVariant),
+                                ),
+                              if (item.txCount != null && item.balance != null)
+                                const Spacer(),
+                              if (item.balance != null)
+                                Text(
+                                  "${hasReceived ? S.of(context).received : S.of(context).balance}: ${item.balance}",
+                                  style: TextStyle(
+                                      fontSize: 12,
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurfaceVariant),
+                                ),
+                            ],
+                          )
                       ],
                     ),
                   ),

--- a/lib/new-ui/widgets/modern_button.dart
+++ b/lib/new-ui/widgets/modern_button.dart
@@ -75,6 +75,9 @@ class ModernButton extends StatelessWidget {
         if (label != null && label!.isNotEmpty)
           Text(
             label!,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
             style: TextStyle(
                 fontSize: 12,
                 fontWeight: FontWeight.w400,

--- a/lib/new-ui/widgets/receive_page/receive_bottom_buttons.dart
+++ b/lib/new-ui/widgets/receive_page/receive_bottom_buttons.dart
@@ -56,69 +56,86 @@ class _ReceiveBottomButtonsState extends State<ReceiveBottomButtons> {
           duration: const Duration(milliseconds: 300),
           opacity: targetOpacity,
           curve: Curves.easeOut,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 32.0),
-            child: Row(
-              mainAxisSize: MainAxisSize.max,
-              mainAxisAlignment: MainAxisAlignment.center,
-              spacing: 16,
-              children: [
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final isCompact = constraints.maxWidth < 400;
+              final buttonSize = isCompact ? 52.0 : 60.0;
+              final iconSize = isCompact ? 28.0 : 32.0;
+              final horizontalPadding = isCompact ? 12.0 : 32.0;
+              final spacing = isCompact ? 4.0 : 16.0;
+
+              final buttons = <Widget>[
                 AnimatedSwitcher(
-                  duration: Duration(milliseconds: 200),
+                  duration: const Duration(milliseconds: 200),
                   child: ModernButton.svg(
                     key: ValueKey(copied),
-                    size: 60,
-                    iconSize: 32,
+                    size: buttonSize,
+                    iconSize: iconSize,
                     svgPath: "assets/new-ui/copy.svg",
                     onPressed: handleCopy,
                     label: copied ? S.of(context).copied : S.of(context).copy,
-                    iconColor: copied ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.surfaceContainer,
-                    backgroundColor: copied ? Theme.of(context).colorScheme.surfaceContainerHighest : Theme.of(context).colorScheme.primary,
+                    iconColor: copied
+                        ? Theme.of(context).colorScheme.primary
+                        : Theme.of(context).colorScheme.surfaceContainer,
+                    backgroundColor: copied
+                        ? Theme.of(context).colorScheme.surfaceContainerHighest
+                        : Theme.of(context).colorScheme.primary,
                   ),
                 ),
                 ModernButton.svg(
-                    size: 60,
-                    iconSize: 32,
-                    svgPath: "assets/new-ui/set-amount.svg",
-                    onPressed: widget.onAmountButtonPressed,
-                    label: S.of(context).set_amount),
+                  size: buttonSize,
+                  iconSize: iconSize,
+                  svgPath: "assets/new-ui/set-amount.svg",
+                  onPressed: widget.onAmountButtonPressed,
+                  label: S.of(context).set_amount,
+                ),
                 if (widget.showLabelButton)
                   ModernButton.svg(
-                      size: 60,
-                      iconSize: 32,
-                      svgPath: "assets/new-ui/add-label.svg",
-                      onPressed: widget.onLabelButtonPressed,
-                      label: S.of(context).label),
+                    size: buttonSize,
+                    iconSize: iconSize,
+                    svgPath: "assets/new-ui/add-label.svg",
+                    onPressed: widget.onLabelButtonPressed,
+                    label: S.of(context).label,
+                  ),
                 if (widget.showAccountsButton)
                   ModernButton.svg(
-                      size: 60,
-                      iconSize: 32,
-                      svgPath: "assets/new-ui/addr-book.svg",
-                      onPressed: widget.onAccountsButtonPressed,
-                      label: S.of(context).addresses),
-              ],
-            ),
+                    size: buttonSize,
+                    iconSize: iconSize,
+                    svgPath: "assets/new-ui/addr-book.svg",
+                    onPressed: widget.onAccountsButtonPressed,
+                    label: S.of(context).addresses,
+                  ),
+              ];
+
+              return Padding(
+                padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+                child: Row(
+                  mainAxisSize: MainAxisSize.max,
+                  spacing: spacing,
+                  children: buttons
+                      .map((button) => Expanded(child: button))
+                      .toList(),
+                ),
+              );
+            },
           ),
         ),
       ),
     );
   }
-
-
-
   // android 13 (sdk 33) added a built-in "text was copied to clipboard" ui element
   // older android and iphone still needs an indicator though
   Future<bool> shouldShowCopied() async {
     if (!Platform.isAndroid) return true;
 
     try {
-        final deviceInfo = DeviceInfoPlugin();
-        final androidInfo = await deviceInfo.androidInfo;
-        final sdk = androidInfo.version.sdkInt;
-    
-        return sdk < 33;
+      final deviceInfo = DeviceInfoPlugin();
+      final androidInfo = await deviceInfo.androidInfo;
+      final sdk = androidInfo.version.sdkInt;
+
+      return sdk < 33;
     } catch (_) {
-        return true;
+      return true;
     }
   }
 }

--- a/test/new-ui/address_row_test.dart
+++ b/test/new-ui/address_row_test.dart
@@ -1,0 +1,42 @@
+import 'package:cake_wallet/generated/i18n.dart';
+import 'package:cake_wallet/locales/locale.dart';
+import 'package:cake_wallet/new-ui/pages/addresses_page.dart';
+import 'package:cake_wallet/view_model/wallet_address_list/wallet_address_list_item.dart';
+import 'package:cw_core/wallet_type.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('does not render unavailable Zcash address metadata', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('es'),
+        localizationsDelegates: localizationDelegates,
+        supportedLocales: S.delegate.supportedLocales,
+        home: Scaffold(
+          body: AddressRow(
+            selected: false,
+            first: true,
+            last: true,
+            item: WalletAddressListItem(
+              address: 't1abcdefghijklmnopqrstuvwxyz1234567',
+              isPrimary: false,
+            ),
+            onSelect: () {},
+            walletType: WalletType.zcash,
+            onLabelChanged: () {},
+            onAddressHidden: () {},
+            hasBalance: false,
+            hasReceived: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('null'), findsNothing);
+    expect(find.textContaining('Transacciones:'), findsNothing);
+    expect(find.textContaining('Saldo:'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/new-ui/receive_bottom_buttons_test.dart
+++ b/test/new-ui/receive_bottom_buttons_test.dart
@@ -1,0 +1,52 @@
+import 'package:cake_wallet/generated/i18n.dart';
+import 'package:cake_wallet/locales/locale.dart';
+import 'package:cake_wallet/new-ui/widgets/receive_page/receive_bottom_buttons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpButtons(
+    WidgetTester tester, {
+    required double width,
+  }) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = Size(width, 640);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('es'),
+        localizationsDelegates: localizationDelegates,
+        supportedLocales: S.delegate.supportedLocales,
+        home: Scaffold(
+          body: ReceiveBottomButtons(
+            largeQrMode: false,
+            onCopyButtonPressed: () {},
+            onAmountButtonPressed: () {},
+            onLabelButtonPressed: () {},
+            onAccountsButtonPressed: () {},
+            showLabelButton: true,
+            showAccountsButton: true,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  for (final width in [320.0, 360.0]) {
+    testWidgets(
+      'keeps all Spanish receive actions visible at ${width.toInt()}px',
+      (tester) async {
+        await pumpButtons(tester, width: width);
+
+        expect(find.text('Copiar'), findsOneWidget);
+        expect(find.text('Establecer cantidad'), findsOneWidget);
+        expect(find.text('Etiqueta'), findsOneWidget);
+        expect(find.text('Direcciones'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+}


### PR DESCRIPTION
Issue Number (if Applicable): N/A

# Description

This change keeps the receive-page actions usable on compact Android screens and avoids displaying unavailable address metadata as literal `null` values.

## Changes

- Use equal-width flexible action cells in the receive-page bottom row.
- Reduce button size, padding, and spacing below 400 logical pixels.
- Allow `ModernButton` labels to use up to two centered lines with ellipsis.
- Render transaction count and balance independently only when each value is available.
- Add widget coverage for Spanish labels at 320 px and 360 px widths.
- Add widget coverage for address rows whose metadata is unavailable.

## Validation

- `git diff --check` passes.
- Widget tests were added, but could not be executed locally because the generated root pubspec and Flutter toolchain are not available in the analysis environment. CI validation is requested.

# Pull Request - Checklist

- [ ] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed
