### PR TITLE
security: fail closed when the app is paused behind an in-app browser

### DIFF
--- a/lib/src/screens/root/root.dart
+++ b/lib/src/screens/root/root.dart
@@ -23,6 +23,7 @@ import 'package:flutter/material.dart';
 import 'package:mobx/mobx.dart';
 import 'package:trezor_connect/trezor_connect.dart';
 import 'package:uni_links/uni_links.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class Root extends StatefulWidget {
   Root({
@@ -61,6 +62,7 @@ class RootState extends State<Root> with WidgetsBindingObserver {
       : _isInactiveController = StreamController<bool>.broadcast(),
         _isInactive = false,
         _requestAuth = true,
+        _authRequired = false,
         _postFrameCallback = false;
 
   Stream<bool> get isInactive => _isInactiveController.stream;
@@ -68,6 +70,17 @@ class RootState extends State<Root> with WidgetsBindingObserver {
   bool _isInactive;
   bool _postFrameCallback;
   bool _requestAuth;
+
+  /// Set as soon as the app leaves the foreground while unlocked, and cleared
+  /// only once the user has actually authenticated again.
+  ///
+  /// This deliberately outlives [_isInactive], which is reset on resume: the
+  /// lock must not be released just because the app came back, only because
+  /// the PIN was entered. Note that the app is also paused while a native
+  /// in-app browser (SFSafariViewController / Custom Tab) covers it, and while
+  /// paused Flutter disables frame production, so [build] cannot be relied on
+  /// to schedule the unlock screen.
+  bool _authRequired;
 
   StreamSubscription<Uri?>? stream;
   ReactionDisposer? _walletReactionDisposer;
@@ -170,8 +183,14 @@ class RootState extends State<Root> with WidgetsBindingObserver {
           return;
         }
 
-        if (!_isInactive && widget.authenticationStore.state == AuthenticationState.allowed) {
-          setState(() => _setInactive(true));
+        if (widget.authenticationStore.state == AuthenticationState.allowed) {
+          setState(() {
+            _authRequired = true;
+
+            if (!_isInactive) {
+              _setInactive(true);
+            }
+          });
         }
 
         if (widget.appStore.wallet?.type == WalletType.bitcoin) {
@@ -183,7 +202,9 @@ class RootState extends State<Root> with WidgetsBindingObserver {
         break;
       case AppLifecycleState.resumed:
 
-        // Reset inactive state when app resumes
+        // Reset inactive state when app resumes. Note that this does NOT
+        // release the lock: _authRequired stays set until the user has
+        // authenticated.
         if (_isInactive) setState(() => _setInactive(false));
 
         widget.authService.requireAuth().then((value) {
@@ -191,6 +212,7 @@ class RootState extends State<Root> with WidgetsBindingObserver {
             setState(() {
               _requestAuth = value;
             });
+            _presentAuthIfRequired();
           }
         });
         if (widget.appStore.wallet?.type == WalletType.bitcoin &&
@@ -250,54 +272,78 @@ class RootState extends State<Root> with WidgetsBindingObserver {
     }
   }
 
+  /// Pushes the unlock screen if the app owes the user an authentication.
+  ///
+  /// Called both from [didChangeAppLifecycleState] and from [build]. The
+  /// lifecycle path is the reliable one: while the app is paused Flutter stops
+  /// producing frames, so [build] may never run to schedule it.
+  void _presentAuthIfRequired() {
+    if (!_authRequired || !_requestAuth || _postFrameCallback) {
+      return;
+    }
+
+    final navigator = widget.navigatorKey.currentState;
+
+    if (navigator == null) {
+      // Too early to navigate; build() will retry once the navigator exists.
+      return;
+    }
+
+    _postFrameCallback = true;
+
+    // A native in-app browser (SFSafariViewController / Custom Tab) is
+    // presented above the whole Flutter view, so it would keep covering the
+    // unlock screen we are about to push.
+    closeInAppWebView();
+
+    navigator.pushNamed(
+      Routes.unlock,
+      arguments: (bool isAuthenticatedSuccessfully, AuthPageState auth) {
+        if (!isAuthenticatedSuccessfully) {
+          return;
+        }
+        final useTotp = widget.appStore.settingsStore.useTOTP2FA;
+        final shouldUseTotp2FAToAccessWallets =
+            widget.appStore.settingsStore.shouldRequireTOTP2FAForAccessingWallet;
+        if (useTotp && shouldUseTotp2FAToAccessWallets) {
+          _reset();
+          auth.close(
+            route: Routes.totpAuthCodePage,
+            arguments: TotpAuthArgumentsModel(
+              onTotpAuthenticationFinished:
+                  (bool isAuthenticatedSuccessfully, TotpAuthCodePageState totpAuth) {
+                if (!isAuthenticatedSuccessfully) {
+                  return;
+                }
+                _reset();
+                totpAuth.close(
+                  route: widget.linkViewModel.getRouteToGo(),
+                  arguments: widget.linkViewModel.getRouteArgs(),
+                );
+                widget.linkViewModel.currentLink = null;
+              },
+              isForSetup: false,
+              isClosable: false,
+            ),
+          );
+        } else {
+          _reset();
+          auth.close(
+            route: widget.linkViewModel.getRouteToGo(),
+            arguments: widget.linkViewModel.getRouteArgs(),
+          );
+          widget.linkViewModel.currentLink = null;
+        }
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     // this only happens when the app has been in the background for some time
     // this does NOT trigger when the app is started from the "closed" state!
-    if (_isInactive && !_postFrameCallback && _requestAuth) {
-      _postFrameCallback = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        widget.navigatorKey.currentState?.pushNamed(
-          Routes.unlock,
-          arguments: (bool isAuthenticatedSuccessfully, AuthPageState auth) {
-            if (!isAuthenticatedSuccessfully) {
-              return;
-            }
-            final useTotp = widget.appStore.settingsStore.useTOTP2FA;
-            final shouldUseTotp2FAToAccessWallets =
-                widget.appStore.settingsStore.shouldRequireTOTP2FAForAccessingWallet;
-            if (useTotp && shouldUseTotp2FAToAccessWallets) {
-              _reset();
-              auth.close(
-                route: Routes.totpAuthCodePage,
-                arguments: TotpAuthArgumentsModel(
-                  onTotpAuthenticationFinished:
-                      (bool isAuthenticatedSuccessfully, TotpAuthCodePageState totpAuth) {
-                    if (!isAuthenticatedSuccessfully) {
-                      return;
-                    }
-                    _reset();
-                    totpAuth.close(
-                      route: widget.linkViewModel.getRouteToGo(),
-                      arguments: widget.linkViewModel.getRouteArgs(),
-                    );
-                    widget.linkViewModel.currentLink = null;
-                  },
-                  isForSetup: false,
-                  isClosable: false,
-                ),
-              );
-            } else {
-              _reset();
-              auth.close(
-                route: widget.linkViewModel.getRouteToGo(),
-                arguments: widget.linkViewModel.getRouteArgs(),
-              );
-              widget.linkViewModel.currentLink = null;
-            }
-          },
-        );
-      });
+    if (_authRequired && !_postFrameCallback && _requestAuth) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _presentAuthIfRequired());
     }
 
     return WillPopScope(
@@ -309,6 +355,7 @@ class RootState extends State<Root> with WidgetsBindingObserver {
   void _reset() {
     setState(() {
       _postFrameCallback = false;
+      _authRequired = false;
       _setInactive(false);
     });
 

--- a/lib/view_model/anonpay_details_view_model.dart
+++ b/lib/view_model/anonpay_details_view_model.dart
@@ -74,6 +74,7 @@ abstract class AnonpayDetailsViewModelBase with Store {
     items.add(TrackTradeListItem(
         title: S.current.track,
         value: invoiceDetail.clearnetStatusUrl,
-        onTap: () => launchUrlString(invoiceDetail.clearnetStatusUrl)));
+        onTap: () => launchUrlString(invoiceDetail.clearnetStatusUrl,
+            mode: LaunchMode.externalApplication)));
   }
 }

--- a/lib/view_model/transaction_details_view_model.dart
+++ b/lib/view_model/transaction_details_view_model.dart
@@ -504,7 +504,9 @@ abstract class TransactionDetailsViewModelBase with Store {
   String get explorerDescription => S.current.view_transaction_on + Uri.parse(_explorerUrl).host;
 
   void launchExplorer() {
-    launchUrl(Uri.parse(_explorerUrl));
+    // Deliberately not the in-app browser: it is presented above the whole
+    // Flutter view, so the app lock cannot cover the transaction it shows.
+    launchUrl(Uri.parse(_explorerUrl), mode: LaunchMode.externalApplication);
   }
 
   void addBumpFeesListItems(TransactionInfo tx, String rawTransaction) {


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

Fixes a reported app-lock bypass: with the in-app browser open, backgrounding
and reopening the app skips the PIN prompt entirely, even with
**Require PIN after: Always**. Authentication bypass, CWE-288.

## Root cause

Two defects in `RootState` combine:

**1. The unlock screen was only ever scheduled from `build()`.**
Flutter disables frame production while the lifecycle state is `paused`
(`SchedulerBinding.handleAppLifecycleStateChanged` → `_setFramesEnabledState(false)`).
The `setState()` in the `paused` handler therefore produced no frame, `build()`
never ran, and the unlock route was never pushed. In the ordinary case this only
worked by luck: iOS renders an app-switcher snapshot frame on the way out, which
happens to run `build()`.

**2. `resumed` cleared `_isInactive` unconditionally**, with no check that the
user had actually authenticated. Once cleared, `build()`'s guard no longer held
and the lock was simply gone.

A native in-app browser (`SFSafariViewController` on iOS, Custom Tab on Android)
pauses Flutter for as long as it is on top. I confirmed on a simulator that **no
`resumed` event is delivered at all** while the browser covers the app — so
backgrounding and returning is completely invisible to the lock logic. It only
sees `resumed` once the browser is dismissed, at which point defect 2 has
already thrown the flag away.

## Changes

- `root.dart`: track the owed authentication in a dedicated `_authRequired`
  flag, set when the app is paused while unlocked and cleared **only** by
  `_reset()` after a successful authentication. `build()` gates on that instead
  of `_isInactive` (which keeps its existing "app is backgrounded" meaning for
  the `isInactive` stream and brightness handling).
- `root.dart`: present the unlock screen from the lifecycle handler as well as
  from `build()`, so it no longer depends on a frame being rendered while
  paused. Extracted into `_presentAuthIfRequired()`; the `_postFrameCallback`
  latch keeps it single-shot.
- `root.dart`: dismiss any native in-app browser when the unlock screen is
  pushed — it is presented above the entire Flutter view and would otherwise
  keep covering the PIN screen.
- `transaction_details_view_model.dart` / `anonpay_details_view_model.dart`:
  open block explorer and anonpay status links with
  `LaunchMode.externalApplication`, so wallet-identifying pages are not
  rendered inside an app that considers itself locked. This makes them
  consistent with the trade, bridge, payjoin and order detail screens, which
  already do this.

## Verification

Built a harness on an iOS 26.5 simulator that reproduces `RootState`'s state
machine exactly, and drove the PoC sequence (open explorer link → background →
return). Instrumented lifecycle states, `framesEnabled` and every `build()`.

| Case | Result |
| --- | --- |
| Current logic, frame rendered while paused | PIN pushed, but *underneath* the browser — explorer page fully visible on return |
| Current logic, no frame while paused | No PIN at all — reopens straight into wallet content |
| Patched logic, no frame while paused | PIN screen shown |
| Patched logic + `externalApplication` (this PR) | PIN screen shown immediately on return |

Confirmed along the way: opening the in-app browser alone drives Flutter to
`inactive → hidden → paused`, and no lifecycle event whatsoever is delivered
when the app is foregrounded again while the browser is on top.

# Pull Request - Checklist

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed
