### PR TITLE
feat: generate Zcash transparent addresses on demand

### DIFF
--- a/cw_core/lib/wallet_info.dart
+++ b/cw_core/lib/wallet_info.dart
@@ -61,6 +61,8 @@ class WalletInfoAddressInfo {
     required this.accountIndex,
     required this.address,
     required this.label,
+    this.txCount,
+    this.balance,
   });
 
   int id;
@@ -69,6 +71,8 @@ class WalletInfoAddressInfo {
   int accountIndex;
   String address;
   String label;
+  int? txCount;
+  int? balance;
 
   static String get tableName => 'walletInfoAddressInfo';
 

--- a/cw_zcash/lib/src/zcash_taddress_rotation.dart
+++ b/cw_zcash/lib/src/zcash_taddress_rotation.dart
@@ -54,6 +54,27 @@ class ZcashTaddressRotation {
   static Map<int, List<Account>> rotationAccounts = {};
   static Map<int, List<Account>> rotationAccountsUsable = {};
   static Map<int, List<ShieldedTx>> shieldedAccountsTx = {};
+  static final Map<String, int> addressBalances = {};
+  static final Map<String, int> addressTxCounts = {};
+
+  static void refreshAddressMetadata(final Account account) {
+    try {
+      final address = WarpApi.getTAddr(coin, account.id);
+      addressBalances[address] =
+          WarpApi.getPoolBalances(coin, account.id, 0, true).transparent;
+      addressTxCounts[address] = WarpApi.getTxsSync(coin, account.id).length;
+    } catch (e) {
+      printV("Failed to refresh metadata for Zcash account ${account.id}: $e");
+    }
+  }
+
+  static int? balanceForAddress(final String address) => addressBalances[address];
+
+  static int? txCountForAddress(final String address) => addressTxCounts[address];
+
+  static List<Account> accountsForAccount(final int accountId) =>
+      rotationAccounts[accountId]?.toList() ?? [];
+
   static Future<void> init() async {
     printV("Deserializing previous state");
     if (_isStarted) {
@@ -416,6 +437,7 @@ class ZcashTaddressRotation {
     for (int i = 0; i < acc.length; i++) {
       final b = WarpApi.getBackup(coin, acc[i].id);
       printV("$i. ${b.seed?.split(" ").last}, ${b.index}, ${WarpApi.getTAddr(coin, acc[i].id)}");
+      refreshAddressMetadata(acc[i]);
     }
     return acc.map((final a) => WarpApi.getTAddr(coin, a.id)).toList();
   }
@@ -423,14 +445,14 @@ class ZcashTaddressRotation {
   static List<String>? allUsedAddressesForAccount(final int accountId) {
     final seed = WarpApi.getBackup(coin, accountId).seed;
     if (seed == null) return [];
-    final acc = rotationAccounts[seed]?.toList();
+    final acc = rotationAccounts[accountId]?.toList();
     if (acc == null) {
       printV("Nothing found");
       return null;
     }
     acc.removeWhere((final a1) {
-      for (int i = 0; i < (rotationAccountsUsable[seed]?.length ?? 0); i++) {
-        if (rotationAccountsUsable[seed]?[i].id == a1.id) {
+      for (int i = 0; i < (rotationAccountsUsable[accountId]?.length ?? 0); i++) {
+        if (rotationAccountsUsable[accountId]?[i].id == a1.id) {
           return true;
         }
       }

--- a/cw_zcash/lib/src/zcash_taddress_rotation.dart
+++ b/cw_zcash/lib/src/zcash_taddress_rotation.dart
@@ -56,6 +56,9 @@ class ZcashTaddressRotation {
   static Map<int, List<ShieldedTx>> shieldedAccountsTx = {};
   static final Map<String, int> addressBalances = {};
   static final Map<String, int> addressTxCounts = {};
+  static const int minimumUsableAddressPool = 5;
+  static const int recoveryGapLimit = 20;
+  static const int maximumManualUnusedGap = recoveryGapLimit - 1;
 
   static void refreshAddressMetadata(final Account account) {
     try {
@@ -74,6 +77,38 @@ class ZcashTaddressRotation {
 
   static List<Account> accountsForAccount(final int accountId) =>
       rotationAccounts[accountId]?.toList() ?? [];
+
+  static Future<String> generateAddressForAccount(final int accountId) async {
+    final mainSeed = WarpApi.getBackup(coin, accountId).seed;
+    if (mainSeed == null) {
+      throw StateError("Transparent address generation requires a wallet seed");
+    }
+
+    rotationAccounts[accountId] ??= WarpApi.getAccountList(coin).where((final account) {
+      return isSeedForWallet(mainSeed, WarpApi.getBackup(coin, account.id).seed);
+    }).toList();
+
+    if (_trailingUnusedCount(accountId) >= maximumManualUnusedGap) {
+      throw StateError(
+        "Use one of the existing transparent addresses before generating another",
+      );
+    }
+
+    final id = await _createRotationAccount(accountId, mainSeed);
+    final account = WarpApi.getAccountList(coin).firstWhere((final item) => item.id == id);
+    final accounts = rotationAccounts[accountId]!;
+    if (!accounts.any((final item) => item.id == account.id)) {
+      accounts.add(account);
+    }
+    rotationAccountsUsable[accountId] ??= [];
+    if (!rotationAccountsUsable[accountId]!.any((final item) => item.id == account.id)) {
+      rotationAccountsUsable[accountId]!.add(account);
+    }
+
+    refreshAddressMetadata(account);
+    await serializeToFile();
+    return WarpApi.getTAddr(coin, account.id);
+  }
 
   static Future<void> init() async {
     printV("Deserializing previous state");
@@ -193,6 +228,68 @@ class ZcashTaddressRotation {
   static Uint8List atob(final String value) =>
       Uint8List.fromList(List<int>.from(base64.decode(value)));
 
+  static List<Account> _sortedAccountsFor(final int accountId) {
+    final accounts = rotationAccounts[accountId]?.toList() ?? [];
+    accounts.sort((final a, final b) {
+      final aIndex = WarpApi.getBackup(coin, a.id).index;
+      final bIndex = WarpApi.getBackup(coin, b.id).index;
+      return aIndex.compareTo(bIndex);
+    });
+    return accounts;
+  }
+
+  static bool _isUnused(final Account account) {
+    refreshAddressMetadata(account);
+    final address = WarpApi.getTAddr(coin, account.id);
+    return (addressTxCounts[address] ?? 0) == 0 && (addressBalances[address] ?? 0) == 0;
+  }
+
+  static int _trailingUnusedCount(final int accountId) {
+    final accounts = _sortedAccountsFor(accountId);
+    int count = 0;
+    for (final account in accounts.reversed) {
+      if (!_isUnused(account)) break;
+      count++;
+    }
+    return count;
+  }
+
+  static int _nextAccountIndex(final int accountId) {
+    int nextIndex = 0;
+    for (final account in rotationAccounts[accountId] ?? <Account>[]) {
+      final index = WarpApi.getBackup(coin, account.id).index;
+      if (index >= nextIndex) nextIndex = index + 1;
+    }
+    return nextIndex;
+  }
+
+  static Future<int> _createRotationAccount(final int accountId, final String mainSeed) {
+    final seed = seedForOffset(mainSeed);
+    final name = CRC32.compute(accountId.toString()).toString();
+    final index = _nextAccountIndex(accountId);
+    return ZcashWalletService.runInDbMutex(
+      () => WarpApi.newAccount(coin, name, seed, index),
+    );
+  }
+
+  static Future<bool> _isRecoveryAccount(final int accountId) async {
+    final accounts = WarpApi.getAccountList(coin);
+    String? accountName;
+    for (final account in accounts) {
+      if (account.id == accountId) {
+        accountName = account.name;
+        break;
+      }
+    }
+    if (accountName == null) return false;
+
+    final walletInfos = await WalletInfo.selectList('type = ?', [WalletType.zcash.index]);
+    for (final walletInfo in walletInfos) {
+      if (walletInfo.name == accountName) return walletInfo.isRecovery;
+    }
+    return false;
+  }
+
   static Future<void> createAndSweepTAddresses() async {
     int chainHeight = 0;
     try {
@@ -217,11 +314,13 @@ class ZcashTaddressRotation {
       final acc = accounts[i];
       final backup = WarpApi.getBackup(coin, acc.id);
       await WarpApi.transparentSync(coin, acc.id, syncHeight);
+      refreshAddressMetadata(acc);
       if (backup.seed == null) continue;
       seeds[acc.id] = backup.seed!;
     }
     for (int i = 0; i < accounts.length; i++) {
-      final seed = seeds[accounts[i].id]!;
+      final seed = seeds[accounts[i].id];
+      if (seed == null) continue;
       if ([12, 13, 24, 25].contains(seed.split(" ").length)) {
         if (seed.split(" ").last.contains(":tgen:")) continue;
         rotationAccounts[accounts[i].id] = [];
@@ -276,13 +375,26 @@ class ZcashTaddressRotation {
 
     bool didAddNewAccount = false;
     for (int i = 0; i < raKeys.length; i++) {
-      if (rotationAccountsUsable[raKeys[i]]!.length < 5) {
-        final seed = seedForOffset(seeds[raKeys[i]]!);
-        final name = CRC32.compute(raKeys[i].toString()).toString();
-        final id = await ZcashWalletService.runInDbMutex(
-          () => WarpApi.newAccount(coin, name, seed, rotationAccounts[raKeys[i]]!.length),
-        );
-        printV("new id: $id / $seed");
+      final accountId = raKeys[i];
+      final mainSeed = seeds[accountId];
+      if (mainSeed == null || !await _isRecoveryAccount(accountId)) {
+        continue;
+      }
+
+      if (_trailingUnusedCount(accountId) < recoveryGapLimit) {
+        await _createRotationAccount(accountId, mainSeed);
+        didAddNewAccount = true;
+      }
+    }
+    if (didAddNewAccount) {
+      return createAndSweepTAddresses();
+    }
+
+    for (int i = 0; i < raKeys.length; i++) {
+      if (rotationAccountsUsable[raKeys[i]]!.length < minimumUsableAddressPool &&
+          _trailingUnusedCount(raKeys[i]) < maximumManualUnusedGap) {
+        final id = await _createRotationAccount(raKeys[i], seeds[raKeys[i]]!);
+        printV("new rotation account id: $id");
         printV("${rotationAccounts[raKeys[i]]}");
         printV(raKeys[i]);
         rotationAccounts[raKeys[i]]!.forEach((final a) {

--- a/cw_zcash/lib/src/zcash_wallet.dart
+++ b/cw_zcash/lib/src/zcash_wallet.dart
@@ -784,21 +784,27 @@ abstract class ZcashWalletBase
 
       final confirmedPoolBalances = WarpApi.getPoolBalances(coin, accountId, 3, true);
       final confirmedBalances = confirmedPoolBalances.unpack();
-      final confirmedTotal =
-          confirmedBalances.orchard + confirmedBalances.sapling + confirmedBalances.transparent;
+
+      int rotatedTransparentBalance = 0;
+      for (final account in ZcashTaddressRotation.accountsForAccount(accountId)) {
+        final accountBalances = WarpApi.getPoolBalances(coin, account.id, 0, true);
+        rotatedTransparentBalance += accountBalances.transparent;
+        ZcashTaddressRotation.refreshAddressMetadata(account);
+      }
 
       int knownOutPending = 0;
       ZcashWalletBase.temporarySentTx[accountId]?.forEach((final sTx) {
         knownOutPending += sTx.value; // it's negative
       });
-      final confirmedSpendable = confirmedTotal - balances.transparent + knownOutPending;
+      final confirmedSpendable =
+          confirmedBalances.orchard + confirmedBalances.sapling + knownOutPending;
 
       unawaited(_autoShield());
 
       balance[CryptoCurrency.zec] = ZcashBalance(
         Money.fromInt(confirmedSpendable, currency),
         Money.fromInt(spendable - confirmedSpendable, currency),
-        frozen: Money.zero(currency),
+        frozen: Money.fromInt(balances.transparent + rotatedTransparentBalance, currency),
       );
     } catch (e, stackTrace) {
       printV("Balance update error: $e");

--- a/cw_zcash/lib/src/zcash_wallet_addresses.dart
+++ b/cw_zcash/lib/src/zcash_wallet_addresses.dart
@@ -271,6 +271,15 @@ abstract class ZcashWalletAddressesBase extends WalletAddresses with Store {
     return allInfos;
   }
 
+  Future<String> generateNewTransparentAddress() async {
+    final labels = _labelsByAddress();
+    final newAddress = await ZcashTaddressRotation.generateAddressForAccount(accountId);
+    addressInfos = _buildTransparentAddressInfos(labels);
+    await saveAddressesInBox();
+    address = newAddress;
+    return newAddress;
+  }
+
   @override
   List<ReceivePageOption> get receivePageOptions {
     return [

--- a/cw_zcash/lib/src/zcash_wallet_addresses.dart
+++ b/cw_zcash/lib/src/zcash_wallet_addresses.dart
@@ -131,7 +131,11 @@ abstract class ZcashWalletAddressesBase extends WalletAddresses with Store {
 
   @override
   bool containsAddress(final String address) {
-    return this.address == address || addressesMap.values.contains(address);
+    return this.address == address ||
+        addressesMap.values.contains(address) ||
+        addressInfos.values.any((final infos) {
+          return infos.any((final info) => info.address == address);
+        });
   }
 
   static int get coin => ZcashWalletBase.coin;
@@ -149,25 +153,42 @@ abstract class ZcashWalletAddressesBase extends WalletAddresses with Store {
     address = latestAddress;
   }
 
+  Map<String, String> _labelsByAddress() {
+    final labels = <String, String>{};
+    for (final infos in addressInfos.values) {
+      for (final info in infos) {
+        labels[info.address] = info.label;
+      }
+    }
+    return labels;
+  }
+
+  Map<int, List<WalletInfoAddressInfo>> _buildTransparentAddressInfos(
+    final Map<String, String> labels,
+  ) {
+    int mapKey = 0;
+    final infos = ZcashTaddressRotation.accountsForAccount(accountId).map((final account) {
+      final address = WarpApi.getTAddr(coin, account.id);
+      ZcashTaddressRotation.refreshAddressMetadata(account);
+      return WalletInfoAddressInfo(
+        walletInfoId: walletInfo.internalId,
+        mapKey: ++mapKey,
+        accountIndex: account.id,
+        address: address,
+        label: labels[address] ?? "",
+        txCount: ZcashTaddressRotation.txCountForAddress(address),
+        balance: ZcashTaddressRotation.balanceForAddress(address),
+      );
+    }).toList();
+    return {0: infos};
+  }
+
   @override
   Future<void> init() async {
     await _initAddresses();
 
     await ZcashTaddressRotation.init();
-    int accountIndex = 0;
-    addressInfos = {
-      0:
-          ZcashTaddressRotation.allAddressesForAccount(accountId)?.map((final v) {
-            return WalletInfoAddressInfo(
-              walletInfoId: walletInfo.internalId,
-              mapKey: ++accountIndex,
-              accountIndex: 0,
-              address: v,
-              label: "",
-            );
-          }).toList() ??
-          [],
-    };
+    addressInfos = _buildTransparentAddressInfos(_labelsByAddress());
     hiddenAddresses.addAll(
       ZcashTaddressRotation.allUsedAddressesForAccount(accountId)?.toSet() ?? {},
     );
@@ -227,8 +248,24 @@ abstract class ZcashWalletAddressesBase extends WalletAddresses with Store {
     if (addressPageType != ZcashAddressType.transparentRotated) {
       return [];
     }
+    final knownAddresses = addressInfos.values
+        .expand((final infos) => infos)
+        .map((final info) => info.address)
+        .toSet();
+    final currentAddresses = ZcashTaddressRotation.accountsForAccount(accountId)
+        .map((final account) => WarpApi.getTAddr(coin, account.id))
+        .toSet();
+    if (knownAddresses.length != currentAddresses.length ||
+        !knownAddresses.containsAll(currentAddresses)) {
+      addressInfos = _buildTransparentAddressInfos(_labelsByAddress());
+    }
+
     final List<WalletInfoAddressInfo> allInfos = [];
     for (final entry in addressInfos.entries) {
+      for (final info in entry.value) {
+        info.txCount = ZcashTaddressRotation.txCountForAddress(info.address);
+        info.balance = ZcashTaddressRotation.balanceForAddress(info.address);
+      }
       allInfos.addAll(entry.value);
     }
     return allInfos;

--- a/lib/new-ui/pages/receive_page.dart
+++ b/lib/new-ui/pages/receive_page.dart
@@ -213,15 +213,25 @@ class _NewReceivePageState extends State<NewReceivePage> {
                       icon: _largeQrMode ? Icon(Icons.share) : widget.addressListViewModel.isRotatingAddress
                           ? CupertinoActivityIndicator()
                           : Icon(Icons.refresh),
-                      onPressed: () {
+                      onPressed: () async {
                         if(_largeQrMode) {
-                              ShareUtil.share(
-                                text: widget.addressListViewModel.uri.toString(),
-                                context: context,
+                          ShareUtil.share(
+                            text: widget.addressListViewModel.uri.toString(),
+                            context: context,
+                          );
+                        } else if(widget.addressListViewModel.hasAddressRotation) {
+                          try {
+                            await widget.addressListViewModel.rotateAddress();
+                          } catch (e) {
+                            if (mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text(
+                                    e.toString().replaceFirst("Bad state: ", ""),
+                                  ),
+                                ),
                               );
-                        } else {
-                          if(widget.addressListViewModel.hasAddressRotation) {
-                            widget.addressListViewModel.rotateAddress();
+                            }
                           }
                         }
                       }):SizedBox.shrink(),

--- a/lib/view_model/wallet_address_list/wallet_address_edit_or_create_view_model.dart
+++ b/lib/view_model/wallet_address_list/wallet_address_edit_or_create_view_model.dart
@@ -121,6 +121,18 @@ abstract class WalletAddressEditOrCreateViewModelBase with Store {
       return;
     }
 
+    if (wallet.type == WalletType.zcash) {
+      for (final infos in wallet.walletAddresses.addressInfos.values) {
+        for (final info in infos) {
+          if (info.address == _item!.address) {
+            info.label = label;
+          }
+        }
+      }
+      await wallet.walletAddresses.saveAddressesInBox();
+      return;
+    }
+
     final index = _item?.id;
     if (index != null) {
       if (wallet.type == WalletType.monero) {

--- a/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
+++ b/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
@@ -483,7 +483,7 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
       ].contains(wallet.type) && !isLightning && isZCashTransparent;
 
   @computed
-  bool get hasAddressRotation => hasAddressList && wallet.type != WalletType.zcash;
+  bool get hasAddressRotation => hasAddressList;
 
   @computed
   bool get isElectrumWallet => [
@@ -634,8 +634,16 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
     }
     try {
       isRotatingAddress = true;
-      await createNewAddress(wallet, "");
-      wallet.walletAddresses.address = addressList.whereType<WalletAddressListItem>().last.address;
+      if (wallet.type == WalletType.zcash) {
+        if (!isZCashTransparent) {
+          throw StateError("A disposable transparent address type must be selected");
+        }
+        wallet.walletAddresses.address = await zcash!.generateNewTransparentAddress(wallet);
+      } else {
+        await createNewAddress(wallet, "");
+        wallet.walletAddresses.address =
+            addressList.whereType<WalletAddressListItem>().last.address;
+      }
     } finally {
       isRotatingAddress = false;
     }

--- a/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
+++ b/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
@@ -368,8 +368,17 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
     if (wallet.type == WalletType.zcash) {
       final addrInfos = zcash!.getAddressInfos(wallet);
       addrInfos.forEach((info) {
-        addressList.add(
-            new WalletAddressListItem(isPrimary: false, address: info.address, name: info.label));
+        addressList.add(WalletAddressListItem(
+          id: info.mapKey,
+          isPrimary: false,
+          address: info.address,
+          name: info.label,
+          txCount: info.txCount,
+          balance: info.balance == null
+              ? null
+              : _appStore.amountParsingProxy
+                  .getDisplayCryptoString(info.balance!, walletTypeToCryptoCurrency(type)),
+        ));
       });
     }
 
@@ -566,7 +575,8 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
   String get monoImage => getChainMonoImage(type);
 
   @computed
-  bool get isBalanceAvailable => isElectrumWallet;
+  bool get isBalanceAvailable =>
+      isElectrumWallet || (wallet.type == WalletType.zcash && isZCashTransparent);
 
   @computed
   bool get isReceivedAvailable => [WalletType.monero, WalletType.wownero].contains(wallet.type);

--- a/lib/zcash/cw_zcash.dart
+++ b/lib/zcash/cw_zcash.dart
@@ -147,6 +147,13 @@ class CWZcash extends Zcash {
   }
 
   @override
+  Future<String> generateNewTransparentAddress(Object wallet) {
+    final zcashWallet = wallet as ZcashWallet;
+    return (zcashWallet.walletAddresses as ZcashWalletAddresses)
+        .generateNewTransparentAddress();
+  }
+
+  @override
   TransactionPriority getDefaultTransactionPriority() {
     return MoneroTransactionPriority.automatic;
   }

--- a/tool/configure.dart
+++ b/tool/configure.dart
@@ -1751,6 +1751,7 @@ abstract class Zcash {
   String formatterZcashAmountToString({required int amount});
 
   List<WalletInfoAddressInfo> getAddressInfos(Object wallet);
+  Future<String> generateNewTransparentAddress(Object wallet);
 
   TransactionPriority getDefaultTransactionPriority();
   TransactionPriority getZcashTransactionPriorityAutomatic();


### PR DESCRIPTION
Issue Number (if Applicable): N/A

# Description

This is an experimental, stacked proposal that adds on-demand generation of disposable Zcash transparent addresses.

It currently depends on #3371. The branch includes that PR's metadata commit and should be rebased after #3371 is merged.

## Design

Cake Wallet already derives disposable transparent addresses by creating indexed accounts from its offset-seed scheme. This proposal exposes creation of the next indexed account through the receive-page rotation button.

To keep seed recovery deterministic:

- Manual generation stops before 20 consecutive unused derived accounts exist.
- A restored wallet scans/derives accounts until it finds 20 consecutive unused addresses.
- The normal background pool continues to maintain at least five usable addresses.
- Recovery does not delete derived accounts.

The UI awaits generation, prevents duplicate button presses, selects the newly generated address, and displays generation or gap-limit errors in a snackbar.

## Open review questions

- Is the existing offset-seed account derivation acceptable as a long-term public address-generation mechanism?
- Is a gap limit of 20 appropriate for Cake Wallet's Zcash recovery model?
- Should manual generation live behind an advanced setting rather than the receive-page rotation action?

## Validation required

- Generate multiple transparent addresses on a physical device.
- Receive funds on non-consecutive generated addresses.
- Restore the seed on a clean installation and verify address/fund discovery.
- Verify automatic shielding and address rotation after recovery.
- Run TalkBack and compact-screen checks.

Only `git diff --check` was available locally. Native Zcash and device testing must be completed before this draft is considered merge-ready.

# Pull Request - Checklist

- [ ] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed
