### PR TITLE
a11y: add accessible-navigation fallback button to ConfirmSwiper

### DIFF
--- a/lib/new-ui/pages/bridge/bridge_confirm_sheet.dart
+++ b/lib/new-ui/pages/bridge/bridge_confirm_sheet.dart
@@ -217,6 +217,7 @@ class _BridgeConfirmSheetState extends State<BridgeConfirmSheet> {
                       bridgeViewModel.executeBridge();
                     },
                     swiperText: S.of(context).swipe_to_bridge,
+                    accessibleNavigationModeButtonText: S.of(context).confirm,
                   );
                 },
               ),

--- a/lib/new-ui/widgets/confirm_swiper.dart
+++ b/lib/new-ui/widgets/confirm_swiper.dart
@@ -1,12 +1,23 @@
 import 'dart:math';
 
+import 'package:cake_wallet/new-ui/widgets/new_primary_button.dart';
 import 'package:flutter/material.dart';
 
 class ConfirmSwiper extends StatefulWidget {
   final VoidCallback onConfirmed;
   final String swiperText;
 
-  const ConfirmSwiper({super.key, required this.onConfirmed, required this.swiperText});
+  /// Label of the plain button rendered instead of the swiper when the platform
+  /// reports accessible navigation (VoiceOver / TalkBack), which intercepts the
+  /// horizontal drag the swiper depends on. Falls back to [swiperText].
+  final String? accessibleNavigationModeButtonText;
+
+  const ConfirmSwiper({
+    super.key,
+    required this.onConfirmed,
+    required this.swiperText,
+    this.accessibleNavigationModeButtonText,
+  });
 
   @override
   State<ConfirmSwiper> createState() => _ConfirmSwiperState();
@@ -30,6 +41,15 @@ class _ConfirmSwiperState extends State<ConfirmSwiper> {
 
   @override
   Widget build(BuildContext context) {
+    if (MediaQuery.of(context).accessibleNavigation) {
+      return NewPrimaryButton(
+        onPressed: widget.onConfirmed,
+        text: widget.accessibleNavigationModeButtonText ?? widget.swiperText,
+        color: Theme.of(context).colorScheme.primary,
+        textColor: Theme.of(context).colorScheme.onPrimary,
+      );
+    }
+
     final radius = (pillSize + pillHorizontalPadding * 2) / 2;
 
     return LayoutBuilder(
@@ -41,7 +61,7 @@ class _ConfirmSwiperState extends State<ConfirmSwiper> {
         final maxDrag = areaWidth - pillSize - pillHorizontalPadding;
         final triggerAt = maxDrag - _triggerThreshold;
 
-        return GestureDetector(
+        final swiper = GestureDetector(
           onHorizontalDragUpdate: (d) {
             setState(() {
               drag = max(pillHorizontalPadding, min(maxDrag, drag + d.delta.dx));
@@ -97,6 +117,17 @@ class _ConfirmSwiperState extends State<ConfirmSwiper> {
               ],
             ),
           ),
+        );
+
+        // A single accessibility node for the whole control: the flowing label and
+        // the arrow knob are decorative and must not become separate stops. No
+        // semantics action is exposed here; a screen reader gets the button
+        // variant above instead.
+        return Semantics(
+          container: true,
+          excludeSemantics: true,
+          label: widget.swiperText,
+          child: swiper,
         );
       },
     );

--- a/lib/new-ui/widgets/send_page/send_confirm_bottom_widget.dart
+++ b/lib/new-ui/widgets/send_page/send_confirm_bottom_widget.dart
@@ -47,7 +47,8 @@ class SendConfirmBottomWidget extends StatelessWidget {
             onConfirmed: () {
               sendViewModel.commitTransaction(context);
             },
-            swiperText: "${S.of(context).swipe_to_send}");
+            swiperText: "${S.of(context).swipe_to_send}",
+            accessibleNavigationModeButtonText: S.of(context).send);
       case IsExecutingState:
         return LoadingBottomWidget(
           text: "${S.of(context).generating_transaction}...",

--- a/lib/src/screens/wallet_connect/widgets/wc_connection_request_sheet.dart
+++ b/lib/src/screens/wallet_connect/widgets/wc_connection_request_sheet.dart
@@ -80,6 +80,7 @@ class WCConnectionRequestSheet extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 24),
           child: ConfirmSwiper(
             swiperText: S.of(context).wc_swipe_to_approve,
+            accessibleNavigationModeButtonText: S.of(context).wc_action_approve,
             onConfirmed: () {
               if (Navigator.canPop(context)) {
                 Navigator.of(context).pop(WCBottomSheetResult.one);

--- a/lib/src/screens/wallet_connect/widgets/wc_signing_request_sheet.dart
+++ b/lib/src/screens/wallet_connect/widgets/wc_signing_request_sheet.dart
@@ -82,6 +82,7 @@ class WCSigningRequestSheet extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 24),
           child: ConfirmSwiper(
             swiperText: swipeLabel,
+            accessibleNavigationModeButtonText: S.of(context).confirm,
             onConfirmed: () {
               if (Navigator.canPop(context)) {
                 Navigator.of(context).pop(WCBottomSheetResult.one);


### PR DESCRIPTION
Issue Number (if Applicable): Related to #3402, #3406 — Jira [CW-1574](https://cakej.atlassian.net/browse/CW-1574)

# Description

Part 2 of the screen-reader accessibility remediation (VoiceOver/TalkBack). This removes the single hardest blocker: `ConfirmSwiper` — the swipe-to-confirm control gating **send, bridge, WalletConnect session approval, and WalletConnect signing** — was a bare `GestureDetector` requiring a horizontal drag. VoiceOver and TalkBack intercept horizontal swipes for navigation, so a screen-reader user could not complete any of those flows at all.

**Changes**
- `ConfirmSwiper`: when `MediaQuery.accessibleNavigation` is true (i.e., a screen reader is active), it now renders a conventional full-width `NewPrimaryButton` instead of the swiper — the exact pattern the legacy UI already uses in `StandardSlideButton` (`lib/src/widgets/standard_slide_button_widget.dart`). New optional `accessibleNavigationModeButtonText` names the button; it falls back to `swiperText`.
- The swipe branch is behaviorally unchanged for sighted users, but now exposes a single labeled semantics node instead of a label-less gesture area with two decorative child stops.
- All four call sites pass an operation-specific button label using **existing** ARB keys only: Send → `send`, WalletConnect approve → `wc_action_approve`, bridge and WalletConnect sign → `confirm`.

**Notes for reviewers**
- Bridge uses "Confirm" because no "Bridge" action verb exists in the ARB (only `swipe_to_bridge`, which would be misleading on a non-swipe button). A future `bridge_action` key would be a small improvement.
- `wc_signing_request_sheet.dart` also uses "Confirm" since its swipe label is chosen dynamically by callers; threading an operation-specific label through would touch more surface than this PR wants to.
- The new accessible button intentionally has no semantics `onTap` in the non-accessible branch — activation without the deliberate swipe is only possible when the OS reports accessible navigation, same as the legacy control.

**Verification**
- `flutter analyze` (Flutter 3.41.9, same as CI) — zero new issues vs `dev` baseline.
- No new strings; no visual changes outside accessible-navigation mode.
- Widget tests covering the fallback land in the dedicated test PR at the end of this series.
- On-device VoiceOver/TalkBack verification pending (see checklist).

# Pull Request - Checklist

- [ ] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed
