### PR TITLE
disable dismissing or dragging down SendConfirmSheet

### DIFF
--- a/lib/new-ui/pages/send_page.dart
+++ b/lib/new-ui/pages/send_page.dart
@@ -803,6 +803,8 @@ class _NewSendPageState extends State<NewSendPage> {
           }
           showModalBottomSheet(
               isScrollControlled: true,
+              isDismissible: false,
+              enableDrag: false,
               context: navigatorKey.currentContext ?? context,
               backgroundColor: Colors.transparent,
               builder: (context) {


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Prevents accidentally closing the confirmation sheet while the transaction is being generated. The only way to close the sheet is via the "x" button or the Android back button.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
