### PR TITLE
fix: match spent Bitcoin outputs by outpoint

### DIFF
--- a/cw_bitcoin/lib/bitcoin_unspent.dart
+++ b/cw_bitcoin/lib/bitcoin_unspent.dart
@@ -1,6 +1,13 @@
 import 'package:cw_bitcoin/bitcoin_address_record.dart';
 import 'package:cw_core/unspent_transaction_output.dart';
 
+bool matchesUnspentOutpoint(
+  Unspent unspent, {
+  required String transactionHash,
+  required int outputIndex,
+}) =>
+    unspent.hash == transactionHash && unspent.vout == outputIndex;
+
 class BitcoinUnspent extends Unspent {
   BitcoinUnspent(BaseBitcoinAddressRecord addressRecord, String hash, int value, int vout)
       : bitcoinAddressRecord = addressRecord,

--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -1600,14 +1600,24 @@ abstract class ElectrumWalletBase
           transactionHistory.addOne(transaction);
           if (estimatedTx.spendsSilentPayment) {
             transactionHistory.transactions.values.forEach((tx) {
-              tx.unspents?.removeWhere(
-                  (unspent) => estimatedTx.utxos.any((e) => e.utxo.txHash == unspent.hash));
+              tx.unspents?.removeWhere((unspent) => estimatedTx.utxos.any(
+                    (input) => matchesUnspentOutpoint(
+                      unspent,
+                      transactionHash: input.utxo.txHash,
+                      outputIndex: input.utxo.vout,
+                    ),
+                  ));
               transactionHistory.addOne(tx);
             });
           }
 
-          unspentCoins
-              .removeWhere((utxo) => estimatedTx.utxos.any((e) => e.utxo.txHash == utxo.hash));
+          unspentCoins.removeWhere((unspent) => estimatedTx.utxos.any(
+                (input) => matchesUnspentOutpoint(
+                  unspent,
+                  transactionHash: input.utxo.txHash,
+                  outputIndex: input.utxo.vout,
+                ),
+              ));
 
           await updateBalance();
           await updateAllUnspents();

--- a/cw_bitcoin/test/bitcoin_unspent_test.dart
+++ b/cw_bitcoin/test/bitcoin_unspent_test.dart
@@ -1,0 +1,30 @@
+import "package:cw_bitcoin/bitcoin_unspent.dart";
+import "package:cw_core/unspent_transaction_output.dart";
+import "package:flutter_test/flutter_test.dart";
+
+void main() {
+  group("matchesUnspentOutpoint", () {
+    final unspent = Unspent("address", "transaction-a", 1000, 1, null);
+
+    test("matches the same transaction hash and output index", () {
+      expect(
+        matchesUnspentOutpoint(unspent, transactionHash: "transaction-a", outputIndex: 1),
+        isTrue,
+      );
+    });
+
+    test("does not match a sibling output from the same transaction", () {
+      expect(
+        matchesUnspentOutpoint(unspent, transactionHash: "transaction-a", outputIndex: 0),
+        isFalse,
+      );
+    });
+
+    test("does not match the same output index from another transaction", () {
+      expect(
+        matchesUnspentOutpoint(unspent, transactionHash: "transaction-b", outputIndex: 1),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #3176

# Description

Bitcoin post-send cleanup removed unspents by transaction hash alone. When a transaction contained multiple wallet-owned outputs, spending one output could also remove its still-unspent sibling from cached transaction history and the in-memory unspent list.

This changes both cleanup paths to identify spent outputs by the complete outpoint: transaction hash and output index. A focused `cw_bitcoin` unit test covers exact matches, sibling outputs from the same transaction, and matching output indexes from different transactions.

## Validation

- `flutter test --no-pub test/bitcoin_unspent_test.dart`
- `flutter test --no-pub` (12 tests)
- `flutter analyze --no-pub test/bitcoin_unspent_test.dart`

# Pull Request - Checklist

- [ ] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed
