### PR TITLE
Fix Kryptonim spelling in ProviderType (Kriptonim -> Kryptonim)

### DIFF
--- a/lib/buy/buy_quote.dart
+++ b/lib/buy/buy_quote.dart
@@ -314,7 +314,7 @@ class Quote extends SelectableOption {
         payout: _toDouble(json['amount']) ?? 0.0,
         paymentType: paymentType,
         recommendations: [],
-        provider: ProvidersHelper.getProviderByType(ProviderType.kriptonim),
+        provider: ProvidersHelper.getProviderByType(ProviderType.kryptonim),
         isBuyAction: isBuyAction,
         limits: Limits(min: minLimit, max: maxLimit));
   }

--- a/lib/entities/provider_types.dart
+++ b/lib/entities/provider_types.dart
@@ -7,7 +7,7 @@ import 'package:cake_wallet/buy/onramper/onramper_buy_provider.dart';
 import 'package:cake_wallet/buy/robinhood/robinhood_buy_provider.dart';
 import 'package:cake_wallet/di.dart';
 
-enum ProviderType { robinhood, dfx, onramper, moonpay, meld, kriptonim }
+enum ProviderType { robinhood, dfx, onramper, moonpay, meld, kryptonim }
 
 extension ProviderTypeName on ProviderType {
   String get title {
@@ -22,8 +22,8 @@ extension ProviderTypeName on ProviderType {
         return 'MoonPay';
       case ProviderType.meld:
         return 'Meld';
-      case ProviderType.kriptonim:
-        return 'Kriptonim';
+      case ProviderType.kryptonim:
+        return 'Kryptonim';
     }
   }
 
@@ -39,8 +39,8 @@ extension ProviderTypeName on ProviderType {
         return 'moonpay_provider';
       case ProviderType.meld:
         return 'meld_provider';
-      case ProviderType.kriptonim:
-        return 'kriptonim_provider';
+      case ProviderType.kryptonim:
+        return 'kryptonim_provider';
     }
   }
 }
@@ -51,7 +51,7 @@ class ProvidersHelper {
         ProviderType.dfx,
         ProviderType.onramper,
         ProviderType.moonpay,
-        ProviderType.kriptonim
+        ProviderType.kryptonim
       ];
 
   static List<ProviderType> getAvailableSellProviderTypes() => [
@@ -59,7 +59,7 @@ class ProvidersHelper {
         ProviderType.dfx,
         ProviderType.onramper,
         ProviderType.moonpay,
-        ProviderType.kriptonim
+        ProviderType.kryptonim
       ];
 
   static BuyProvider getProviderByType(ProviderType type) {
@@ -74,7 +74,7 @@ class ProvidersHelper {
         return getIt.get<MoonPayProvider>();
       case ProviderType.meld:
         return getIt.get<MeldBuyProvider>();
-      case ProviderType.kriptonim:
+      case ProviderType.kryptonim:
         return getIt.get<KryptonimBuyProvider>();
     }
   }


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

The buy/sell provider "Kryptonim" was spelled inconsistently. `ProviderType` used the misspelling `Kriptonim`, while the provider class itself already used the correct vendor spelling — [`kryptonim.dart:42`](https://github.com/cake-tech/cake_wallet/blob/dev/lib/buy/kryptonim/kryptonim.dart#L42) returns `'Kryptonim'`. The correct spelling is "Kryptonim" (per [kryptonim.com](https://www.kryptonim.com) and the `lib/buy/kryptonim/` directory name).

This PR aligns `ProviderType` with the vendor name:

- Enum member `ProviderType.kriptonim` -> `ProviderType.kryptonim`
- `ProviderTypeName.title`: `'Kriptonim'` -> `'Kryptonim'`
- `ProviderTypeName.id`: `'kriptonim_provider'` -> `'kryptonim_provider'`

Two files touched: `lib/entities/provider_types.dart` and the one call site in `lib/buy/buy_quote.dart`.

## Not user-visible

To be clear about impact: **users never saw "Kriptonim"** — this was internal cruft, not a display bug. Every provider name rendered in the buy/sell UI comes from `BuyProvider.title` (`buy_quote.dart:55`, `buy_quote.dart:124`, `buy_sell_view_model.dart:287/292/456`), which was already correct for Kryptonim.

In fact both `ProviderTypeName.title` and `ProviderTypeName.id` have **zero call sites anywhere in the repo**. `ProviderType` is referenced in only three files — `provider_types.dart`, `buy_quote.dart` (`getProviderByType`), and `buy_sell_view_model.dart:60/68` (`getAvailableBuy/SellProviderTypes`) — and none of them access `.title` or `.id`. `buy_sell_view_model` maps `ProviderType` -> `BuyProvider` immediately and discards the enum, so nothing downstream holds a `ProviderType` to call `.title` on. The extension is effectively dead code today; this just stops it from being wrong if someone starts using it.

## No migration needed for the `id` rename

Renaming a persisted id would break existing installs, so I checked this specifically before touching it. Nothing persists it:

- **Zero occurrences** of `moonpay_provider`, `onramper_provider`, `meld_provider`, `dfx_connect_provider`, or `robinhood_connect_provider` anywhere outside the `id` getter itself — searched the full repo including native Android/iOS sources, YAML, and JSON. Nothing reads or writes these strings, so there is nothing in shared preferences, analytics, or backup payloads to migrate.
- **The enum is never deserialized either**: `ProviderType.values` and `.name` on a `ProviderType` both have zero occurrences, so no stored index or member name maps back onto the enum. Renaming the member cannot break an upgrade.
- The only persisted provider selection is `exchange-providers-selection` (`exchange_view_model.dart:1656`), which keys off `ExchangeProvider.title` — a separate swap-provider hierarchy that never involves `ProviderType`. Untouched by this PR.

## Note for reviewers on verification

I was not able to run `dart analyze` cleanly: the checkout has no generated `pubspec.yaml` / `.dart_tool`, so every `package:cake_wallet/...` import fails to resolve and the analyzer emits ~200 pre-existing unrelated errors. A real analyze run needs a full `./configure_cake_wallet.sh` + `flutter pub get` first, so **CI is the first actual compile check on this change.**

Instead I verified completeness by exhaustive search, which is sound for a Dart enum member since it is only reachable as `ProviderType.<member>`, via `.values`, or via `.name` — all three confirmed to have no remaining references. A case-insensitive grep for `kriptonim` across the repo now returns nothing. The three `switch` statements remain exhaustive because the declaration and every `case` were renamed in lockstep.

No docs change is needed — docs.cakewallet.com and the existing Buy support page already use "Kryptonim", matching the provider class. This was found while auditing the docs against the code.

# Pull Request - Checklist

- [ ] Initial Manual Tests Passed — not run; see verification note above (rename verified by exhaustive search, CI is the first compile check)
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code — no formatting changes; edits are in-place symbol renames preserving the repo's 100-column style
- [x] Look for code duplication
- [x] Clear naming for variables and methods — this PR is the naming fix
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed — N/A, no user-visible or UI change
