### PR TITLE
Fix stale seed location path in seed_display_path

### DIFF
--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -947,7 +947,7 @@
   "seed_alert_yes": "Yes, I have",
   "seed_and_keys": "Seed & Keys",
   "seed_choose": "Choose seed language",
-  "seed_display_path": "Menu → Security and Backup → Show key/seeds",
+  "seed_display_path": "Settings → Wallet settings → Seed & Keys",
   "seed_hex_form": "Wallet seed (hex form)",
   "seed_key": "Seed key",
   "seed_language": "Seed language",


### PR DESCRIPTION
## Problem

`seed_display_path` still describes the old UI navigation:

```
"seed_display_path": "Menu → Security and Backup → Show key/seeds",
```

With `FeatureFlag.hasNewUi = true` (`lib/utils/feature_flag.dart:20`) that path doesn't exist in the shipping app: there's no "Menu", and the "Show seed/keys" row is commented out of the Security page (`lib/src/screens/settings/security_backup_page.dart:155-159`).

The real path is **Settings → Wallet settings → Seed & Keys** — the settings modal's top bar reads "Settings" (`lib/new-ui/pages/settings_page.dart:154`), the section header is `wallet_settings` = "Wallet settings", and the row is `seed_and_keys` = "Seed & Keys" → `Routes.showKeys` (`lib/new-ui/pages/settings_page.dart:61-62`).

## Fix

One-line change to the English string.

## Where it renders

Both call sites are reachable in the new UI, and in both the string is the bolded tail of a sentence, so the bare path works exactly as before:

| Site | Preceding text | Renders as |
|---|---|---|
| `lib/src/screens/seed/seed_verification/seed_verification_success_view.dart:54` | `seed_verified_subtext` — "…You can view this seed again from the" | "…from the **Settings → Wallet settings → Seed & Keys**" |
| `lib/src/screens/new_wallet/wallet_group_existing_seed_description_page.dart:57` | `wallet_group_description_view_seed` — "You can always view this seed again under" | "…under **Settings → Wallet settings → Seed & Keys**" |

## Translations

English only, matching the convention for changed source strings (see #3436). `are_translations_sane.yml` only validates JSON; the 31 locale files keep the key and go through the translation pipeline. `jq` passes on all of them.