### PR TITLE
fix: keep full TRC20 Energy fee limit

### DIFF
--- a/cw_tron/lib/tron_client.dart
+++ b/cw_tron/lib/tron_client.dart
@@ -12,6 +12,7 @@ import 'package:cw_tron/default_tron_tokens.dart';
 import 'package:cw_tron/pending_tron_transaction.dart';
 import 'package:cw_tron/tron_abi.dart';
 import 'package:cw_tron/tron_balance.dart';
+import 'package:cw_tron/tron_fee_estimate.dart';
 import 'package:cw_tron/tron_http_provider.dart';
 import 'package:cw_core/tron_token.dart';
 import 'package:cw_tron/tron_transaction_model.dart';
@@ -118,7 +119,7 @@ class TronClient {
     }
   }
 
-  Future<int> getFeeLimit(
+  Future<TronFeeEstimate> getFeeEstimate(
     TransactionRaw rawTransaction,
     TronAddress address,
     TronAddress receiverAddress, {
@@ -144,52 +145,39 @@ class TronClient {
       final transactionSize = fakeTransaction.length + 64;
 
       // Assign the calculated size to the variable representing the required bandwidth.
-      int neededBandWidth = transactionSize;
+      final neededBandWidth = transactionSize;
       log('Initial Needed Bandwidth: $neededBandWidth');
 
-      int neededEnergy = energyUsed;
-      log('Initial Needed Energy: $neededEnergy');
+      log('Initial Needed Energy: $energyUsed');
 
       // Fetch account resources to assess the available bandwidth and energy
       final accountResource =
           await _provider!.request(TronRequestGetAccountResource(address: address));
 
-      neededEnergy -= accountResource.howManyEnergy.toInt();
-      log('Account resource energy: ${accountResource.howManyEnergy.toInt()}');
-      log('Needed Energy after deducting from account resource energy: $neededEnergy');
+      final availableEnergy = accountResource.howManyEnergy.toInt();
+      log('Account resource energy: $availableEnergy');
 
       // Deduct the bandwidth from the account's available bandwidth.
       final BigInt accountBandWidth = accountResource.howManyBandwIth;
       log('Account resource bandwidth: ${accountResource.howManyBandwIth.toInt()}');
 
-      if (accountBandWidth >= BigInt.from(neededBandWidth) && !isEstimatedFeeFlow) {
-        log('Account has more bandwidth than required');
-        neededBandWidth = 0;
-      }
+      final feeEstimate = calculateTronFeeEstimate(
+        energyUsed: energyUsed,
+        availableEnergy: availableEnergy,
+        energyPrice: energyInSun.toInt(),
+        bandwidthUsed: neededBandWidth,
+        availableBandwidth: accountBandWidth.toInt(),
+        bandwidthPrice: bandWidthInSun,
+        useAvailableBandwidth: !isEstimatedFeeFlow,
+        memoFee: rawTransaction.data != null ? chainParams.getMemoFee! : 0,
+      );
 
-      if (neededEnergy < 0) {
-        neededEnergy = 0;
-      }
+      log('Energy Fee Limit: ${feeEstimate.feeLimit}');
+      log('Estimated Burn: ${feeEstimate.estimatedBurn}');
 
-      final energyBurn = neededEnergy * energyInSun.toInt();
-      log('Energy Burn: $energyBurn');
-
-      final bandWidthBurn = neededBandWidth * bandWidthInSun;
-      log('Bandwidth Burn: $bandWidthBurn');
-
-      int totalBurn = energyBurn + bandWidthBurn;
-      log('Total Burn: $totalBurn');
-
-      /// If there is a note (memo), calculate the memo fee.
-      if (rawTransaction.data != null) {
-        totalBurn += chainParams.getMemoFee!;
-      }
-
-      log('Final total burn: $totalBurn');
-
-      return totalBurn;
+      return feeEstimate;
     } catch (_) {
-      return 0;
+      return const TronFeeEstimate.zero();
     }
   }
 
@@ -224,12 +212,13 @@ class TronClient {
       timestamp: block.blockHeader.rawData.timestamp,
     );
 
-    final estimatedFee = await getFeeLimit(
+    final feeEstimate = await getFeeEstimate(
       rawTransaction,
       ownerAddress,
       ownerAddress,
       isEstimatedFeeFlow: true,
     );
+    final estimatedFee = feeEstimate.estimatedBurn;
 
     _nativeTxEstimatedFee = estimatedFee;
 
@@ -256,13 +245,15 @@ class TronClient {
       log("Tron TRC20 error: ${request.error} \n ${request.respose}");
     }
 
-    return getFeeLimit(
+    final feeEstimate = await getFeeEstimate(
       request.transactionRaw!,
       ownerAddress,
       ownerAddress,
       energyUsed: request.energyUsed ?? 0,
       isEstimatedFeeFlow: true,
     );
+
+    return feeEstimate.estimatedBurn;
   }
 
   Future<PendingTronTransaction> signTransaction({
@@ -282,6 +273,7 @@ class TronClient {
 
     Money totalAmount;
     TransactionRaw rawTransaction;
+    late int estimatedFee;
     if (isNativeTransaction) {
       if (sendAll) {
         final accountResource =
@@ -308,16 +300,19 @@ class TronClient {
         tronBalance,
         sendAll,
       );
+      estimatedFee = rawTransaction.feeLimit?.toInt() ?? 0;
     } else {
       final tokenAddress = (amount.currency as TronToken).contractAddress;
       totalAmount = amount;
-      rawTransaction = await _signTrcTokenTransaction(
+      final trcTransaction = await _signTrcTokenTransaction(
         ownerAddress,
         receiverAddress,
         totalAmount,
         tokenAddress,
         tronBalance,
       );
+      rawTransaction = trcTransaction.rawTransaction;
+      estimatedFee = trcTransaction.estimatedFee;
     }
 
     final signature = ownerPrivKey.sign(rawTransaction.toBuffer());
@@ -330,7 +325,7 @@ class TronClient {
     return PendingTronTransaction(
         signedTransaction: signature,
         amount: totalAmount,
-        fee: Money(rawTransaction.feeLimit ?? BigInt.zero, CryptoCurrency.trx),
+        fee: Money(BigInt.from(estimatedFee), CryptoCurrency.trx),
         sendTransaction: sendTx,
         id: rawTransaction.txID);
   }
@@ -372,12 +367,13 @@ class TronClient {
       timestamp: block.blockHeader.rawData.timestamp,
     );
 
-    final feeLimit = await getFeeLimit(rawTransaction, ownerAddress, receiverAddress);
-    final feeLimitToUse = feeLimit != 0 ? feeLimit : defaultFeeLimit;
+    final feeEstimate = await getFeeEstimate(rawTransaction, ownerAddress, receiverAddress);
+    final estimatedBurn = feeEstimate.estimatedBurn;
+    final feeLimitToUse = estimatedBurn != 0 ? estimatedBurn : defaultFeeLimit;
     final tronBalanceInt = tronBalance.toInt();
 
-    if (feeLimit > tronBalanceInt) {
-      final feeInTrx = TronHelper.fromSun(BigInt.parse(feeLimit.toString()));
+    if (estimatedBurn > tronBalanceInt) {
+      final feeInTrx = TronHelper.fromSun(BigInt.from(estimatedBurn));
       throw Exception(
         'You don\'t have enough TRX to cover the transaction fee for this transaction. Please top up.\nTransaction fee: $feeInTrx TRX',
       );
@@ -386,7 +382,7 @@ class TronClient {
     return rawTransaction.copyWith(feeLimit: BigInt.from(feeLimitToUse));
   }
 
-  Future<TransactionRaw> _signTrcTokenTransaction(
+  Future<_PreparedTronTransaction> _signTrcTokenTransaction(
     TronAddress ownerAddress,
     TronAddress receiverAddress,
     Money amount,
@@ -410,21 +406,25 @@ class TronClient {
       throw Exception('An error occurred while creating the transfer request. Please try again.');
     }
 
-    final feeLimit = await getFeeLimit(
+    final feeEstimate = await getFeeEstimate(
       request.transactionRaw!,
       ownerAddress,
       receiverAddress,
       energyUsed: request.energyUsed ?? 0,
     );
 
-    if (feeLimit > tronBalance.toInt()) {
-      final feeInTrx = TronHelper.fromSun(BigInt.parse(feeLimit.toString()));
+    if (feeEstimate.estimatedBurn > tronBalance.toInt()) {
+      final feeInTrx = TronHelper.fromSun(BigInt.from(feeEstimate.estimatedBurn));
       throw Exception(
         'You don\'t have enough TRX to cover the transaction fee for this transaction. Please top up. Transaction fee: $feeInTrx TRX',
       );
     }
 
-    return request.transactionRaw!.copyWith(feeLimit: BigInt.from(feeLimit));
+    return _PreparedTronTransaction(
+      rawTransaction:
+          request.transactionRaw!.copyWith(feeLimit: BigInt.from(feeEstimate.feeLimit)),
+      estimatedFee: feeEstimate.estimatedBurn,
+    );
   }
 
   Future<String> sendTransaction({
@@ -533,4 +533,14 @@ class TronClient {
       return null;
     }
   }
+}
+
+class _PreparedTronTransaction {
+  const _PreparedTronTransaction({
+    required this.rawTransaction,
+    required this.estimatedFee,
+  });
+
+  final TransactionRaw rawTransaction;
+  final int estimatedFee;
 }

--- a/cw_tron/lib/tron_fee_estimate.dart
+++ b/cw_tron/lib/tron_fee_estimate.dart
@@ -1,0 +1,35 @@
+class TronFeeEstimate {
+  const TronFeeEstimate({
+    required this.feeLimit,
+    required this.estimatedBurn,
+  });
+
+  const TronFeeEstimate.zero()
+      : feeLimit = 0,
+        estimatedBurn = 0;
+
+  final int feeLimit;
+  final int estimatedBurn;
+}
+
+TronFeeEstimate calculateTronFeeEstimate({
+  required int energyUsed,
+  required int availableEnergy,
+  required int energyPrice,
+  required int bandwidthUsed,
+  required int availableBandwidth,
+  required int bandwidthPrice,
+  required bool useAvailableBandwidth,
+  int memoFee = 0,
+}) {
+  // Available Energy reduces the amount of TRX that may be burned, but it does not reduce the
+  // execution budget declared by the transaction's fee limit.
+  final energyToBurn = energyUsed > availableEnergy ? energyUsed - availableEnergy : 0;
+  final bandwidthToBurn =
+      useAvailableBandwidth && availableBandwidth >= bandwidthUsed ? 0 : bandwidthUsed;
+
+  return TronFeeEstimate(
+    feeLimit: energyUsed * energyPrice,
+    estimatedBurn: energyToBurn * energyPrice + bandwidthToBurn * bandwidthPrice + memoFee,
+  );
+}

--- a/cw_tron/test/tron_fee_estimate_test.dart
+++ b/cw_tron/test/tron_fee_estimate_test.dart
@@ -1,0 +1,54 @@
+import "package:cw_tron/tron_fee_estimate.dart";
+import "package:flutter_test/flutter_test.dart";
+
+void main() {
+  const energyUsed = 65000;
+  const energyPrice = 210;
+
+  TronFeeEstimate estimate({required int availableEnergy}) => calculateTronFeeEstimate(
+        energyUsed: energyUsed,
+        availableEnergy: availableEnergy,
+        energyPrice: energyPrice,
+        bandwidthUsed: 0,
+        availableBandwidth: 0,
+        bandwidthPrice: 1000,
+        useAvailableBandwidth: true,
+      );
+
+  test("uses the full Energy cost as the fee limit without available Energy", () {
+    final result = estimate(availableEnergy: 0);
+
+    expect(result.feeLimit, energyUsed * energyPrice);
+    expect(result.estimatedBurn, energyUsed * energyPrice);
+  });
+
+  test("available Energy reduces only the estimated burn", () {
+    final result = estimate(availableEnergy: 20000);
+
+    expect(result.feeLimit, energyUsed * energyPrice);
+    expect(result.estimatedBurn, (energyUsed - 20000) * energyPrice);
+  });
+
+  test("fully covered Energy keeps the full fee limit with no estimated burn", () {
+    final result = estimate(availableEnergy: 130000);
+
+    expect(result.feeLimit, energyUsed * energyPrice);
+    expect(result.estimatedBurn, 0);
+  });
+
+  test("bandwidth and memo fees affect the burn but not the Energy limit", () {
+    final result = calculateTronFeeEstimate(
+      energyUsed: energyUsed,
+      availableEnergy: energyUsed,
+      energyPrice: energyPrice,
+      bandwidthUsed: 300,
+      availableBandwidth: 0,
+      bandwidthPrice: 1000,
+      useAvailableBandwidth: true,
+      memoFee: 1000000,
+    );
+
+    expect(result.feeLimit, energyUsed * energyPrice);
+    expect(result.estimatedBurn, 1300000);
+  });
+}


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #2073

# Description

TRC20 transaction signing used the estimated TRX burn as the raw transaction `feeLimit`. When an account had staked, delegated, or rented Energy, that estimate was reduced by the available Energy and the resulting execution limit could be too small for the contract call.

This change separates the two values:

- the raw transaction keeps the full estimated Energy execution limit;
- the displayed fee and TRX balance check use the estimated burn after available resources.

Unit coverage verifies the behavior with no, partial, and fully covering account Energy, and keeps bandwidth and memo costs out of the Energy execution limit.

## Testing

- `cd cw_tron && flutter test --no-pub`
- `cd cw_tron && flutter analyze --no-pub lib/tron_fee_estimate.dart test/tron_fee_estimate_test.dart`

Live delegated-Energy transaction testing was not performed; this PR is opened as a draft for that final verification.

# Pull Request - Checklist

- [ ] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [x] Manual tests in accessibility mode (TalkBack on Android) passed (not applicable: no UI changes)
