### PR TITLE
Improve code of SP stealth addresses

### DIFF
--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -1536,7 +1536,7 @@ abstract class ElectrumWalletBase
           network: network,
           memo: estimatedTx.memo,
           inputOrdering: BitcoinOrdering.shuffle,
-          outputOrdering: BitcoinOrdering.none,
+          outputOrdering: BitcoinOrdering.shuffle,
           enableRBF: !estimatedTx.spendsUnconfirmedTX,
         );
       }
@@ -1594,6 +1594,7 @@ abstract class ElectrumWalletBase
         isSendAll: estimatedTx.isSendAll,
         hasTaprootInputs: hasTaprootInputs,
         utxos: estimatedTx.utxos,
+        derivedOutputs: updatedOutputs,
         publicKeys: estimatedTx.publicKeys,
         isViewOnly: keys.privateKey.isEmpty,
       )..addListener((transaction) async {
@@ -2297,7 +2298,7 @@ abstract class ElectrumWalletBase
         network: network,
         memo: memo,
         inputOrdering: BitcoinOrdering.shuffle,
-        outputOrdering: BitcoinOrdering.none,
+        outputOrdering: BitcoinOrdering.shuffle,
         enableRBF: true,
       );
 

--- a/cw_bitcoin/lib/pending_bitcoin_transaction.dart
+++ b/cw_bitcoin/lib/pending_bitcoin_transaction.dart
@@ -31,6 +31,7 @@ class PendingBitcoinTransaction with PendingTransaction {
     this.hasTaprootInputs = false,
     this.isMweb = false,
     this.utxos = const [],
+    this.derivedOutputs = const [],
     this.publicKeys,
     this.commitOverride,
     this.unsignedPsbt,
@@ -47,6 +48,9 @@ class PendingBitcoinTransaction with PendingTransaction {
   final bool hasTaprootInputs;
   final bool isViewOnly;
   List<UtxoWithAddress> utxos;
+
+  final List<BitcoinOutput> derivedOutputs;
+
   bool isMweb;
   String? changeAddressOverride;
   String? idOverride;
@@ -78,6 +82,13 @@ class PendingBitcoinTransaction with PendingTransaction {
   List<TxOutput> get outputs => _tx.outputs;
 
   bool get hasSilentPayment => _tx.hasSilentPayment;
+
+  List<String?> get stealthAddresses => derivedOutputs
+      .where((out) => !out.isChange)
+      .map((out) => out.isSilentPayment
+          ? out.address.toAddress(network ?? BitcoinNetwork.mainnet)
+          : null)
+      .toList();
 
   PendingChange? get change {
     try {

--- a/lib/bitcoin/cw_bitcoin.dart
+++ b/lib/bitcoin/cw_bitcoin.dart
@@ -687,28 +687,20 @@ class CWBitcoin extends Bitcoin {
   }
 
   List<Output> updateOutputs(PendingTransaction pendingTransaction, List<Output> outputs) {
-    if (pendingTransaction is PendingLightningTransaction) return outputs;
-
-    final pendingTx = pendingTransaction as PendingBitcoinTransaction;
-
-    if (!pendingTx.hasSilentPayment) {
+    if (pendingTransaction is! PendingBitcoinTransaction || !pendingTransaction.hasSilentPayment) {
       return outputs;
     }
 
-    final updatedOutputs = outputs.map((output) {
-      try {
-        final pendingOut = pendingTx.outputs[outputs.indexOf(output)];
-        final updatedOutput = output;
+    final stealthAddresses = pendingTransaction.stealthAddresses;
+    if (stealthAddresses.length != outputs.length) {
+      printV("well, that shouldn't happen");
+      return outputs;
+    }
 
-        updatedOutput.stealthAddress = P2trAddress.fromScriptPubkey(script: pendingOut.scriptPubKey)
-            .toAddress(BitcoinNetwork.mainnet);
-        return updatedOutput;
-      } catch (_) {}
-
-      return output;
-    }).toList();
-
-    return updatedOutputs;
+    for (var i = 0; i < outputs.length; i++) {
+      outputs[i].stealthAddress = stealthAddresses[i];
+    }
+    return outputs;
   }
 
   @override


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Make the SP stealth addresses not reliant on output index

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
