### PR TITLE
Shuffle output order on bitcoin sends

### DIFF
--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -1536,7 +1536,7 @@ abstract class ElectrumWalletBase
           network: network,
           memo: estimatedTx.memo,
           inputOrdering: BitcoinOrdering.shuffle,
-          outputOrdering: BitcoinOrdering.none,
+          outputOrdering: BitcoinOrdering.shuffle,
           enableRBF: !estimatedTx.spendsUnconfirmedTX,
         );
       }
@@ -2297,7 +2297,7 @@ abstract class ElectrumWalletBase
         network: network,
         memo: memo,
         inputOrdering: BitcoinOrdering.shuffle,
-        outputOrdering: BitcoinOrdering.none,
+        outputOrdering: BitcoinOrdering.shuffle,
         enableRBF: true,
       );
 


### PR DESCRIPTION
change was placed deterministically last (`BitcoinOrdering.none`), identifiable by position. Switch the two on-chain builders (main + RBF) to `BitcoinOrdering.shuffle`. Change is found by `isChange`, not position.

ref: https://github.com/payjoin/rust-payjoin/issues/1597#issuecomment-4618489879

closes #3376 