### PR TITLE
a11y: decorative/meaningful image semantics, labeled icon buttons, audible addresses

### DIFF
--- a/lib/new-ui/pages/scan_page.dart
+++ b/lib/new-ui/pages/scan_page.dart
@@ -253,6 +253,7 @@ class _ScanPageState extends State<ScanPage> {
                       ),
                       FloatingIconButton(
                           iconPath: "assets/new-ui/paste.svg",
+                          semanticLabel: S.of(context).paste,
                           onPressed: () async {
                             final data = await Clipboard.getData("text/plain");
                             if (data?.text != null) {

--- a/lib/new-ui/widgets/coins_page/token_image_widget.dart
+++ b/lib/new-ui/widgets/coins_page/token_image_widget.dart
@@ -17,11 +17,16 @@ class TokenImageWidget extends StatefulWidget {
     required this.imageUrl,
     required this.size,
     this.errorWidget,
+    this.semanticsLabel,
   });
 
   final String imageUrl;
   final double size;
   final Widget? errorWidget;
+
+  /// Accessible name for the token artwork. Leave `null` (the default) when the
+  /// token is already named by adjacent text, so the image stays decorative.
+  final String? semanticsLabel;
 
   @override
   State<TokenImageWidget> createState() => _TokenImageWidgetState();
@@ -132,6 +137,7 @@ class _TokenImageWidgetState extends State<TokenImageWidget> {
         fit: BoxFit.cover,
         filterQuality: FilterQuality.high,
         errorWidget: widget.errorWidget,
+        semanticsLabel: widget.semanticsLabel,
       ),
     );
 

--- a/lib/new-ui/widgets/receive_page/receive_qr_code.dart
+++ b/lib/new-ui/widgets/receive_page/receive_qr_code.dart
@@ -51,71 +51,74 @@ class ReceiveQrCode extends StatelessWidget {
                 height: 45,
               )),
         ),
-        Semantics(
-          label: S.of(context).qr_code_receive_address,
-          hint: largeQrMode ? S.of(context).qr_close_fullscreen : S.of(context).qr_fullscreen,
-          button: true,
-          enabled: true,
-          child: GestureDetector(
-            onTap: onTap,
-            behavior: HitTestBehavior.opaque,
-            child: TweenAnimationBuilder<double>(
-              tween: Tween<double>(begin: 0, end: targetY),
-              duration: animDuration,
-              curve: Curves.easeOutCubic,
-              builder: (context, value, child) {
-                return Transform.translate(
-                  offset: Offset(0, value),
-                  child: child,
-                );
-              },
-              child: Observer(
-                builder: (_) => Column(
-                  children: [
-                    AnimatedScale(
-                      curve: Curves.easeOutCubic,
-                      alignment: Alignment.bottomCenter,
-                      scale: resolvedScale,
-                      duration: animDuration,
-                      child: AnimatedContainer(
-                        duration: animDuration,
+        // The QR, and the payjoin badge below it, share one tap target, so they
+        // are merged into a single button node named by the QR's own label
+        // rather than each becoming a separate focus stop.
+        MergeSemantics(
+          child: Semantics(
+            hint: largeQrMode ? S.of(context).qr_close_fullscreen : S.of(context).qr_fullscreen,
+            button: true,
+            enabled: true,
+            child: GestureDetector(
+              onTap: onTap,
+              behavior: HitTestBehavior.opaque,
+              child: TweenAnimationBuilder<double>(
+                tween: Tween<double>(begin: 0, end: targetY),
+                duration: animDuration,
+                curve: Curves.easeOutCubic,
+                builder: (context, value, child) {
+                  return Transform.translate(
+                    offset: Offset(0, value),
+                    child: child,
+                  );
+                },
+                child: Observer(
+                  builder: (_) => Column(
+                    children: [
+                      AnimatedScale(
                         curve: Curves.easeOutCubic,
-                        width: resolvedSize,
-                        height: resolvedSize,
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(20),
-                          color: Colors.white,
-                        ),
-                        child: Container(
+                        alignment: Alignment.bottomCenter,
+                        scale: resolvedScale,
+                        duration: animDuration,
+                        child: AnimatedContainer(
+                          duration: animDuration,
+                          curve: Curves.easeOutCubic,
+                          width: resolvedSize,
+                          height: resolvedSize,
                           decoration: BoxDecoration(
-                              borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-                              color: addressListViewModel.hasPayjoin && !largeQrMode
-                                  ? Theme.of(context).colorScheme.surfaceContainer
-                                  : Colors.transparent),
-                          child: ClipRRect(
-                              borderRadius: BorderRadius.circular(20),
-                              child: Observer(
-                                  builder: (_) => QrImage(
-                                        data: addressListViewModel.uri.toString(),
-                                        size: resolvedSize,
-                                        embeddedImagePath:
-                                            addressListViewModel.tokenCurrency != null
-                                                ? addressListViewModel.tokenCurrency ==
-                                                        CryptoCurrency.btcln
-                                                    ? addressListViewModel.qrImage
-                                                    : addressListViewModel.tokenCurrency!.iconPath
-                                                : addressListViewModel.qrImage,
-                                      ))),
+                            borderRadius: BorderRadius.circular(20),
+                            color: Colors.white,
+                          ),
+                          child: Container(
+                            decoration: BoxDecoration(
+                                borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+                                color: addressListViewModel.hasPayjoin && !largeQrMode
+                                    ? Theme.of(context).colorScheme.surfaceContainer
+                                    : Colors.transparent),
+                            child: ClipRRect(
+                                borderRadius: BorderRadius.circular(20),
+                                child: Observer(
+                                    builder: (_) => QrImage(
+                                          data: addressListViewModel.uri.toString(),
+                                          size: resolvedSize,
+                                          semanticsLabel: S.of(context).qr_code_receive_address,
+                                          embeddedImagePath:
+                                              addressListViewModel.tokenCurrency != null
+                                                  ? addressListViewModel.tokenCurrency ==
+                                                          CryptoCurrency.btcln
+                                                      ? addressListViewModel.qrImage
+                                                      : addressListViewModel
+                                                          .tokenCurrency!.iconPath
+                                                  : addressListViewModel.qrImage,
+                                        ))),
+                          ),
                         ),
                       ),
-                    ),
-                    if (addressListViewModel.hasPayjoin)
-                      // Hidden but still mounted in large-QR mode, so keep it out
-                      // of the semantics tree there. The icon is decorative and
-                      // the badge reads as a single node.
-                      ExcludeSemantics(
-                        excluding: largeQrMode,
-                        child: MergeSemantics(
+                      if (addressListViewModel.hasPayjoin)
+                        // Hidden but still mounted in large-QR mode, so keep it
+                        // out of the semantics tree there.
+                        ExcludeSemantics(
+                          excluding: largeQrMode,
                           child: Opacity(
                               opacity: largeQrMode ? 0 : 1,
                               child: Container(
@@ -136,12 +139,12 @@ class ReceiveQrCode extends StatelessWidget {
                                     ),
                                   ))),
                         ),
-                      ),
-                    AnimatedSize(
-                        duration: animDuration,
-                        curve: Curves.easeOutCubic,
-                        child: SizedBox(height: largeQrMode ? largeQrModeBottomPadding + 40 : 0))
-                  ],
+                      AnimatedSize(
+                          duration: animDuration,
+                          curve: Curves.easeOutCubic,
+                          child: SizedBox(height: largeQrMode ? largeQrModeBottomPadding + 40 : 0))
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/new-ui/widgets/receive_page/receive_qr_code.dart
+++ b/lib/new-ui/widgets/receive_page/receive_qr_code.dart
@@ -51,10 +51,15 @@ class ReceiveQrCode extends StatelessWidget {
                 height: 45,
               )),
         ),
-        GestureDetector(
-          onTap: onTap,
-          behavior: HitTestBehavior.opaque,
-          child: TweenAnimationBuilder<double>(
+        Semantics(
+          label: S.of(context).qr_code_receive_address,
+          hint: S.of(context).qr_fullscreen,
+          button: true,
+          enabled: true,
+          child: GestureDetector(
+            onTap: onTap,
+            behavior: HitTestBehavior.opaque,
+            child: TweenAnimationBuilder<double>(
               tween: Tween<double>(begin: 0, end: targetY),
               duration: animDuration,
               curve: Curves.easeOutCubic,
@@ -105,31 +110,42 @@ class ReceiveQrCode extends StatelessWidget {
                       ),
                     ),
                     if (addressListViewModel.hasPayjoin)
-                      Opacity(
-                          opacity: largeQrMode ? 0 : 1,
-                          child: Container(
-                              width: resolvedSize,
-                              decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.vertical(bottom: Radius.circular(16)),
-                                  color: Theme.of(context).colorScheme.surfaceContainer),
-                              child: Padding(
-                                padding: const EdgeInsets.symmetric(vertical: 2.0),
-                                child: Row(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  spacing: 4,
-                                  children: [
-                                    CakeImageWidget(imageUrl: "assets/new-ui/payjoin.svg"),
-                                    Text(S.of(context).payjoin_enabled)
-                                  ],
-                                ),
-                              ))),
+                      // Hidden but still mounted in large-QR mode, so keep it out
+                      // of the semantics tree there. The icon is decorative and
+                      // the badge reads as a single node.
+                      ExcludeSemantics(
+                        excluding: largeQrMode,
+                        child: MergeSemantics(
+                          child: Opacity(
+                              opacity: largeQrMode ? 0 : 1,
+                              child: Container(
+                                  width: resolvedSize,
+                                  decoration: BoxDecoration(
+                                      borderRadius:
+                                          BorderRadius.vertical(bottom: Radius.circular(16)),
+                                      color: Theme.of(context).colorScheme.surfaceContainer),
+                                  child: Padding(
+                                    padding: const EdgeInsets.symmetric(vertical: 2.0),
+                                    child: Row(
+                                      mainAxisAlignment: MainAxisAlignment.center,
+                                      spacing: 4,
+                                      children: [
+                                        CakeImageWidget(imageUrl: "assets/new-ui/payjoin.svg"),
+                                        Text(S.of(context).payjoin_enabled)
+                                      ],
+                                    ),
+                                  ))),
+                        ),
+                      ),
                     AnimatedSize(
                         duration: animDuration,
                         curve: Curves.easeOutCubic,
                         child: SizedBox(height: largeQrMode ? largeQrModeBottomPadding + 40 : 0))
                   ],
                 ),
-              )),
+              ),
+            ),
+          ),
         ),
       ],
     );

--- a/lib/new-ui/widgets/receive_page/receive_qr_code.dart
+++ b/lib/new-ui/widgets/receive_page/receive_qr_code.dart
@@ -53,7 +53,7 @@ class ReceiveQrCode extends StatelessWidget {
         ),
         Semantics(
           label: S.of(context).qr_code_receive_address,
-          hint: S.of(context).qr_fullscreen,
+          hint: largeQrMode ? S.of(context).qr_close_fullscreen : S.of(context).qr_fullscreen,
           button: true,
           enabled: true,
           child: GestureDetector(

--- a/lib/new-ui/widgets/send_page/floating_icon_button.dart
+++ b/lib/new-ui/widgets/send_page/floating_icon_button.dart
@@ -3,28 +3,45 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
 class FloatingIconButton extends StatelessWidget {
-  const FloatingIconButton({super.key, required this.iconPath, required this.onPressed});
+  const FloatingIconButton({
+    super.key,
+    required this.iconPath,
+    required this.onPressed,
+    required this.semanticLabel,
+  });
 
   final String iconPath;
   final VoidCallback onPressed;
 
+  /// Localized accessible name for this icon-only button. The icon itself stays
+  /// decorative, so this is the only name a screen reader can announce.
+  final String semanticLabel;
+
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      borderRadius: const BorderRadius.all(Radius.circular(6)),
-      child: InkWell(
+    return MergeSemantics(
+      child: Semantics(
+        label: semanticLabel,
+        button: true,
+        enabled: true,
+        child: Material(
+          color: Colors.transparent,
           borderRadius: const BorderRadius.all(Radius.circular(6)),
-          onTap: onPressed,
-          child: Padding(
-            padding: const EdgeInsets.all(4.0),
-            child: CakeImageWidget(
-              imageUrl: iconPath,
-              width: 22,
-              height: 22,
-              colorFilter: ColorFilter.mode(Theme.of(context).colorScheme.primary, BlendMode.srcIn),
-            ),
-          )),
+          child: InkWell(
+              borderRadius: const BorderRadius.all(Radius.circular(6)),
+              onTap: onPressed,
+              child: Padding(
+                padding: const EdgeInsets.all(4.0),
+                child: CakeImageWidget(
+                  imageUrl: iconPath,
+                  width: 22,
+                  height: 22,
+                  colorFilter:
+                      ColorFilter.mode(Theme.of(context).colorScheme.primary, BlendMode.srcIn),
+                ),
+              )),
+        ),
+      ),
     );
   }
 }

--- a/lib/new-ui/widgets/send_page/send_address_input.dart
+++ b/lib/new-ui/widgets/send_page/send_address_input.dart
@@ -128,16 +128,19 @@ class _NewSendAddressInputState extends State<NewSendAddressInput> {
                       SizedBox.shrink(),
                       FloatingIconButton(
                           iconPath: "assets/new-ui/paste.svg",
+                          semanticLabel: S.of(context).paste,
                           onPressed: () async {
                             _pasteAddress(context);
                           }),
                       FloatingIconButton(
                           iconPath: "assets/new-ui/scan.svg",
+                          semanticLabel: S.of(context).scan_qr_code,
                           onPressed: () {
                             _presentQRScanner(context);
                           }),
                       FloatingIconButton(
                           iconPath: "assets/new-ui/contacts_outlined.svg",
+                          semanticLabel: S.of(context).address_book,
                           onPressed: () {
                             _presetAddressBookPicker(context);
                           }),

--- a/lib/new-ui/widgets/send_page/send_amount_input.dart
+++ b/lib/new-ui/widgets/send_page/send_amount_input.dart
@@ -1,3 +1,4 @@
+import "package:cake_wallet/generated/i18n.dart";
 import "package:cake_wallet/new-ui/widgets/coins_page/token_image_widget.dart";
 import "package:cake_wallet/new-ui/widgets/send_page/floating_icon_button.dart";
 import "package:cake_wallet/src/widgets/cake_image_widget.dart";
@@ -88,6 +89,7 @@ class _NewSendAmountInputState extends State<NewSendAmountInput> {
                           ),
                           FloatingIconButton(
                             iconPath: "assets/new-ui/paste.svg",
+                            semanticLabel: S.of(context).paste,
                             onPressed: () async {
                               final data = await Clipboard.getData(Clipboard.kTextPlain);
                               if (data != null && data.text != null) {

--- a/lib/new-ui/widgets/send_page/send_memo_input.dart
+++ b/lib/new-ui/widgets/send_page/send_memo_input.dart
@@ -41,6 +41,7 @@ class NewSendMemoInput extends StatelessWidget {
               SizedBox(width: 12),
               FloatingIconButton(
                   iconPath: "assets/new-ui/paste.svg",
+                  semanticLabel: S.of(context).paste,
                   onPressed: () async {
                     final data = await Clipboard.getData(Clipboard.kTextPlain);
                     if (data != null && data.text != null) {

--- a/lib/src/screens/receive/widgets/qr_image.dart
+++ b/lib/src/screens/receive/widgets/qr_image.dart
@@ -1,3 +1,4 @@
+import 'package:cake_wallet/generated/i18n.dart';
 import 'package:cake_wallet/new-ui/widgets/coins_page/token_image_widget.dart';
 import 'package:cake_wallet/src/widgets/cake_image_widget.dart';
 import 'package:flutter/material.dart';
@@ -13,6 +14,7 @@ class QrImage extends StatelessWidget {
     this.errorCorrectionLevel = qr.QrErrorCorrectLevel.H,
     this.embeddedImagePath,
     this.badgeImageOnEmbeddedImagePath,
+    this.semanticsLabel,
   });
 
   final double? size;
@@ -23,6 +25,11 @@ class QrImage extends StatelessWidget {
   final int errorCorrectionLevel;
   final String? embeddedImagePath;
   final String? badgeImageOnEmbeddedImagePath;
+
+  /// Accessible name announced for the code itself. Defaults to a generic
+  /// localized "QR code" so the code is always discoverable; pass a more
+  /// specific label when the host screen knows what the code encodes.
+  final String? semanticsLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -57,25 +64,25 @@ class QrImage extends StatelessWidget {
     } else {
       centerImageToUse = centerImage;
     }
-    // The QR matrix, the embedded logo and its badge are all purely visual: the
-    // data they encode is announced by the labelled control hosting this widget,
-    // so nothing in here should become a focus stop of its own.
-    return ExcludeSemantics(
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          qr.QrImageView(
-            data: data,
-            errorCorrectionLevel: errorCorrectionLevel,
-            version: version ?? qr.QrVersions.auto,
-            size: qrSize,
-            foregroundColor: foregroundColor,
-            backgroundColor: backgroundColor,
-            padding: const EdgeInsets.all(12.0),
-          ),
-          centerImageToUse,
-        ],
-      ),
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        qr.QrImageView(
+          data: data,
+          errorCorrectionLevel: errorCorrectionLevel,
+          version: version ?? qr.QrVersions.auto,
+          size: qrSize,
+          foregroundColor: foregroundColor,
+          backgroundColor: backgroundColor,
+          padding: const EdgeInsets.all(12.0),
+          // The package default is a hardcoded English "qr code"; use the
+          // localized string so the code is announced in the user's language.
+          semanticsLabel: semanticsLabel ?? S.of(context).scan_qr_code,
+        ),
+        // The embedded logo and its badge are purely decorative — the node
+        // above already announces the code — so keep them out of the tree.
+        ExcludeSemantics(child: centerImageToUse),
+      ],
     );
   }
 }

--- a/lib/src/screens/receive/widgets/qr_image.dart
+++ b/lib/src/screens/receive/widgets/qr_image.dart
@@ -57,20 +57,25 @@ class QrImage extends StatelessWidget {
     } else {
       centerImageToUse = centerImage;
     }
-    return Stack(
-      alignment: Alignment.center,
-      children: [
-        qr.QrImageView(
-          data: data,
-          errorCorrectionLevel: errorCorrectionLevel,
-          version: version ?? qr.QrVersions.auto,
-          size: qrSize,
-          foregroundColor: foregroundColor,
-          backgroundColor: backgroundColor,
-          padding: const EdgeInsets.all(12.0),
-        ),
-        centerImageToUse,
-      ],
+    // The QR matrix, the embedded logo and its badge are all purely visual: the
+    // data they encode is announced by the labelled control hosting this widget,
+    // so nothing in here should become a focus stop of its own.
+    return ExcludeSemantics(
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          qr.QrImageView(
+            data: data,
+            errorCorrectionLevel: errorCorrectionLevel,
+            version: version ?? qr.QrVersions.auto,
+            size: qrSize,
+            foregroundColor: foregroundColor,
+            backgroundColor: backgroundColor,
+            padding: const EdgeInsets.all(12.0),
+          ),
+          centerImageToUse,
+        ],
+      ),
     );
   }
 }

--- a/lib/src/widgets/cake_image_widget.dart
+++ b/lib/src/widgets/cake_image_widget.dart
@@ -17,6 +17,7 @@ class CakeImageWidget extends StatelessWidget {
     this.alignment,
     this.allowDrawingOutsideViewBox,
     this.filterQuality,
+    this.semanticsLabel,
   });
 
   final String? imageUrl;
@@ -31,6 +32,16 @@ class CakeImageWidget extends StatelessWidget {
   final bool? allowDrawingOutsideViewBox;
   final double borderRadius;
   final FilterQuality? filterQuality;
+
+  /// Accessible name for this image.
+  ///
+  /// Leave `null` (the default) for decorative imagery — the image then
+  /// contributes nothing at all to the semantics tree, so screen readers do not
+  /// stop on an unnamed node. Pass a localized string only when the image is the
+  /// sole carrier of information for the user.
+  final String? semanticsLabel;
+
+  bool get _isDecorative => semanticsLabel == null;
 
   @override
   Widget build(BuildContext context) {
@@ -52,6 +63,8 @@ class CakeImageWidget extends StatelessWidget {
             alignment: alignment ?? Alignment.center,
             allowDrawingOutsideViewBox: allowDrawingOutsideViewBox ?? false,
             colorFilter: effectiveColorFilter,
+            semanticsLabel: semanticsLabel,
+            excludeFromSemantics: _isDecorative,
             fit: fit ?? BoxFit.contain, errorBuilder: (context, e, trace) {
           return SvgPicture.asset(
             imageUrl!,
@@ -61,6 +74,8 @@ class CakeImageWidget extends StatelessWidget {
             width: width,
             errorBuilder: (_, __, ___) => SizedBox(height: height, width: width),
             colorFilter: effectiveColorFilter,
+            semanticsLabel: semanticsLabel,
+            excludeFromSemantics: _isDecorative,
             fit: fit ?? BoxFit.contain,
           );
         });
@@ -72,6 +87,8 @@ class CakeImageWidget extends StatelessWidget {
           fit: fit,
           color: color,
           filterQuality: filterQuality ?? FilterQuality.medium,
+          semanticLabel: semanticsLabel,
+          excludeFromSemantics: _isDecorative,
           errorBuilder: (_, __, ___) => _buildErrorWidget(context),
         );
       }
@@ -85,9 +102,9 @@ class CakeImageWidget extends StatelessWidget {
               alignment: alignment ?? Alignment.center,
               allowDrawingOutsideViewBox: allowDrawingOutsideViewBox ?? false,
               fit: fit ?? BoxFit.contain,
-              placeholderBuilder: (_) {
-                return loadingWidget ?? const Center(child: CircularProgressIndicator());
-              },
+              semanticsLabel: semanticsLabel,
+              excludeFromSemantics: _isDecorative,
+              placeholderBuilder: (_) => _buildLoadingWidget(),
               errorBuilder: (_, __, ___) => _buildErrorWidget(context),
             )
           : Image.network(
@@ -97,9 +114,11 @@ class CakeImageWidget extends StatelessWidget {
               fit: fit ?? BoxFit.cover,
               color: color,
               filterQuality: filterQuality ?? FilterQuality.medium,
+              semanticLabel: semanticsLabel,
+              excludeFromSemantics: _isDecorative,
               loadingBuilder: (_, Widget child, ImageChunkEvent? progress) {
                 if (progress == null) return child;
-                return loadingWidget ?? const Center(child: CircularProgressIndicator());
+                return _buildLoadingWidget();
               },
               errorBuilder: (_, __, ___) => _buildErrorWidget(context),
             );
@@ -108,8 +127,13 @@ class CakeImageWidget extends StatelessWidget {
     return imageWidget;
   }
 
+  /// A caller-supplied [loadingWidget] owns its own semantics; the built-in
+  /// spinner is purely visual and must not become an unnamed focus stop.
+  Widget _buildLoadingWidget() =>
+      loadingWidget ?? const ExcludeSemantics(child: Center(child: CircularProgressIndicator()));
+
   Widget _buildErrorWidget(BuildContext context) {
-    return Container(
+    final Widget placeholder = Container(
       height: height,
       width: width,
       decoration: BoxDecoration(
@@ -125,5 +149,20 @@ class CakeImageWidget extends StatelessWidget {
             ),
       ),
     );
+
+    // Several call sites render meaningful content (e.g. the asset's initials) as
+    // their [errorWidget], so leave its semantics to the caller.
+    if (errorWidget != null) {
+      return placeholder;
+    }
+
+    return _isDecorative
+        ? ExcludeSemantics(child: placeholder)
+        : Semantics(
+            container: true,
+            image: true,
+            label: semanticsLabel,
+            child: ExcludeSemantics(child: placeholder),
+          );
   }
 }

--- a/lib/src/widgets/rounded_checkbox.dart
+++ b/lib/src/widgets/rounded_checkbox.dart
@@ -3,13 +3,21 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class RoundedCheckbox extends StatelessWidget {
-  RoundedCheckbox({Key? key, required this.value}) : super(key: key);
+  RoundedCheckbox({Key? key, required this.value, this.excludeFromSemantics = false})
+      : super(key: key);
 
   final bool value;
 
+  /// Set to `true` when an ancestor already exposes the selection state (for
+  /// example a row wrapped in `Semantics(selected: ...)`), so the same state is
+  /// not announced twice.
+  final bool excludeFromSemantics;
+
   @override
   Widget build(BuildContext context) {
-    return value
+    // Unchecked renders nothing at all, so without an explicit `checked` state
+    // the selection is invisible to screen readers.
+    final Widget indicator = value
         ? Container(
             height: 20.0,
             width: 20.0,
@@ -17,11 +25,21 @@ class RoundedCheckbox extends StatelessWidget {
               borderRadius: BorderRadius.all(Radius.circular(50.0)),
               color: Theme.of(context).colorScheme.primary,
             ),
-            child: Icon(
-              Icons.check,
-              color: Theme.of(context).colorScheme.surface,
-              size: 14.0,
+            child: ExcludeSemantics(
+              child: Icon(
+                Icons.check,
+                color: Theme.of(context).colorScheme.surface,
+                size: 14.0,
+              ),
             ))
-        : Offstage();
+        : const Offstage();
+
+    if (excludeFromSemantics) {
+      return ExcludeSemantics(child: indicator);
+    }
+
+    // Deliberately not a semantics container: the state merges into the
+    // enclosing row/option node instead of adding a second focus stop.
+    return Semantics(checked: value, child: indicator);
   }
 }

--- a/lib/src/widgets/rounded_checkbox.dart
+++ b/lib/src/widgets/rounded_checkbox.dart
@@ -3,15 +3,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class RoundedCheckbox extends StatelessWidget {
-  RoundedCheckbox({Key? key, required this.value, this.excludeFromSemantics = false})
-      : super(key: key);
+  RoundedCheckbox({Key? key, required this.value}) : super(key: key);
 
   final bool value;
-
-  /// Set to `true` when an ancestor already exposes the selection state (for
-  /// example a row wrapped in `Semantics(selected: ...)`), so the same state is
-  /// not announced twice.
-  final bool excludeFromSemantics;
 
   @override
   Widget build(BuildContext context) {
@@ -25,18 +19,12 @@ class RoundedCheckbox extends StatelessWidget {
               borderRadius: BorderRadius.all(Radius.circular(50.0)),
               color: Theme.of(context).colorScheme.primary,
             ),
-            child: ExcludeSemantics(
-              child: Icon(
-                Icons.check,
-                color: Theme.of(context).colorScheme.surface,
-                size: 14.0,
-              ),
+            child: Icon(
+              Icons.check,
+              color: Theme.of(context).colorScheme.surface,
+              size: 14.0,
             ))
-        : const Offstage();
-
-    if (excludeFromSemantics) {
-      return ExcludeSemantics(child: indicator);
-    }
+        : Offstage();
 
     // Deliberately not a semantics container: the state merges into the
     // enclosing row/option node instead of adding a second focus stop.

--- a/lib/utils/address_formatter.dart
+++ b/lib/utils/address_formatter.dart
@@ -80,12 +80,25 @@ class AddressFormatter {
       spans.add(TextSpan(text: '${chunks[i]} ', style: style));
     }
 
-    return RichText(
-      text: TextSpan(children: spans),
-      textAlign: textAlign ?? TextAlign.start,
-      overflow: TextOverflow.visible,
+    return _withAddressSemantics(
+      address: address,
+      child: RichText(
+        text: TextSpan(children: spans),
+        textAlign: textAlign ?? TextAlign.start,
+        overflow: TextOverflow.visible,
+      ),
     );
   }
+
+  /// The visual segmentation turns an address into space-separated pseudo-words
+  /// (and, when truncated, into a literal "..."), which cannot be used to verify
+  /// an address by ear. Announce the full address instead, exactly the way
+  /// `Text.semanticsLabel` does.
+  static Widget _withAddressSemantics({required String address, required Widget child}) =>
+      Semantics(
+        label: address,
+        child: ExcludeSemantics(child: child),
+      );
 
   static Widget _buildTruncatedAddress({
     required String address,
@@ -112,10 +125,13 @@ class AddressFormatter {
         TextSpan(text: lastChunk, style: evenTextStyle),
       ];
 
-      return RichText(
-        text: TextSpan(children: spans),
-        textAlign: textAlign ?? TextAlign.start,
-        overflow: TextOverflow.visible,
+      return _withAddressSemantics(
+        address: address,
+        child: RichText(
+          text: TextSpan(children: spans),
+          textAlign: textAlign ?? TextAlign.start,
+          overflow: TextOverflow.visible,
+        ),
       );
     } else {
       final int digitCount = chunkSize;
@@ -142,10 +158,13 @@ class AddressFormatter {
         TextSpan(text: lastPart, style: evenTextStyle),
       ];
 
-      return RichText(
-        text: TextSpan(children: spans),
-        textAlign: textAlign ?? TextAlign.start,
-        overflow: TextOverflow.visible,
+      return _withAddressSemantics(
+        address: address,
+        child: RichText(
+          text: TextSpan(children: spans),
+          textAlign: textAlign ?? TextAlign.start,
+          overflow: TextOverflow.visible,
+        ),
       );
     }
   }

--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -832,6 +832,7 @@
   "public_key": "Public key",
   "purchase_gift_card": "Purchase Gift Card",
   "purple_dark_theme": "Purple Dark Theme",
+  "qr_close_fullscreen": "Tap to close full screen QR code",
   "qr_code_format": "QR Code Format",
   "qr_code_format_body": "BCUR (Blockchain Commons Uniform Resources) is the industry standard, and most widely compatible with Bitcoin hardware wallets, and should be selected by most users. BBQR (Better Bitcoin QR) is a unique format used only by COLDCARD hardware wallets, starting with their model Q.",
   "qr_code_format_note": "Different QR code formats are used by different hardware wallets in the Bitcoin space",

--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -835,6 +835,7 @@
   "qr_code_format": "QR Code Format",
   "qr_code_format_body": "BCUR (Blockchain Commons Uniform Resources) is the industry standard, and most widely compatible with Bitcoin hardware wallets, and should be selected by most users. BBQR (Better Bitcoin QR) is a unique format used only by COLDCARD hardware wallets, starting with their model Q.",
   "qr_code_format_note": "Different QR code formats are used by different hardware wallets in the Bitcoin space",
+  "qr_code_receive_address": "QR code for your receive address",
   "qr_fullscreen": "Tap to open full screen QR code",
   "qr_instruction": "Use this address to receive any token or collectible on",
   "qr_payment_amount": "This QR code contains a payment amount. Do you want to overwrite the current value?",


### PR DESCRIPTION
Issue Number (if Applicable): Related to #3402, #3406 — Jira [CW-1574](https://cakej.atlassian.net/browse/CW-1574)

# Description

Part 3 of the screen-reader accessibility remediation (VoiceOver/TalkBack): image and compact-icon primitives.

**Changes**
- `CakeImageWidget` (186 call sites): new optional `semanticsLabel`, honored in all four render branches (precompiled vector asset, raster asset, network SVG, network raster). `null` — the default — now means genuinely decorative: the image contributes **no** accessibility node instead of an unnamed `image` node. Built-in loading spinners and the error placeholder no longer create unlabeled focus stops; caller-supplied `errorWidget`s keep their own semantics (several call sites render meaningful initials there).
- `FloatingIconButton`: new **required** `semanticLabel`, exposed as one labeled button node. All 6 call sites migrated (paste ×4, scan QR, address book) using existing ARB keys.
- `RoundedCheckbox`: previously the unchecked state rendered `Offstage()` — selection state was completely invisible to screen readers. It now always exposes `checked:` state (no visual change), with an `excludeFromSemantics` escape hatch for rows that announce their own selection (used by the receive address-type list PR in this series).
- Receive QR code: the QR block is now a single labeled button node ("QR code for your receive address", hint = existing `qr_fullscreen` key), with the QR matrix, embedded logo, badge and wordmark excluded; the payjoin badge merges icon+text into one node.
- `AddressFormatter`: both segmented-address `RichText` builders now carry the **full** address as their semantics label, so screen readers read the actual address instead of 4-character pseudo-words ("beesh onekay…") or "dot dot dot" for the truncation ellipsis. This is the security-critical fix that makes destination-address verification by ear possible.
- 1 new English-only ARB key: `qr_code_receive_address`.

**Notes for reviewers**
- Screen readers will read the address label as a continuous string; a character-by-character "spell out" affordance is a possible future UX improvement, but a correct continuous read is a strict improvement over chunk pseudo-words.
- FloatingIconButton's 30×30 hit target remains below the 44/48pt platform minimums — deliberately not changed here to keep this PR visual-change-free; flagged for a follow-up.

**Verification**
- `flutter analyze` (Flutter 3.41.9, same as CI) — zero new issues vs `dev` baseline. flutter_svg 2.2.x API names verified against the resolved package.
- No visual or pointer-behavior changes; all `ValueKey`s preserved.
- Widget tests land in the dedicated test PR at the end of this series; on-device VoiceOver/TalkBack verification pending.

# Pull Request - Checklist

- [ ] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed
