### PR TITLE
Fix typo in multichain receive infobox (addess → address)

### DIFF
--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -556,7 +556,7 @@
   "incorrect_seed_option": "Incorrect. Please try again",
   "incorrect_seed_option_back": "Incorrect. Please make sure your seed is saved correctly and try again.",
   "infobox_auto_address": "Your receive address will rotate every time you receive a transaction",
-  "infobox_multichain": "Use this addess to receive any token or collectible on",
+  "infobox_multichain": "Use this address to receive any token or collectible on",
   "infobox_rotation": "Your receive address will rotate every time you close and reopen this screen",
   "input": "Input",
   "inputs": "Inputs",


### PR DESCRIPTION
## Description

Fixes a typo in the multichain receive screen infobox. On the EVM (Ethereum) receive screen the notice read:

> Use this **addess** to receive any token or collectible on Ethereum

"addess" → "address".

## Change

Single-string fix to `infobox_multichain` in `res/values/strings_en.arb`. Only the English source string was affected — all other locales already have correct translations of this key.

## Verification

Verified in production v6.3.1 on the Ethereum wallet receive screen.