### PR TITLE
Hide the receive rotation notice for static Zcash address types

### DIFF
--- a/lib/new-ui/pages/receive_page.dart
+++ b/lib/new-ui/pages/receive_page.dart
@@ -97,6 +97,10 @@ class _NewReceivePageState extends State<NewReceivePage> {
     ) as WalletAddressListItem?;
 
     reaction((_) => widget.receiveOptionViewModel.selectedReceiveOption, (option) {
+      // The infobox depends on the selected address type, so the page has to be
+      // rebuilt when it changes.
+      if (mounted) setState(() {});
+
       if (widget.dashboardViewModel.type == WalletType.bitcoin &&
           bitcoin!.isBitcoinReceivePageOption(option)) {
         widget.addressListViewModel.setAddressType(bitcoin!.getOptionToType(option));
@@ -179,6 +183,7 @@ class _NewReceivePageState extends State<NewReceivePage> {
       autoGenerateSubaddressStatus: widget.lightningMode
           ? AutoGenerateSubaddressStatus.disabled
           : widget.dashboardViewModel.settingsStore.autoGenerateSubaddressStatus,
+      addressRotates: _selectedAddressRotates,
     );
 
     return Container(
@@ -349,6 +354,13 @@ class _NewReceivePageState extends State<NewReceivePage> {
       ),
     );
   }
+
+  /// Zcash is the only wallet type that also offers static address types, so
+  /// the rotation notice must not be shown for it unless the disposable
+  /// transparent type is the one currently selected.
+  bool get _selectedAddressRotates =>
+      widget.addressListViewModel.type != WalletType.zcash ||
+      zcash!.isRotatingAddressOption(widget.receiveOptionViewModel.selectedReceiveOption);
 
   void _showLabelModal() {
     showMaterialModalBottomSheet(

--- a/lib/new-ui/widgets/receive_page/receive_info_box.dart
+++ b/lib/new-ui/widgets/receive_page/receive_info_box.dart
@@ -16,10 +16,15 @@ class ReceiveInfoBox extends StatelessWidget {
       required this.onDismissed,
       this.bottomWidget});
 
+  /// [addressRotates] tells whether the address type currently selected on the
+  /// receive page actually rotates. Most wallet types only ever expose rotating
+  /// address types, so it defaults to true; Zcash also offers static types, for
+  /// which the rotation notice would be wrong.
   static ReceiveInfoBox? forWalletType(WalletType type,
       {required VoidCallback onDismissed,
       required AutoGenerateSubaddressStatus autoGenerateSubaddressStatus,
-      List<CryptoCurrency>? supportedCurrencies}) {
+      List<CryptoCurrency>? supportedCurrencies,
+      bool addressRotates = true}) {
     switch (type) {
       case WalletType.nano:
         return null;
@@ -43,6 +48,7 @@ class ReceiveInfoBox extends StatelessWidget {
             ));
       default:
         if (autoGenerateSubaddressStatus == AutoGenerateSubaddressStatus.disabled) return null;
+        if (!addressRotates) return null;
         return ReceiveInfoBox(
           iconPath: "assets/new-ui/info.svg",
           message: S.current.infobox_auto_address,

--- a/lib/zcash/cw_zcash.dart
+++ b/lib/zcash/cw_zcash.dart
@@ -170,6 +170,14 @@ class CWZcash extends Zcash {
     return getSelectedAddressType(wallet) == ZcashReceivePageOption.transparentRotated;
   }
 
+  /// The disposable transparent type is the only Zcash address type that
+  /// rotates. The public transparent address, both shielded types and the
+  /// unified address are all derived from the account and stay the same.
+  @override
+  bool isRotatingAddressOption(ReceivePageOption option) {
+    return option == ZcashReceivePageOption.transparentRotated;
+  }
+
   @override
   dynamic getZcashAddressType(ReceivePageOption option) {
     switch (option) {

--- a/tool/configure.dart
+++ b/tool/configure.dart
@@ -1760,6 +1760,7 @@ abstract class Zcash {
   ReceivePageOption getSelectedAddressType(Object wallet);
   dynamic getZcashAddressType(ReceivePageOption option);
   bool hasSelectedTransparentAddress(Object wallet);
+  bool isRotatingAddressOption(ReceivePageOption option);
   Future<void> setAddressType(Object wallet, dynamic option);
   dynamic getOptionToType(ReceivePageOption option);
   void unlockDatabase(String password);


### PR DESCRIPTION
## Problem

On the Zcash Receive screen, the notice *"Your receive address will rotate every time you receive a transaction"* is rendered for **every** address type, including the ones that are explicitly static. It is most obviously wrong for **Public (Static & Transparent)**, where the notice directly contradicts the type's own name.

`ReceiveInfoBox.forWalletType()` falls through to a `default:` branch that renders `infobox_auto_address` for any wallet type that isn't Nano or one of the multichain EVM/Solana/Tron/Zano types, gated only on `autoGenerateSubaddressStatus`. Nothing in that path is aware of the *selected* address type, so Zcash — the one wallet type that offers both rotating and static receive addresses — always got the notice.

## Which Zcash types actually rotate

Checked against the model rather than the labels. `ZcashAddressType` has five values, and `ZcashWalletAddresses._applyAddressForCurrentType()` only ever swaps in a fresh address for one of them:

```dart
if (_addressPageType == ZcashAddressType.transparentRotated) {
  final addr = await ZcashTaddressRotation.addressForAccount(accountId);
  ...
}
address = latestAddress;
```

Every other type resolves to a fixed address derived from the account (`taddr` / `saddr` / `oaddr` / `ua` out of `zkool_account.getAddresses`). So:

| Address type | `ZcashAddressType` | Rotates | Notice before | Notice after |
|---|---|---|---|---|
| Shielded — Default (Orchard) | `shieldedOrchard` | no | yes | no |
| Transparent — Disposable | `transparentRotated` | **yes** | yes | **yes** |
| Unified — Compatible Shielded | `unifiedType` | no | yes | no |
| Legacy Shielded — Sapling | `shieldedSapling` | no | yes | no |
| Public — Static & Transparent | `transparent` | no | yes | no |

This also matches the existing `hasSelectedTransparentAddress()`, which already treats `transparentRotated` as the only rotating type.

## Change

- `Zcash.isRotatingAddressOption(ReceivePageOption)` — new proxy method, `option == ZcashReceivePageOption.transparentRotated`.
- `ReceiveInfoBox.forWalletType()` takes `bool addressRotates = true` and returns `null` in the `default:` branch when it's false. The default keeps every existing caller's behaviour.
- `NewReceivePage` passes `_selectedAddressRotates`, which short-circuits to `true` for any non-Zcash wallet and otherwise asks the proxy about `receiveOptionViewModel.selectedReceiveOption`.

`selectedReceiveOption` is used as the source of truth rather than the persisted `walletInfo.addressPageType`, because `WalletAddressListViewModel.setAddressType()` writes its observable *before* awaiting the wallet-side write — reading persisted state would render the notice one selection stale. The existing `selectedReceiveOption` reaction now also calls `setState` so the infobox is re-evaluated when the type changes.

## Other assets

`infobox_auto_address` has exactly one Dart reference (`receive_info_box.dart:48`); everything else matching that key is translations, and no string was touched, so there is no translation churn. `ReceiveInfoBox` itself has one call site, `new-ui/pages/receive_page.dart`.

The widget *is* shared across assets, so the gate was written to be inert everywhere else: `_selectedAddressRotates` returns `true` for every wallet type except Zcash, so Monero/Wownero subaddresses, Bitcoin/Litecoin, BCH, Decred and Dogecoin keep the notice exactly as before, still gated on `autoGenerateSubaddressStatus`. The multichain branch (`infobox_multichain`) is untouched — different message, and Zcash isn't in that list.

## Verification

**Not verified on device.** This checkout has never been configured (`pubspec.yaml`, `lib/wallet_types.g.dart` and the generated `lib/zcash/zcash.dart` are all absent), so I could not run `flutter analyze` or produce a build to confirm against the emulator. The change is reasoned from the source, and the edited files parse, but it has not been exercised at runtime.

Worth confirming on a real build:
- Public (Static & Transparent) — notice **gone**
- Transparent (Disposable) — notice **still present**
- Shielded / Unified / Legacy Shielded — notice **gone**
- Monero — notice still present with auto-subaddress enabled

## Adjacent, not fixed

`CWZcash.getZcashAddressType()` has no `case ZcashReceivePageOption.transparentRotated:` and throws `Exception("Unknown ReceivePageOption!")` on its `default:`. The new receive page returns early via `getOptionToType()` and never reaches it, but the old UI (`lib/src/screens/dashboard/pages/address_page.dart:322-323`) calls it directly for Zcash, so selecting the disposable transparent type there looks like it would throw. Left alone as out of scope for this fix.

---

Original defect: finding #4 of the 2026-07-25 Zcash QA session, re-confirmed 2026-07-26 on `cyjan-zec-ironwood` (`com.cakewallet.test_cyjanzecironwo`, 6.3.2 / 6418) on a Pixel 8 AVD — all five ZEC address types showed the notice.
