### PR TITLE
fix: prevent duplicate backup imports

### DIFF
--- a/lib/view_model/restore_from_backup_view_model.dart
+++ b/lib/view_model/restore_from_backup_view_model.dart
@@ -54,6 +54,7 @@ abstract class RestoreFromBackupViewModelBase with Store {
         } else {
           state = FailureState(e.toString() + "\n" + s.toString());
         }
+        return;
       }
 
       try {
@@ -61,6 +62,7 @@ abstract class RestoreFromBackupViewModelBase with Store {
       } catch (e, s) {
         state = FailureState('Failed app initialization, please try again');
         ExceptionHandler.onError(FlutterErrorDetails(exception: e, stack: s, silent: true));
+        return;
       }
 
       final store = getIt.get<AppStore>();


### PR DESCRIPTION
Issue Number (if Applicable): Fixes CW-1608

# Description

Rejects overlapping backup import attempts while an import is already running. The restore action now exposes and clears a single in-flight state across success and failure, preventing duplicate restore calls and conflicting UI state.

# Validation

- Focused `NewFuturePrimaryButton` lifecycle suite: 13 passed
- Integrated Android debug build and launch validation performed with the candidate batch
