### PR TITLE
Fix domain lookup toggles for Yat and Zcash.me providers

### DIFF
--- a/lib/core/address_resolver/yat/yat_address_provider.dart
+++ b/lib/core/address_resolver/yat/yat_address_provider.dart
@@ -20,7 +20,7 @@ class YatAddressProvider extends AddressLookupProvider {
   bool canHandle(String q) => q.hasOnlyEmojis; // Yat handle example: 🐶🐾
 
   @override
-  bool isEnabled(SettingsStore settingsStore) => settingsStore.lookupsWellKnown;
+  bool isEnabled(SettingsStore settingsStore) => settingsStore.lookupsYatService;
 
   @override
   Future<List<ParsedAddress>> resolve({

--- a/lib/core/address_resolver/zcash/zcash_me_address_provider.dart
+++ b/lib/core/address_resolver/zcash/zcash_me_address_provider.dart
@@ -15,7 +15,7 @@ class ZcashMeAddressProvider extends AddressLookupProvider {
   List<CryptoCurrency> get supportedCurrencies => [CryptoCurrency.zec];
 
   @override
-  bool isEnabled(SettingsStore settingsStore) => settingsStore.lookupsZcashNames;
+  bool isEnabled(SettingsStore settingsStore) => settingsStore.lookupsZcashAddress;
 
   @override
   bool canHandle(String query) {


### PR DESCRIPTION
## Problem

Two address-lookup providers checked the wrong `SettingsStore` flag in their `isEnabled()`, so the corresponding toggles in **Settings > Connection and sync > Domain lookups** had no effect:

1. **Yat** — `YatAddressProvider.isEnabled` read `settingsStore.lookupsWellKnown`, but the "Yat" toggle reads/writes `lookupsYatService` (see `ConnectionSyncViewModel.lookupValue`/`setLookupValue`, `AddressSource.yatRecord`). As a result, toggling "Yat" off did nothing, and toggling ".wellknown" off unexpectedly disabled Yat too.
2. **Zcash.me** — `ZcashMeAddressProvider.isEnabled` read `settingsStore.lookupsZcashNames`, but the "Zcash.me" toggle reads/writes `lookupsZcashAddress` (`AddressSource.zcashAddress`). As a result, the "Zcash.me" toggle did nothing and it was instead gated by the "Zcash Names" toggle.

## Fix

Each provider now reads the flag its own toggle actually writes:

- `YatAddressProvider.isEnabled` → `settingsStore.lookupsYatService`
- `ZcashMeAddressProvider.isEnabled` → `settingsStore.lookupsZcashAddress`

Both flags are existing non-nullable `bool` fields in `SettingsStore`, so there is no null-safety impact. The `.wellknown` and "Zcash Names" toggles now only affect their own providers.

## Verification

Cross-checked against the toggle mapping in `lib/view_model/settings/connection_sync_view_model.dart` (`lookupValue`/`setLookupValue`) and the flag definitions in `lib/store/settings_store.dart`.