### PR TITLE
readme: remove wownero from supported cryptocurrency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Cake Wallet includes support for several cryptocurrencies, including:
 * Nano (XNO)
 * Zano (ZANO)
 * Decred (DCR)
-* Wownero (WOW)
 
 ## Features
 


### PR DESCRIPTION
Removed Wownero (WOW) from the list of supported cryptocurrencies.

Issue Number (if Applicable): Fixes #3411