### PR TITLE
Add onionbalance Tor frontends to default node lists

### DIFF
--- a/assets/bitcoin_electrum_server_list.yml
+++ b/assets/bitcoin_electrum_server_list.yml
@@ -10,6 +10,11 @@
   isOfficial: true
   label: "Cake Wallet Electrs"
 -
+  uri: cakebtc5pihzt3byjclxfumiwvtxj72auarshrsvmaatmwmr7dj6zyid.onion:50001
+  useSSL: false
+  isOfficial: true
+  label: "Cake Wallet (Tor)"
+-
   uri: fulcrum.sethforprivacy.com:50002
   useSSL: true
   isEnabledForAutoSwitching: true

--- a/assets/litecoin_electrum_server_list.yml
+++ b/assets/litecoin_electrum_server_list.yml
@@ -6,6 +6,11 @@
   isEnabledForAutoSwitching: true
   label: "Cake Wallet"
 -
+  uri: cakeltcnzbdxhk3dhlzxjnnylxbfhhbx2njegaluyh35t7dca35vcnqd.onion:50001
+  useSSL: false
+  isOfficial: true
+  label: "Cake Wallet (Tor)"
+-
   uri: litecoin.stackwallet.com:20063
   useSSL: true
   isEnabledForAutoSwitching: true

--- a/assets/node_list.yml
+++ b/assets/node_list.yml
@@ -7,8 +7,9 @@
   useSSL: true
   isEnabledForAutoSwitching: true
 -
-  label: "Cake Wallet (Onion)"
-  uri: cakexmrl7bonq7ovjka5kuwuyd3f7qnkz6z6s6dmsy3uckwra7bvggyd.onion:18081
+  label: "Cake Wallet (Tor)"
+  uri: cakexmrkbd7ptshw7vfzhzqgg77xgeavdrxm6zbu57lppfkj3fczbrqd.onion:18081
+  isOfficial: true
 -
   label: "Seth For Privacy"
   uri: node.sethforprivacy.com:443

--- a/assets/zcash_node_list.yml
+++ b/assets/zcash_node_list.yml
@@ -15,7 +15,3 @@
   useSSL: false
   isOfficial: true
   label: "Cake Wallet (Tor)"
--
-  uri: bvp2l442g5ogma7rywzahm7eqyhpp3g26n3gvvxeioqn5csio2ir6myd.onion:9067
-  useSSL: false
-  label: "Cake Wallet (Tor #2)"

--- a/assets/zcash_node_list.yml
+++ b/assets/zcash_node_list.yml
@@ -11,8 +11,9 @@
   isEnabledForAutoSwitching: true
   label: "Zec.rocks"
 -
-  uri: 2c4whzg26j6hgjh22rxynj3oig4gm22ga7x74weclujywxye23v3u5id.onion:9067
+  uri: cakezecgh6enylxz3yya52pu4rq3bojy7zfhvnegqkq4qbbpzderjiqd.onion:9067
   useSSL: false
+  isOfficial: true
   label: "Cake Wallet (Tor)"
 -
   uri: bvp2l442g5ogma7rywzahm7eqyhpp3g26n3gvvxeioqn5csio2ir6myd.onion:9067

--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -761,7 +761,11 @@ abstract class ElectrumWalletBase
     if (await checkIfMempoolAPIIsEnabled() && type == WalletType.bitcoin) {
       try {
         final response = await ProxyWrapper()
-            .get(clearnetUri: Uri.parse("https://mempool.cakewallet.com/api/v1/fees/recommended"))
+            .get(
+              clearnetUri: Uri.parse("https://mempool.cakewallet.com/api/v1/fees/recommended"),
+              onionUri: Uri.parse(
+                  "http://cakememcninjdqbaub3tp2iswuigxqtdoevnpgzkolmy4gvhrrsub3yd.onion/api/v1/fees/recommended"),
+            )
             .timeout(Duration(seconds: 15));
 
         final result = json.decode(response.body) as Map<String, dynamic>;


### PR DESCRIPTION
## What

Adds the new load-balanced onionbalance Tor frontends to the default node configs:

| Fleet | Port | Onion |
|---|---|---|
| Monero | 18081 | `cakexmrkbd7...brqd.onion` — replaces the old per-instance onion |
| Zcash | 9067 | `cakezecgh6e...jiqd.onion` — replaces both old per-instance Tor nodes |
| Bitcoin | 50001 | `cakebtc5pih...zyid.onion` — new entry |
| Litecoin | 50001 | `cakeltcnzbd...cnqd.onion` — new entry |
| Mempool | 80 | `cakememcnin...b3yd.onion` — used for BTC fee fetching over Tor |

## Details

- All Cake Tor nodes are marked `isOfficial: true` so they get the official-node badge in the node list.
- Bitcoin fee fetching (`updateFeeRates`) now passes the mempool onion frontend as `onionUri` to `ProxyWrapper().get()`, so it is used automatically whenever the in-app Tor is enabled (ProxyWrapper prefers the onion URI when Tor is started).
- The old per-instance Zcash onions ("Cake Wallet (Tor)" and "Cake Wallet (Tor #2)") are both replaced by the single onionbalance frontend; the old endpoints stay up in prod for users on older app versions.
- No migration needed: `validateBuiltinNodes()` runs at startup and syncs built-in nodes from the yml lists into the DB for existing users (removing the old onion entries and adding the new ones).

Out of scope (future PR): automatically switching node selection to the Tor node when a user enables Tor, unless they're on a custom non-default node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)