### PR TITLE
Shuffle input order on bitcoin sends

### DIFF
--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -1539,6 +1539,7 @@ abstract class ElectrumWalletBase
           fee: estimatedTx.fee.amount,
           network: network,
           memo: estimatedTx.memo,
+          inputOrdering: BitcoinOrdering.shuffle,
           outputOrdering: BitcoinOrdering.none,
           enableRBF: !estimatedTx.spendsUnconfirmedTX,
         );
@@ -2329,6 +2330,7 @@ abstract class ElectrumWalletBase
         fee: BigInt.from(newFee),
         network: network,
         memo: memo,
+        inputOrdering: BitcoinOrdering.shuffle,
         outputOrdering: BitcoinOrdering.none,
         enableRBF: true,
       );


### PR DESCRIPTION
Inputs were BIP-69 sorted (`bitcoin_base` default `inputOrdering: bip69`, never overridden), identifiable from the tx alone. Set `inputOrdering: BitcoinOrdering.shuffle` on the two on-chain builders (main + RBF). BCH and the hardware-wallet path are left as-is.

ref: [payjoin/rust-payjoin#1597 (comment)](https://github.com/payjoin/rust-payjoin/issues/1597#issuecomment-4622384284)

closes #3378