### PR TITLE
fix: show Zcash transparent address metadata

### DIFF
--- a/cw_core/lib/wallet_info.dart
+++ b/cw_core/lib/wallet_info.dart
@@ -61,6 +61,8 @@ class WalletInfoAddressInfo {
     required this.accountIndex,
     required this.address,
     required this.label,
+    this.txCount,
+    this.balance,
   });
 
   int id;
@@ -69,6 +71,8 @@ class WalletInfoAddressInfo {
   int accountIndex;
   String address;
   String label;
+  int? txCount;
+  int? balance;
 
   static String get tableName => 'walletInfoAddressInfo';
 

--- a/cw_zcash/lib/src/zcash_taddress_rotation.dart
+++ b/cw_zcash/lib/src/zcash_taddress_rotation.dart
@@ -54,6 +54,27 @@ class ZcashTaddressRotation {
   static Map<int, List<Account>> rotationAccounts = {};
   static Map<int, List<Account>> rotationAccountsUsable = {};
   static Map<int, List<ShieldedTx>> shieldedAccountsTx = {};
+  static final Map<String, int> addressBalances = {};
+  static final Map<String, int> addressTxCounts = {};
+
+  static void refreshAddressMetadata(final Account account) {
+    try {
+      final address = WarpApi.getTAddr(coin, account.id);
+      addressBalances[address] =
+          WarpApi.getPoolBalances(coin, account.id, 0, true).transparent;
+      addressTxCounts[address] = WarpApi.getTxsSync(coin, account.id).length;
+    } catch (e) {
+      printV("Failed to refresh metadata for Zcash account ${account.id}: $e");
+    }
+  }
+
+  static int? balanceForAddress(final String address) => addressBalances[address];
+
+  static int? txCountForAddress(final String address) => addressTxCounts[address];
+
+  static List<Account> accountsForAccount(final int accountId) =>
+      rotationAccounts[accountId]?.toList() ?? [];
+
   static Future<void> init() async {
     printV("Deserializing previous state");
     if (_isStarted) {
@@ -416,6 +437,7 @@ class ZcashTaddressRotation {
     for (int i = 0; i < acc.length; i++) {
       final b = WarpApi.getBackup(coin, acc[i].id);
       printV("$i. ${b.seed?.split(" ").last}, ${b.index}, ${WarpApi.getTAddr(coin, acc[i].id)}");
+      refreshAddressMetadata(acc[i]);
     }
     return acc.map((final a) => WarpApi.getTAddr(coin, a.id)).toList();
   }
@@ -423,14 +445,14 @@ class ZcashTaddressRotation {
   static List<String>? allUsedAddressesForAccount(final int accountId) {
     final seed = WarpApi.getBackup(coin, accountId).seed;
     if (seed == null) return [];
-    final acc = rotationAccounts[seed]?.toList();
+    final acc = rotationAccounts[accountId]?.toList();
     if (acc == null) {
       printV("Nothing found");
       return null;
     }
     acc.removeWhere((final a1) {
-      for (int i = 0; i < (rotationAccountsUsable[seed]?.length ?? 0); i++) {
-        if (rotationAccountsUsable[seed]?[i].id == a1.id) {
+      for (int i = 0; i < (rotationAccountsUsable[accountId]?.length ?? 0); i++) {
+        if (rotationAccountsUsable[accountId]?[i].id == a1.id) {
           return true;
         }
       }

--- a/cw_zcash/lib/src/zcash_wallet.dart
+++ b/cw_zcash/lib/src/zcash_wallet.dart
@@ -784,21 +784,27 @@ abstract class ZcashWalletBase
 
       final confirmedPoolBalances = WarpApi.getPoolBalances(coin, accountId, 3, true);
       final confirmedBalances = confirmedPoolBalances.unpack();
-      final confirmedTotal =
-          confirmedBalances.orchard + confirmedBalances.sapling + confirmedBalances.transparent;
+
+      int rotatedTransparentBalance = 0;
+      for (final account in ZcashTaddressRotation.accountsForAccount(accountId)) {
+        final accountBalances = WarpApi.getPoolBalances(coin, account.id, 0, true);
+        rotatedTransparentBalance += accountBalances.transparent;
+        ZcashTaddressRotation.refreshAddressMetadata(account);
+      }
 
       int knownOutPending = 0;
       ZcashWalletBase.temporarySentTx[accountId]?.forEach((final sTx) {
         knownOutPending += sTx.value; // it's negative
       });
-      final confirmedSpendable = confirmedTotal - balances.transparent + knownOutPending;
+      final confirmedSpendable =
+          confirmedBalances.orchard + confirmedBalances.sapling + knownOutPending;
 
       unawaited(_autoShield());
 
       balance[CryptoCurrency.zec] = ZcashBalance(
         Money.fromInt(confirmedSpendable, currency),
         Money.fromInt(spendable - confirmedSpendable, currency),
-        frozen: Money.zero(currency),
+        frozen: Money.fromInt(balances.transparent + rotatedTransparentBalance, currency),
       );
     } catch (e, stackTrace) {
       printV("Balance update error: $e");

--- a/cw_zcash/lib/src/zcash_wallet_addresses.dart
+++ b/cw_zcash/lib/src/zcash_wallet_addresses.dart
@@ -131,7 +131,11 @@ abstract class ZcashWalletAddressesBase extends WalletAddresses with Store {
 
   @override
   bool containsAddress(final String address) {
-    return this.address == address || addressesMap.values.contains(address);
+    return this.address == address ||
+        addressesMap.values.contains(address) ||
+        addressInfos.values.any((final infos) {
+          return infos.any((final info) => info.address == address);
+        });
   }
 
   static int get coin => ZcashWalletBase.coin;
@@ -149,25 +153,42 @@ abstract class ZcashWalletAddressesBase extends WalletAddresses with Store {
     address = latestAddress;
   }
 
+  Map<String, String> _labelsByAddress() {
+    final labels = <String, String>{};
+    for (final infos in addressInfos.values) {
+      for (final info in infos) {
+        labels[info.address] = info.label;
+      }
+    }
+    return labels;
+  }
+
+  Map<int, List<WalletInfoAddressInfo>> _buildTransparentAddressInfos(
+    final Map<String, String> labels,
+  ) {
+    int mapKey = 0;
+    final infos = ZcashTaddressRotation.accountsForAccount(accountId).map((final account) {
+      final address = WarpApi.getTAddr(coin, account.id);
+      ZcashTaddressRotation.refreshAddressMetadata(account);
+      return WalletInfoAddressInfo(
+        walletInfoId: walletInfo.internalId,
+        mapKey: ++mapKey,
+        accountIndex: account.id,
+        address: address,
+        label: labels[address] ?? "",
+        txCount: ZcashTaddressRotation.txCountForAddress(address),
+        balance: ZcashTaddressRotation.balanceForAddress(address),
+      );
+    }).toList();
+    return {0: infos};
+  }
+
   @override
   Future<void> init() async {
     await _initAddresses();
 
     await ZcashTaddressRotation.init();
-    int accountIndex = 0;
-    addressInfos = {
-      0:
-          ZcashTaddressRotation.allAddressesForAccount(accountId)?.map((final v) {
-            return WalletInfoAddressInfo(
-              walletInfoId: walletInfo.internalId,
-              mapKey: ++accountIndex,
-              accountIndex: 0,
-              address: v,
-              label: "",
-            );
-          }).toList() ??
-          [],
-    };
+    addressInfos = _buildTransparentAddressInfos(_labelsByAddress());
     hiddenAddresses.addAll(
       ZcashTaddressRotation.allUsedAddressesForAccount(accountId)?.toSet() ?? {},
     );
@@ -227,8 +248,24 @@ abstract class ZcashWalletAddressesBase extends WalletAddresses with Store {
     if (addressPageType != ZcashAddressType.transparentRotated) {
       return [];
     }
+    final knownAddresses = addressInfos.values
+        .expand((final infos) => infos)
+        .map((final info) => info.address)
+        .toSet();
+    final currentAddresses = ZcashTaddressRotation.accountsForAccount(accountId)
+        .map((final account) => WarpApi.getTAddr(coin, account.id))
+        .toSet();
+    if (knownAddresses.length != currentAddresses.length ||
+        !knownAddresses.containsAll(currentAddresses)) {
+      addressInfos = _buildTransparentAddressInfos(_labelsByAddress());
+    }
+
     final List<WalletInfoAddressInfo> allInfos = [];
     for (final entry in addressInfos.entries) {
+      for (final info in entry.value) {
+        info.txCount = ZcashTaddressRotation.txCountForAddress(info.address);
+        info.balance = ZcashTaddressRotation.balanceForAddress(info.address);
+      }
       allInfos.addAll(entry.value);
     }
     return allInfos;

--- a/lib/view_model/wallet_address_list/wallet_address_edit_or_create_view_model.dart
+++ b/lib/view_model/wallet_address_list/wallet_address_edit_or_create_view_model.dart
@@ -121,6 +121,18 @@ abstract class WalletAddressEditOrCreateViewModelBase with Store {
       return;
     }
 
+    if (wallet.type == WalletType.zcash) {
+      for (final infos in wallet.walletAddresses.addressInfos.values) {
+        for (final info in infos) {
+          if (info.address == _item!.address) {
+            info.label = label;
+          }
+        }
+      }
+      await wallet.walletAddresses.saveAddressesInBox();
+      return;
+    }
+
     final index = _item?.id;
     if (index != null) {
       if (wallet.type == WalletType.monero) {

--- a/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
+++ b/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
@@ -368,8 +368,17 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
     if (wallet.type == WalletType.zcash) {
       final addrInfos = zcash!.getAddressInfos(wallet);
       addrInfos.forEach((info) {
-        addressList.add(
-            new WalletAddressListItem(isPrimary: false, address: info.address, name: info.label));
+        addressList.add(WalletAddressListItem(
+          id: info.mapKey,
+          isPrimary: false,
+          address: info.address,
+          name: info.label,
+          txCount: info.txCount,
+          balance: info.balance == null
+              ? null
+              : _appStore.amountParsingProxy
+                  .getDisplayCryptoString(info.balance!, walletTypeToCryptoCurrency(type)),
+        ));
       });
     }
 
@@ -566,7 +575,8 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
   String get monoImage => getChainMonoImage(type);
 
   @computed
-  bool get isBalanceAvailable => isElectrumWallet;
+  bool get isBalanceAvailable =>
+      isElectrumWallet || (wallet.type == WalletType.zcash && isZCashTransparent);
 
   @computed
   bool get isReceivedAvailable => [WalletType.monero, WalletType.wownero].contains(wallet.type);


### PR DESCRIPTION
Issue Number (if Applicable): N/A

# Description

This change provides real transaction-count and balance metadata for rotated Zcash transparent addresses instead of displaying `null`, while preserving address labels across refreshes.

## Changes

- Fix rotated-account lookup to use the integer account ID rather than a seed string as a map key.
- Track transparent balance and transaction count for each rotated account using the existing Warp API data.
- Associate address-list entries with their actual rotated account IDs.
- Refresh address metadata during wallet balance updates.
- Preserve user labels when the transparent address list is rebuilt.
- Allow Zcash transparent address labels to be edited and persisted.
- Include transparent funds in the wallet's frozen balance until they are shielded, so deposits remain visible without being treated as immediately spendable.
- Recognize rotated addresses in `containsAddress()`.

## Validation

- `git diff --check` passes.
- Runtime validation with restored and existing Zcash wallets is still required. The Flutter/native build toolchain was not available in the analysis environment.

# Pull Request - Checklist

- [ ] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed
