### PR TITLE
feat: add `ToMoney` extension for double type and refactor currency amount conversions

### DIFF
--- a/cw_core/lib/amount/money_double.dart
+++ b/cw_core/lib/amount/money_double.dart
@@ -1,0 +1,13 @@
+import 'dart:math';
+import 'package:cw_core/amount/money.dart';
+import 'package:cw_core/currency.dart';
+
+extension ToMoney on double {
+  /// Turn a double representation of a currency amount to a proper Money representation
+  /// truncating currencies with more than 20 decimals because double can not handle more
+  Money? tryToMoney(Currency currency) =>
+      Money.tryParse(toStringAsFixed(min(currency.decimals, 20)), currency);
+
+  Money toMoney(Currency currency) =>
+      Money.parse(toStringAsFixed(min(currency.decimals, 20)), currency);
+}

--- a/cw_solana/lib/solana_client.dart
+++ b/cw_solana/lib/solana_client.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:blockchain_utils/blockchain_utils.dart';
 import 'package:cw_core/amount/money.dart';
+import 'package:cw_core/amount/money_double.dart';
 import 'package:cw_core/crypto_currency.dart';
 import 'package:cw_core/currency.dart';
 import 'package:cw_core/node.dart';
@@ -654,7 +655,7 @@ class SolanaWalletClient {
         from: outgoingFrom,
         to: outgoingTo,
         id: outgoingId,
-        amount: Money.parse(outgoingAmount.toStringAsFixed(outgoingToken.decimals), outgoingToken),
+        amount: outgoingAmount.toMoney(outgoingToken),
         programId: outgoingMintAddress == null
             ? SystemProgramConst.programId.address
             : SPLTokenProgramConst.tokenProgramId.address,
@@ -672,7 +673,7 @@ class SolanaWalletClient {
         from: incomingFrom,
         to: incomingTo,
         id: incomingId,
-        amount: Money.parse(incomingAmount.toStringAsFixed(incomingToken.decimals), incomingToken),
+        amount: incomingAmount.toMoney(incomingToken),
         programId: incomingMintAddress == null
             ? SystemProgramConst.programId.address
             : SPLTokenProgramConst.tokenProgramId.address,
@@ -869,8 +870,7 @@ class SolanaWalletClient {
       from: sender,
       to: receiver,
       id: signature,
-      amount: Money.parse(amount.toStringAsFixed((splToken ?? CryptoCurrency.sol).decimals),
-          splToken ?? CryptoCurrency.sol),
+      amount: amount.toMoney(splToken ?? CryptoCurrency.sol),
       programId: SPLTokenProgramConst.tokenProgramId.address,
       blockTimeInInt: blockTime?.toInt() ?? 0,
       fee: Money.fromInt(fee, CryptoCurrency.sol),

--- a/lib/view_model/exchange/exchange_view_model.dart
+++ b/lib/view_model/exchange/exchange_view_model.dart
@@ -45,6 +45,7 @@ import 'package:cake_wallet/store/app_store.dart';
 import 'package:cake_wallet/utils/exchange_provider_logger.dart';
 import 'package:cw_core/amount/amount_sanitizer.dart';
 import 'package:cw_core/amount/money.dart';
+import 'package:cw_core/amount/money_double.dart';
 import "package:cw_core/wallet_info.dart";
 import 'package:cake_wallet/store/dashboard/fiat_conversion_store.dart';
 import 'package:cake_wallet/store/dashboard/trades_store.dart';
@@ -804,7 +805,7 @@ abstract class ExchangeViewModelBase extends WalletChangeListenerViewModel with 
     }
 
     final amount_ = _enteredAmount / (forcedProvider == null ? bestRate : forcedProviderRate);
-    _depositAmount = Money.tryParse(amount_.toStringAsFixed(depositCurrency.decimals), depositCurrency);
+    _depositAmount = amount_.tryToMoney(depositCurrency);
   }
 
   @action
@@ -863,8 +864,7 @@ abstract class ExchangeViewModelBase extends WalletChangeListenerViewModel with 
     }
 
     final amount_ = _enteredAmount * (forcedProvider == null ? bestRate : forcedProviderRate);
-    _receiveAmount =
-        Money.tryParse(amount_.toStringAsFixed(min(20, receiveCurrency.decimals)), receiveCurrency);
+    _receiveAmount = amount_.tryToMoney(receiveCurrency);
   }
 
   bool checkIfInputMeetsMinOrMaxCondition(String input) {


### PR DESCRIPTION
# Description

This improves the reliability of the conversion from double Money for edge cases with many decimals

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed 
