### PR TITLE
payjoin: exclude 0-conf inputs from receiver candidates

### DIFF
--- a/cw_bitcoin/lib/bitcoin_wallet.dart
+++ b/cw_bitcoin/lib/bitcoin_wallet.dart
@@ -551,8 +551,8 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
     return tx;
   }
 
-  List<UtxoWithPrivateKey> getUtxoWithPrivateKeys() => unspentCoins
-      .where((e) => (e.isSending && !e.isFrozen))
+  List<UtxoWithPrivateKey> getUtxoWithPrivateKeys({bool confirmedOnly = false}) => unspentCoins
+      .where((e) => e.isSending && !e.isFrozen && (!confirmedOnly || (e.confirmations ?? 0) > 0))
       .map((unspent) => UtxoWithPrivateKey.fromUnspent(unspent, this))
       .toList();
 

--- a/cw_bitcoin/lib/payjoin/manager.dart
+++ b/cw_bitcoin/lib/payjoin/manager.dart
@@ -297,10 +297,10 @@ class PayjoinManager {
               break;
 
             case PayjoinReceiverRequestTypes.getCandidateInputs:
-              utxos = _wallet.getUtxoWithPrivateKeys();
+              utxos = _wallet.getUtxoWithPrivateKeys(confirmedOnly: true);
               if (utxos.isEmpty) {
                 await _wallet.updateAllUnspents();
-                utxos = _wallet.getUtxoWithPrivateKeys();
+                utxos = _wallet.getUtxoWithPrivateKeys(confirmedOnly: true);
               }
               mainToIsolateSendPort?.send({
                 'requestId': message['requestId'],


### PR DESCRIPTION
the payjoin receiver's candidate list (`getCandidateInputs` → `getUtxoWithPrivateKeys()`) filtered only `isSending && !isFrozen`, never confirmation depth, so the receiver could contribute a 0-conf input, a temporal fingerprint (an unconfirmed-ancestor spend is observable and lets an analyst partition the payjoin's inputs by owner), and a 0-conf parent can be RBF'd out, invalidating the payjoin.

adds an opt-in `confirmedOnly` flag to `getUtxoWithPrivateKeys`, set only on the receiver candidate path. Scoped to payjoin receiving; signing and normal sends are unaffected.

ref: https://github.com/payjoin/rust-payjoin/issues/1597#issuecomment-4649767163

closes #3388 