### PR TITLE
Fix mismatched support links for SwapTrade and Telegram

### DIFF
--- a/lib/view_model/support_view_model.dart
+++ b/lib/view_model/support_view_model.dart
@@ -44,7 +44,7 @@ abstract class SupportViewModelBase with Store {
           LinkListItem(
               title: 'Telegram',
               icon: 'assets/images/Telegram.png',
-              linkTitle: 't.me/cakewallet',
+              linkTitle: 't.me/cakewalletannouncements',
               link: 'https://t.me/cakewalletannouncements'),
           LinkListItem(
               title: 'Telegram Support Bot',
@@ -75,7 +75,7 @@ abstract class SupportViewModelBase with Store {
               title: 'SwapTrade',
               icon: 'assets/images/swap_trade.png',
               linkTitle: 'help.swaptrade.io',
-              link: 'mailto:support@exolix.com'),
+              link: 'https://help.swaptrade.io/contact/'),
           LinkListItem(
               title: 'Trocador',
               icon: 'assets/images/trocador.png',


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Two entries in `SupportViewModel`'s link list displayed one destination but opened another.

### SwapTrade — wrong provider

`lib/view_model/support_view_model.dart` pointed SwapTrade's link at `mailto:support@exolix.com`, while the visible label read `help.swaptrade.io`. A user with a SwapTrade trade problem tapped SwapTrade support and emailed **Exolix** — who cannot help them, and who absorbed another provider's support traffic.

The bug is older than the SwapTrade name. `git log -S` shows the entry was added as **Quantex** with `linkTitle: 'help.myquantex.com'` and `link: 'mailto:support@exolix.com'`, so Exolix's mailto was copy-pasted from the entry directly above it from the start. ef377fb53 ("Change Quantex to SwapTrade") updated the title, icon, and `linkTitle`, but carried the wrong `link` forward.

Now points at `https://help.swaptrade.io/contact/`:

- Matches what `docs.cakewallet.com/support/swap` already lists for SwapTrade ("Live Chat" via `help.swaptrade.io/contact/`), so the app and the public docs agree.
- Live chat is the **only** contact method that help center publishes — no SwapTrade support email exists — so a `mailto:` alternative isn't available even if we'd prefer one.
- A path below the displayed host matches existing style in this file: the commented-out SideShift entry pairs `linkTitle: 'help.sideshift.ai'` with `link: 'https://help.sideshift.ai/en/'`.

### Telegram — stale label

The inverse problem: `linkTitle` read `t.me/cakewallet` while the link went to `https://t.me/cakewalletannouncements`.

Here the **link** was the correct half. `t.me/cakewallet` exists as a group named "Cake Wallet Community", but self-describes as *"Inactive Cake Wallet Community"* and tells visitors to go to the announcements channel instead. `t.me/cakewalletannouncements` is an active channel (851 subscribers). Sending users to the group the group itself disowns would be a regression, so the stale label was updated to match the destination rather than the reverse.

### Full audit

All 17 entries were checked, not just the reported one. The remaining 15 are consistent: the `mailto:` entries all display the address they open (Email, ChangeNow, SimpleSwap, Exolix, Trocador, DFX, Kryptonim), the `https://` entries display their host (Website, Forum, Discord, Telegram Support Bot), and four use intentionally generic labels where a literal match doesn't apply — GitHub (`S.current.apk_update` → releases), Onramper (`View exchanges` → docs), MoonPay and Robinhood (`S.current.submit_request` → their request forms). Each of those four lands where its label promises.

## For reviewers

**Worth confirming with whoever owns the provider relationships.** `help.swaptrade.io` loads and live chat is present, but the page's footer and social links still show **Quantex** branding — it even lists `admin@myquantex.com` and `help.myquantex.com/contact/`. It's the right destination today and the one our docs advertise, but SwapTrade's help center looks only half-rebranded, so it's worth a check that this is the surface we want users landing on.

Data-only change, so `support_view_model.g.dart` needs no regeneration.

# Pull Request - Checklist

- [ ] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed

Both destination URLs were verified as loading and correct by fetching them directly, but the app itself was not built or launched, so the two manual-test boxes are left unchecked for whoever picks this up.
