### PR TITLE
ci: sanitize branch name when naming test APK in reusable-build

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -176,16 +176,18 @@ jobs:
 
       - name: Rename apk file
         run: |
+          sanitized_branch_name=$(grep '^id=' android/app.properties | cut -d'=' -f2 | sed 's/com\.cakewallet\.test_//')
           cd build/app/outputs/flutter-apk
           mkdir test-apk
-          cp app-arm64-v8a-release.apk test-apk/${BRANCH_NAME}.apk
-          cp app-x86_64-release.apk test-apk/${BRANCH_NAME}_x86.apk
+          cp app-arm64-v8a-release.apk test-apk/${sanitized_branch_name}.apk
+          cp app-x86_64-release.apk test-apk/${sanitized_branch_name}_x86.apk
 
       - name: Find APK file
         id: find_apk
         run: |
           set -x
-          apk_file=$(ls build/app/outputs/flutter-apk/test-apk/${BRANCH_NAME}.apk || exit 1)
+          sanitized_branch_name=$(grep '^id=' android/app.properties | cut -d'=' -f2 | sed 's/com\.cakewallet\.test_//')
+          apk_file=$(ls build/app/outputs/flutter-apk/test-apk/${sanitized_branch_name}.apk || exit 1)
           echo "APK_FILE=$apk_file" >> $GITHUB_ENV
       - name: Write BRANCH_NAME to env
         run: echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV


### PR DESCRIPTION
## Problem

The `internal-build` job's **Rename apk file** / **Find APK file** steps in `reusable-build.yml` use the raw `${BRANCH_NAME}` (`github.head_ref`) as the APK filename:

```bash
cp app-arm64-v8a-release.apk test-apk/${BRANCH_NAME}.apk
```

For any branch whose name contains a `/` (e.g. `claude/my-fix`), this expands to `test-apk/claude/my-fix.apk`, and since the intermediate `test-apk/claude/` directory is never created, `cp` fails with:

```
cp: cannot create regular file 'test-apk/<branch>/<name>.apk': No such file or directory
```

which fails the build for slash-named branches.

## Fix

Derive a sanitized branch name from `android/app.properties` (already written earlier in the job as `id=com.cakewallet.test_<sanitized>`), and use it for the APK filenames. This is the exact approach `automated_integration_test.yml` already uses, so the two workflows now behave consistently.

The Slack upload filename still uses the human-readable branch name — that's metadata, not a local path, so slashes there are harmless.

## Notes

Split out of #3439, where this failure first surfaced. This is CI-only; no app code changes.