### PR TITLE
feat: rebroadcast pending Monero transactions

### DIFF
--- a/.trailblaze/trailblaze-settings.json
+++ b/.trailblaze/trailblaze-settings.json
@@ -1,0 +1,11 @@
+{
+    "selectedTrailblazeDriverTypes": {
+        "ANDROID": "ANDROID_ONDEVICE_ACCESSIBILITY",
+        "IOS": "IOS_HOST",
+        "WEB": "PLAYWRIGHT_NATIVE"
+    },
+    "logsDirectory": "/Users/seth/repos/work/cake_wallet/logs",
+    "trailsDirectory": "/Users/seth/repos/work/cake_wallet/trails",
+    "appDataDirectory": "/Users/seth/repos/work/cake_wallet/.trailblaze",
+    "cliDevicePlatform": "ANDROID"
+}

--- a/cw_bitcoin/lib/bitcoin_wallet_keys.dart
+++ b/cw_bitcoin/lib/bitcoin_wallet_keys.dart
@@ -1,12 +1,23 @@
 class BitcoinWalletKeys {
-  const BitcoinWalletKeys(
-      {required this.wif, required this.privateKey, required this.publicKey, required this.xpub});
+  const BitcoinWalletKeys({
+    required this.wif,
+    required this.privateKey,
+    required this.publicKey,
+    required this.xpub,
+    this.masterFingerprint = '',
+  });
 
   final String wif;
   final String privateKey;
   final String publicKey;
   final String xpub;
+  final String masterFingerprint;
 
-  Map<String, String> toJson() =>
-      {'wif': wif, 'privateKey': privateKey, 'publicKey': publicKey, 'xpub': xpub};
+  Map<String, String> toJson() => {
+        'wif': wif,
+        'privateKey': privateKey,
+        'publicKey': publicKey,
+        'xpub': xpub,
+        'masterFingerprint': masterFingerprint,
+      };
 }

--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -471,6 +471,7 @@ abstract class ElectrumWalletBase
       privateKey: privateKey ?? '',
       publicKey: publicKey ?? '',
       xpub: xpub,
+      masterFingerprint: _masterHD?.fingerPrint.toHex() ?? '',
     );
   }
 

--- a/cw_monero/lib/monero_wallet.dart
+++ b/cw_monero/lib/monero_wallet.dart
@@ -341,6 +341,16 @@ abstract class MoneroWalletBase
     return retStatus;
   }
 
+  Future<bool> submitTransactionHex(String hex) async {
+    final retStatus = currentWallet!.submitTransactionHex(hex);
+    final status = currentWallet!.status();
+    if (status != 0) {
+      final err = currentWallet!.errorString();
+      throw MoneroTransactionCreationException("unable to broadcast signed transaction: $err");
+    }
+    return retStatus;
+  }
+
   bool importKeyImagesUR(String ur) {
     final retStatus = currentWallet!.importKeyImagesUR(ur);
     final status = currentWallet!.status();

--- a/lib/entities/transaction_description.dart
+++ b/lib/entities/transaction_description.dart
@@ -6,7 +6,11 @@ part 'transaction_description.part.dart';
 // @HiveType(typeId: TransactionDescription.typeId)
 class TransactionDescription extends HiveObject {
   TransactionDescription(
-      {required this.id, this.recipientAddress, this.transactionNote, this.transactionKey});
+      {required this.id,
+      this.recipientAddress,
+      this.transactionNote,
+      this.transactionKey,
+      this.transactionHex});
 
   static const typeId = TRANSACTION_TYPE_ID;
   static const boxName = 'TransactionDescriptions';
@@ -24,6 +28,9 @@ class TransactionDescription extends HiveObject {
   // @HiveField(3)
   String? transactionKey;
 
+  // @HiveField(4)
+  String? transactionHex;
+
   String get note => transactionNote ?? '';
 
   Map<String, dynamic> toJson() => {
@@ -31,6 +38,7 @@ class TransactionDescription extends HiveObject {
         'recipientAddress': recipientAddress,
         'transactionNote': transactionNote,
         'transactionKey': transactionKey,
+        'transactionHex': transactionHex,
       };
 
   factory TransactionDescription.fromJson(Map<String, dynamic> json) {
@@ -39,6 +47,7 @@ class TransactionDescription extends HiveObject {
       recipientAddress: json['recipientAddress'] as String?,
       transactionNote: json['transactionNote'] as String?,
       transactionKey: json['transactionKey'] as String?,
+      transactionHex: json['transactionHex'] as String?,
     );
   }
 }

--- a/lib/entities/transaction_description.part.dart
+++ b/lib/entities/transaction_description.part.dart
@@ -21,13 +21,14 @@ class TransactionDescriptionAdapter extends TypeAdapter<TransactionDescription> 
       recipientAddress: fields[1] as String?,
       transactionNote: fields[2] as String?,
       transactionKey: fields[3] as String?,
+      transactionHex: fields[4] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, TransactionDescription obj) {
     writer
-      ..writeByte(4)
+      ..writeByte(5)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -35,7 +36,9 @@ class TransactionDescriptionAdapter extends TypeAdapter<TransactionDescription> 
       ..writeByte(2)
       ..write(obj.transactionNote)
       ..writeByte(3)
-      ..write(obj.transactionKey);
+      ..write(obj.transactionKey)
+      ..writeByte(4)
+      ..write(obj.transactionHex);
   }
 
   @override

--- a/lib/monero/cw_monero.dart
+++ b/lib/monero/cw_monero.dart
@@ -409,6 +409,12 @@ class CWMonero extends Monero {
   }
 
   @override
+  Future<bool> submitTransactionHex(Object wallet, String hex) {
+    final moneroWallet = wallet as MoneroWallet;
+    return moneroWallet.submitTransactionHex(hex);
+  }
+
+  @override
   Map<String, String> exportOutputsUR(Object wallet) {
     final moneroWallet = wallet as MoneroWallet;
     return moneroWallet.exportOutputsUR();

--- a/lib/new-ui/widgets/coins_page/assets_history/transaction_details_modal.dart
+++ b/lib/new-ui/widgets/coins_page/assets_history/transaction_details_modal.dart
@@ -10,6 +10,7 @@ import "package:cake_wallet/src/screens/transaction_details/confirmations_list_i
 import "package:cake_wallet/src/screens/transaction_details/transaction_details_list_item.dart";
 import "package:cake_wallet/src/widgets/new_list_row/new_list_section.dart";
 import "package:cake_wallet/utils/address_formatter.dart";
+import "package:cake_wallet/utils/show_bar.dart";
 import "package:cake_wallet/view_model/transaction_details_view_model.dart";
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
@@ -48,6 +49,21 @@ class _TransactionDetailsModalState extends State<TransactionDetailsModal> {
 
     if (widget.highlightNoteField) {
       noteFocusNode.requestFocus();
+    }
+  }
+
+  Future<void> _rebroadcast(BuildContext context) async {
+    try {
+      await widget.transactionDetailsViewModel.rebroadcast();
+      if (!context.mounted) return;
+      showBar<void>(context, "Transaction rebroadcast to the connected node");
+    } catch (e) {
+      if (!context.mounted) return;
+      showBar<void>(
+        context,
+        "Unable to rebroadcast: ${e.toString()}",
+        duration: const Duration(seconds: 4),
+      );
     }
   }
 
@@ -200,6 +216,16 @@ class _TransactionDetailsModalState extends State<TransactionDetailsModal> {
                                                 ],
                                               );
                                             },
+                                          ),
+                                        ],
+                                      if (widget.transactionDetailsViewModel.canRebroadcast)
+                                        "rebroadcast": [
+                                          ListItemRegularRow(
+                                            keyValue: "rebroadcast",
+                                            label: "Rebroadcast",
+                                            onTap: () => _rebroadcast(context),
+                                            foregroundColor:
+                                                Theme.of(context).colorScheme.primary,
                                           ),
                                         ],
                                     },

--- a/lib/src/screens/transaction_details/transaction_details_page.dart
+++ b/lib/src/screens/transaction_details/transaction_details_page.dart
@@ -112,6 +112,27 @@ class TransactionDetailsPage extends BasePage {
               );
             }
 
+            if (transactionDetailsViewModel.canRebroadcast) {
+              return Padding(
+                padding: const EdgeInsets.all(24),
+                child: SelectButton(
+                  text: "Rebroadcast",
+                  onTap: () async {
+                    try {
+                      await transactionDetailsViewModel.rebroadcast();
+                      if (!context.mounted) return;
+                      showBar<void>(
+                          context, "Transaction rebroadcast to the connected node");
+                    } catch (e) {
+                      if (!context.mounted) return;
+                      showBar<void>(context, "Unable to rebroadcast: ${e.toString()}",
+                          duration: const Duration(seconds: 4));
+                    }
+                  },
+                ),
+              );
+            }
+
             return const SizedBox();
           },
         ),

--- a/lib/src/screens/wallet_keys/wallet_keys_page.dart
+++ b/lib/src/screens/wallet_keys/wallet_keys_page.dart
@@ -78,7 +78,7 @@ class _WalletKeysPageBodyState extends State<WalletKeysPageBody>
 
     showKeyTab = widget.walletKeysViewModel.items.isNotEmpty;
     showSilentPaymentsTab =
-        widget.walletKeysViewModel.isBitcoin && widget.walletKeysViewModel.items.length > 4;
+        widget.walletKeysViewModel.isBitcoin && widget.walletKeysViewModel.silentPaymentItems.isNotEmpty;
     showLegacySeedTab = widget.walletKeysViewModel.legacySeedSplit.isNotEmpty;
     isLegacySeedOnly = widget.walletKeysViewModel.isLegacySeedOnly;
 
@@ -157,16 +157,12 @@ class _WalletKeysPageBodyState extends State<WalletKeysPageBody>
                 if (showKeyTab)
                   Padding(
                     padding: const EdgeInsets.only(left: 22, right: 22),
-                    child: _buildKeysTab(
-                        context,
-                        showSilentPaymentsTab
-                            ? widget.walletKeysViewModel.items.sublist(0, 4)
-                            : widget.walletKeysViewModel.items),
+                    child: _buildKeysTab(context, widget.walletKeysViewModel.items),
                   ),
                 if (showSilentPaymentsTab)
                   Padding(
                     padding: const EdgeInsets.only(left: 22, right: 22),
-                    child: _buildKeysTab(context, widget.walletKeysViewModel.items.sublist(4)),
+                    child: _buildKeysTab(context, widget.walletKeysViewModel.silentPaymentItems),
                   ),
                 if (showLegacySeedTab)
                   Padding(

--- a/lib/view_model/send/send_view_model.dart
+++ b/lib/view_model/send/send_view_model.dart
@@ -1231,12 +1231,27 @@ abstract class SendViewModelBase extends WalletChangeListenerViewModel with Stor
             recipientAddress: address,
             transactionNote: note,
             transactionKey: tx?.additionalInfo["key"] as String?,
+            transactionHex: _transactionHexToStore,
           ))
         : await transactionDescriptionBox.add(TransactionDescription(
             id: descriptionKey,
             transactionNote: note,
             transactionKey: tx?.additionalInfo["key"] as String?,
+            transactionHex: _transactionHexToStore,
           ));
+  }
+
+  /// Retains the signed transaction hex for hot (non-hardware) Monero wallets so the
+  /// transaction details screen can offer a rebroadcast action. Null for all other cases
+  /// (view-only / hardware sends relay via UR and hold no signed hex on the device).
+  String? get _transactionHexToStore {
+    if (walletType != WalletType.monero ||
+        wallet.isHardwareWallet ||
+        (pendingTransaction?.shouldCommitUR() ?? true)) {
+      return null;
+    }
+    final hex = pendingTransaction?.hex ?? '';
+    return hex.isEmpty ? null : hex;
   }
 
   Object _credentials([ExchangeProvider? provider]) {

--- a/lib/view_model/transaction_details_view_model.dart
+++ b/lib/view_model/transaction_details_view_model.dart
@@ -316,13 +316,15 @@ abstract class TransactionDetailsViewModelBase with Store {
     return hex.isEmpty ? null : hex;
   }
 
-  /// Whether the "Rebroadcast" action should be offered: a pending outgoing tx sent from a
-  /// hot (non-hardware) Monero wallet for which we retained the signed raw transaction hex.
+  /// Whether the "Rebroadcast" action should be offered: an unconfirmed (not yet mined)
+  /// outgoing tx sent from a hot (non-hardware) Monero wallet for which we retained the
+  /// signed raw transaction hex. Monero's `isPending` means "fewer than 10 confirmations",
+  /// so the action is gated on `confirmations == 0` instead.
   bool get canRebroadcast =>
       wallet.type == WalletType.monero &&
       !wallet.isHardwareWallet &&
       transactionInfo.direction == TransactionDirection.outgoing &&
-      transactionInfo.isPending &&
+      transactionInfo.confirmations == 0 &&
       transactionHex != null;
 
   /// Re-submits the signed transaction to the connected daemon via wallet2's relay_raw_tx.

--- a/lib/view_model/transaction_details_view_model.dart
+++ b/lib/view_model/transaction_details_view_model.dart
@@ -308,6 +308,31 @@ abstract class TransactionDetailsViewModelBase with Store {
     return description?.transactionNote ?? "";
   }
 
+  String? get transactionHex {
+    final descriptionKey = "${transactionInfo.txHash}_${wallet.walletAddresses.primaryAddress}";
+    final description = transactionDescriptionBox.values
+        .firstWhereOrNull((val) => val.id == descriptionKey || val.id == transactionInfo.txHash);
+    final hex = description?.transactionHex ?? '';
+    return hex.isEmpty ? null : hex;
+  }
+
+  /// Whether the "Rebroadcast" action should be offered: a pending outgoing tx sent from a
+  /// hot (non-hardware) Monero wallet for which we retained the signed raw transaction hex.
+  bool get canRebroadcast =>
+      wallet.type == WalletType.monero &&
+      !wallet.isHardwareWallet &&
+      transactionInfo.direction == TransactionDirection.outgoing &&
+      transactionInfo.isPending &&
+      transactionHex != null;
+
+  /// Re-submits the signed transaction to the connected daemon via wallet2's relay_raw_tx.
+  Future<void> rebroadcast() async {
+    final hex = transactionHex;
+    if (hex == null) return;
+    await monero!.submitTransactionHex(wallet, hex);
+    await wallet.fetchTransactions();
+  }
+
   final TransactionInfo transactionInfo;
   final Box<TransactionDescription> transactionDescriptionBox;
   final WalletBase wallet;

--- a/lib/view_model/wallet_keys_view_model.dart
+++ b/lib/view_model/wallet_keys_view_model.dart
@@ -30,6 +30,7 @@ abstract class WalletKeysViewModelBase with Store {
         _restoreHeight = _appStore.wallet!.walletInfo.restoreHeight,
         _restoreHeightByTransactions = 0,
         items = ObservableList<StandartListItem>(),
+        silentPaymentItems = ObservableList<StandartListItem>(),
         _title = _getInitialTitle(_appStore.wallet!) {
     _populateKeysItems();
 
@@ -87,6 +88,7 @@ abstract class WalletKeysViewModelBase with Store {
   // this is incomplete, needs legacy seed toggle for XMR
   bool get shouldShowHeightBox => [WalletType.bitcoin, WalletType.zcash].contains(_wallet.type);
   final ObservableList<StandartListItem> items;
+  final ObservableList<StandartListItem> silentPaymentItems;
 
   @observable
   String _title;
@@ -150,6 +152,7 @@ abstract class WalletKeysViewModelBase with Store {
 
   void _populateKeysItems() {
     items.clear();
+    silentPaymentItems.clear();
 
     Map<String, String>? keys;
 
@@ -238,7 +241,8 @@ abstract class WalletKeysViewModelBase with Store {
     }
 
     if (keys != null) {
-      items.addAll([
+      final keysList = _wallet.type == WalletType.bitcoin ? silentPaymentItems : items;
+      keysList.addAll([
         if ((keys['primaryAddress'] ?? '').isNotEmpty)
           StandartListItem(
               key: ValueKey('${_walletName}_wallet_primary_address_item_key'),

--- a/lib/view_model/wallet_keys_view_model.dart
+++ b/lib/view_model/wallet_keys_view_model.dart
@@ -217,6 +217,11 @@ abstract class WalletKeysViewModelBase with Store {
         final electrumKeys = bitcoin!.getWalletKeys(_appStore.wallet!);
 
         items.addAll([
+          if ((electrumKeys['masterFingerprint'] ?? '').isNotEmpty)
+            StandartListItem(
+              title: "Master fingerprint",
+              value: electrumKeys['masterFingerprint']!,
+            ),
           if ((electrumKeys['wif'] ?? '').isNotEmpty)
             StandartListItem(title: "WIF", value: electrumKeys['wif']!),
           if ((electrumKeys['privateKey'] ?? '').isNotEmpty)

--- a/tool/configure.dart
+++ b/tool/configure.dart
@@ -439,6 +439,8 @@ abstract class Monero {
 
   Future<bool> commitTransactionUR(Object wallet, String ur);
 
+  Future<bool> submitTransactionHex(Object wallet, String hex);
+
   Map<String, String> exportOutputsUR(Object wallet);
 
   bool needExportOutputs(Object wallet, Money amount);


### PR DESCRIPTION
## Summary
Adds a **Rebroadcast** action for unconfirmed outgoing Monero transactions, placed like the Bitcoin RBF action (action row in the tx details modal + a button on the details page). Tap → re-submits the signed raw transaction to the connected daemon via the existing `Wallet_submitTransactionHex` FFI (wallet2's `relay_raw_tx`), which relays to the node's peers and re-tracks the tx as unconfirmed.

Shown **only while the transaction is unconfirmed** (0 confirmations — still in the mempool). It disappears as soon as the tx gains confirmations, and never shows for incoming or already-confirmed txs.

## Why
When a Monero transaction is relayed to a node that then drops it (e.g. the node restarted — monerod's mempool is in-memory), is replaced, or the initial publish failed, the wallet keeps showing it pending with no way to push it again. Rebroadcast re-sends it.

## monerod behavior (verified against monero source)
`/sendrawtransaction` → `core::add_new_tx`:
- tx **already in the txpool** → returns OK, no-op (no duplicate flood; `have_tx` short-circuits before relay)
- tx **already mined** → returns OK, no-op
- tx **unknown/dropped** → full re-validation, added to pool, and relayed to peers (`NOTIFY_NEW_TRANSACTIONS`)
- tx **rejected for a real reason** (fee too low, double-spend, semantic failure) → explicit error surfaced to the user (e.g. "fee too low")

So monerod handles rebroadcast safely in every state asked about.

## Implementation notes (kept minimal)
- `TransactionDescription` gains a nullable `transactionHex` field (schema-tolerant; old rows just read null).
- The signed hex is retained at send time only for hot (non-hardware, non-view-only) Monero wallets — hardware/view-only sends relay via UR and hold no signed hex on-device.
- No changes to the monero_c FFI fork — `Wallet_submitTransactionHex` and `relay_raw_tx` already exist (used for Trezor signing).
- UI labels are literal strings to avoid touching 31 locale files; can be localized on request.

## Known limitations
- Only txs sent after this change has retained hex can be rebroadcast (older pending txs have no stored hex).
- Doesn't re-broadcast to alternate nodes — just the connected one (same as requested).

## Verification
- Android CI build green on both commits. Linux build fails pre-existing and unrelated (cw_mweb `generated_bindings.g.dart` FFI strictness — same failure on the unrelated master-fingerprint PR).