### PR TITLE
fix: add reconnection logic to hardware wallet flow to handle tap-backs

### DIFF
--- a/lib/buy/dfx/dfx_buy_provider.dart
+++ b/lib/buy/dfx/dfx_buy_provider.dart
@@ -336,14 +336,23 @@ class DFXBuyProvider extends BuyProvider {
       String? countryCode}) async {
     if (wallet.isHardwareWallet) {
       if (!hardwareWalletVM!.isConnected(wallet.walletInfo.type)) {
-        await Navigator.of(context).pushNamed(Routes.connectDevices,
-            arguments: ConnectDevicePageParams(
-                walletType: wallet.walletInfo.type,
-                hardwareWalletType: wallet.walletInfo.hardwareWalletType!,
-                onConnectDevice: (context, hwwVM) {
-                  hwwVM.initWallet(wallet);
-                  Navigator.of(context).pop();
-                }));
+        await Navigator.of(context).pushNamed(
+          Routes.connectDevices,
+          arguments: ConnectDevicePageParams(
+            walletType: wallet.walletInfo.type,
+            hardwareWalletType: wallet.walletInfo.hardwareWalletType!,
+            onConnectDevice: (context, hwwVM) {
+              hwwVM.initWallet(wallet);
+              Navigator.of(context).pop();
+            },
+            isReconnect: false,
+          ),
+        );
+
+        // Recheck to handle tap-backs
+        if (!hardwareWalletVM!.isConnected(wallet.walletInfo.type)) {
+          return;
+        }
       } else {
         hardwareWalletVM!.initWallet(wallet);
       }

--- a/lib/buy/robinhood/robinhood_buy_provider.dart
+++ b/lib/buy/robinhood/robinhood_buy_provider.dart
@@ -174,14 +174,21 @@ class RobinhoodBuyProvider extends BuyProvider {
       String? countryCode}) async {
     if (wallet.isHardwareWallet) {
       if (!hardwareWalletVM!.isConnected(wallet.walletInfo.type)) {
-        await Navigator.of(context).pushNamed(Routes.connectDevices,
-            arguments: ConnectDevicePageParams(
-                walletType: wallet.walletInfo.type,
-                hardwareWalletType: wallet.walletInfo.hardwareWalletType!,
-                onConnectDevice: (context, hwwVM) {
-                  hwwVM.initWallet(wallet);
-                  Navigator.of(context).pop();
-                }));
+        await Navigator.of(context).pushNamed(
+          Routes.connectDevices,
+          arguments: ConnectDevicePageParams(
+            walletType: wallet.walletInfo.type,
+            hardwareWalletType: wallet.walletInfo.hardwareWalletType!,
+            onConnectDevice: (context, hwwVM) {
+              hwwVM.initWallet(wallet);
+              Navigator.of(context).pop();
+            },
+            isReconnect: false,
+          ),
+        );
+        if (!hardwareWalletVM!.isConnected(wallet.walletInfo.type)) {
+          return;
+        }
       } else {
         hardwareWalletVM!.initWallet(wallet);
       }

--- a/lib/new-ui/pages/send_page.dart
+++ b/lib/new-ui/pages/send_page.dart
@@ -823,8 +823,15 @@ class _NewSendPageState extends State<NewSendPage> {
               widget.sendViewModel.hardwareWalletViewModel!.initWallet(widget.sendViewModel.wallet);
               Navigator.of(context).pop();
             },
+            isReconnect: false,
           ),
         );
+
+        // Recheck to handle tap-backs
+        if (!widget.sendViewModel.hardwareWalletViewModel!
+            .isConnected(widget.sendViewModel.walletType)) {
+          return;
+        }
       } else {
         await widget.sendViewModel.hardwareWalletViewModel!.initWallet(widget.sendViewModel.wallet);
       }

--- a/lib/new-ui/widgets/swap_page/swap_confirm_sheet.dart
+++ b/lib/new-ui/widgets/swap_page/swap_confirm_sheet.dart
@@ -47,15 +47,23 @@ class _SwapConfirmSheetState extends State<SwapConfirmSheet> {
 
     if (sendVM.wallet.isHardwareWallet) {
       if (!sendVM.hardwareWalletViewModel!.isConnected(sendVM.walletType)) {
-        await Navigator.of(context).pushNamed(Routes.connectDevices,
-            arguments: ConnectDevicePageParams(
-              walletType: sendVM.walletType,
-              hardwareWalletType: sendVM.wallet.walletInfo.hardwareWalletType!,
-              onConnectDevice: (context, _) {
-                sendVM.hardwareWalletViewModel!.initWallet(sendVM.wallet);
-                Navigator.of(context).pop();
-              },
-            ));
+        await Navigator.of(context).pushNamed(
+          Routes.connectDevices,
+          arguments: ConnectDevicePageParams(
+            walletType: sendVM.walletType,
+            hardwareWalletType: sendVM.wallet.walletInfo.hardwareWalletType!,
+            onConnectDevice: (context, _) {
+              sendVM.hardwareWalletViewModel!.initWallet(sendVM.wallet);
+              Navigator.of(context).pop();
+            },
+            isReconnect: false,
+          ),
+        );
+
+        // Recheck to handle tap-backs
+        if (!sendVM.hardwareWalletViewModel!.isConnected(sendVM.walletType)) {
+          return;
+        }
       } else {
         sendVM.hardwareWalletViewModel!.initWallet(sendVM.wallet);
       }


### PR DESCRIPTION
# Description

Handle HWW tap-back properly and disallow wallet switching in some scenarios. 

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
