### PR TITLE
feat: show Bitcoin transaction fee rates

### DIFF
--- a/cw_bitcoin/lib/electrum_transaction_info.dart
+++ b/cw_bitcoin/lib/electrum_transaction_info.dart
@@ -45,6 +45,7 @@ class ElectrumTransactionInfo extends TransactionInfo {
     this.unspents,
     this.isReceivedSilentPayment = false,
     this.isHogEx = false,
+    this.vsize,
     Map<String, dynamic>? additionalInfo,
   }) {
     this.id = id;
@@ -60,6 +61,22 @@ class ElectrumTransactionInfo extends TransactionInfo {
     this.confirmations = confirmations;
     this.to = to;
     this.additionalInfo = additionalInfo ?? {};
+  }
+
+  /// Virtual size of the transaction in vbytes (segwit-adjusted). Nullable to
+  /// stay readable for legacy cached records created before this field
+  /// existed and for non-Bitcoin transaction infos, where it is never set.
+  int? vsize;
+
+  /// Actual paid fee rate in sat/vB derived from the total fee and the
+  /// transaction's virtual size. Rounding matches the half-up [Money]
+  /// division already used for the displayed fee rate. Returns null when the
+  /// fee or the vsize is unavailable, so callers must not render a rate.
+  int? get feeRateSatsPerVbyte {
+    final f = fee;
+    final v = vsize;
+    if (f == null || v == null || v <= 0) return null;
+    return (f / BigInt.from(v)).amount.toInt();
   }
 
   factory ElectrumTransactionInfo.fromElectrumVerbose(Map<String, Object> obj, WalletType type,
@@ -111,7 +128,8 @@ class ElectrumTransactionInfo extends TransactionInfo {
         direction: direction,
         amount: Money.fromInt(amount, walletTypeToCryptoCurrency(type)),
         date: date,
-        confirmations: confirmations);
+        confirmations: confirmations,
+        vsize: obj['vsize'] as int?);
   }
 
   factory ElectrumTransactionInfo.fromElectrumBundle(
@@ -208,7 +226,8 @@ class ElectrumTransactionInfo extends TransactionInfo {
         date: date,
         isHogEx: isHogEx,
         additionalInfo: {'hasMissingInputTx': hasMissingInputTx},
-        confirmations: bundle.confirmations);
+        confirmations: bundle.confirmations,
+        vsize: bundle.originalTransaction.getVSize());
   }
 
   factory ElectrumTransactionInfo.fromJson(Map<String, dynamic> data, WalletType type) {
@@ -241,6 +260,7 @@ class ElectrumTransactionInfo extends TransactionInfo {
               BitcoinSilentPaymentsUnspent.fromJSON(null, unspent as Map<String, dynamic>))
           .toList(),
       isReceivedSilentPayment: data['isReceivedSilentPayment'] as bool? ?? false,
+      vsize: data['vsize'] as int?,
       additionalInfo: additionalInfo,
     );
   }
@@ -260,6 +280,7 @@ class ElectrumTransactionInfo extends TransactionInfo {
         inputAddresses: inputAddresses,
         outputAddresses: outputAddresses,
         confirmations: info.confirmations,
+        vsize: info.vsize,
         additionalInfo: additionalInfo);
   }
 
@@ -279,6 +300,7 @@ class ElectrumTransactionInfo extends TransactionInfo {
     m['inputAddresses'] = inputAddresses;
     m['outputAddresses'] = outputAddresses;
     m['isReceivedSilentPayment'] = isReceivedSilentPayment;
+    m['vsize'] = vsize;
     m['additionalInfo'] = additionalInfo;
     return m;
   }

--- a/cw_bitcoin/lib/pending_bitcoin_transaction.dart
+++ b/cw_bitcoin/lib/pending_bitcoin_transaction.dart
@@ -185,6 +185,7 @@ class PendingBitcoinTransaction with PendingTransaction {
         inputAddresses: _tx.inputs.map((input) => input.txId).toList(),
         outputAddresses: outputAddresses,
         fee: fee,
+        vsize: _tx.getVSize(),
       );
 
   @override

--- a/cw_bitcoin/test/cw_bitcoin_test.dart
+++ b/cw_bitcoin/test/cw_bitcoin_test.dart
@@ -1,6 +1,63 @@
+import 'package:cw_bitcoin/electrum.dart';
+import 'package:cw_bitcoin/electrum_transaction_info.dart';
+import 'package:cw_core/amount/money.dart';
+import 'package:cw_core/crypto_currency.dart';
+import 'package:cw_core/transaction_direction.dart';
+import 'package:cw_core/wallet_type.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+ElectrumTransactionInfo _bitcoinTxInfo({int? fee, int? vsize}) => ElectrumTransactionInfo(
+      WalletType.bitcoin,
+      id: 'txid',
+      amount: Money.fromInt(0, CryptoCurrency.btc),
+      fee: fee != null ? Money.fromInt(fee, CryptoCurrency.btc) : null,
+      direction: TransactionDirection.incoming,
+      isPending: false,
+      date: DateTime.fromMillisecondsSinceEpoch(0),
+      confirmations: 1,
+      vsize: vsize,
+    );
+
 void main() {
+  group('ElectrumTransactionInfo fee rate', () {
+    test('computes fee rate as fee / vsize in sat/vB', () {
+      expect(_bitcoinTxInfo(fee: 300, vsize: 150).feeRateSatsPerVbyte, 2);
+    });
+
+    test('rounds half-up like the displayed fee rate division', () {
+      expect(_bitcoinTxInfo(fee: 75, vsize: 10).feeRateSatsPerVbyte, 8);
+      expect(_bitcoinTxInfo(fee: 74, vsize: 10).feeRateSatsPerVbyte, 7);
+    });
+
+    test('returns null when vsize is unavailable', () {
+      expect(_bitcoinTxInfo(fee: 300).feeRateSatsPerVbyte, null);
+    });
+
+    test('returns null when fee is unavailable', () {
+      expect(_bitcoinTxInfo(vsize: 150).feeRateSatsPerVbyte, null);
+    });
+
+    test('returns null for non-positive vsize', () {
+      expect(_bitcoinTxInfo(fee: 300, vsize: 0).feeRateSatsPerVbyte, null);
+      expect(_bitcoinTxInfo(fee: 300, vsize: -1).feeRateSatsPerVbyte, null);
+    });
+
+    test('round-trips vsize through json', () {
+      final info = _bitcoinTxInfo(fee: 300, vsize: 150);
+      final restored = ElectrumTransactionInfo.fromJson(info.toJson(), WalletType.bitcoin);
+      expect(restored.vsize, 150);
+      expect(restored.feeRateSatsPerVbyte, 2);
+    });
+
+    test('legacy stored records without vsize stay readable', () {
+      final legacyJson = _bitcoinTxInfo(fee: 300).toJson()..remove('vsize');
+      final restored = ElectrumTransactionInfo.fromJson(legacyJson, WalletType.bitcoin);
+      expect(restored.vsize, null);
+      expect(restored.fee, Money.fromInt(300, CryptoCurrency.btc));
+      expect(restored.feeRateSatsPerVbyte, null);
+    });
+  });
+
   group('lightning matchers', () {
     final RegExp lightningInvoiceRegex =
         RegExp(r'^(lightning:)?(lnbc|lntb|lnbs|lnbcrt)[a-z0-9]+$', caseSensitive: false);

--- a/cw_bitcoin/test/cw_bitcoin_test.dart
+++ b/cw_bitcoin/test/cw_bitcoin_test.dart
@@ -1,63 +1,6 @@
-import 'package:cw_bitcoin/electrum.dart';
-import 'package:cw_bitcoin/electrum_transaction_info.dart';
-import 'package:cw_core/amount/money.dart';
-import 'package:cw_core/crypto_currency.dart';
-import 'package:cw_core/transaction_direction.dart';
-import 'package:cw_core/wallet_type.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-ElectrumTransactionInfo _bitcoinTxInfo({int? fee, int? vsize}) => ElectrumTransactionInfo(
-      WalletType.bitcoin,
-      id: 'txid',
-      amount: Money.fromInt(0, CryptoCurrency.btc),
-      fee: fee != null ? Money.fromInt(fee, CryptoCurrency.btc) : null,
-      direction: TransactionDirection.incoming,
-      isPending: false,
-      date: DateTime.fromMillisecondsSinceEpoch(0),
-      confirmations: 1,
-      vsize: vsize,
-    );
-
 void main() {
-  group('ElectrumTransactionInfo fee rate', () {
-    test('computes fee rate as fee / vsize in sat/vB', () {
-      expect(_bitcoinTxInfo(fee: 300, vsize: 150).feeRateSatsPerVbyte, 2);
-    });
-
-    test('rounds half-up like the displayed fee rate division', () {
-      expect(_bitcoinTxInfo(fee: 75, vsize: 10).feeRateSatsPerVbyte, 8);
-      expect(_bitcoinTxInfo(fee: 74, vsize: 10).feeRateSatsPerVbyte, 7);
-    });
-
-    test('returns null when vsize is unavailable', () {
-      expect(_bitcoinTxInfo(fee: 300).feeRateSatsPerVbyte, null);
-    });
-
-    test('returns null when fee is unavailable', () {
-      expect(_bitcoinTxInfo(vsize: 150).feeRateSatsPerVbyte, null);
-    });
-
-    test('returns null for non-positive vsize', () {
-      expect(_bitcoinTxInfo(fee: 300, vsize: 0).feeRateSatsPerVbyte, null);
-      expect(_bitcoinTxInfo(fee: 300, vsize: -1).feeRateSatsPerVbyte, null);
-    });
-
-    test('round-trips vsize through json', () {
-      final info = _bitcoinTxInfo(fee: 300, vsize: 150);
-      final restored = ElectrumTransactionInfo.fromJson(info.toJson(), WalletType.bitcoin);
-      expect(restored.vsize, 150);
-      expect(restored.feeRateSatsPerVbyte, 2);
-    });
-
-    test('legacy stored records without vsize stay readable', () {
-      final legacyJson = _bitcoinTxInfo(fee: 300).toJson()..remove('vsize');
-      final restored = ElectrumTransactionInfo.fromJson(legacyJson, WalletType.bitcoin);
-      expect(restored.vsize, null);
-      expect(restored.fee, Money.fromInt(300, CryptoCurrency.btc));
-      expect(restored.feeRateSatsPerVbyte, null);
-    });
-  });
-
   group('lightning matchers', () {
     final RegExp lightningInvoiceRegex =
         RegExp(r'^(lightning:)?(lnbc|lntb|lnbs|lnbcrt)[a-z0-9]+$', caseSensitive: false);

--- a/lib/bitcoin/cw_bitcoin.dart
+++ b/lib/bitcoin/cw_bitcoin.dart
@@ -498,6 +498,14 @@ class CWBitcoin extends Bitcoin {
   }
 
   @override
+  int? getTransactionFeeRate(Object transactionInfo) {
+    if (transactionInfo is ElectrumTransactionInfo) {
+      return transactionInfo.feeRateSatsPerVbyte;
+    }
+    return null;
+  }
+
+  @override
   Future<bool> isChangeSufficientForFee(Object wallet, String txId, String newFee) async {
     final bitcoinWallet = wallet as ElectrumWallet;
     return bitcoinWallet.isChangeSufficientForFee(txId, int.parse(newFee));

--- a/lib/view_model/transaction_details_view_model.dart
+++ b/lib/view_model/transaction_details_view_model.dart
@@ -97,6 +97,15 @@ class TxDetailRowDefinition {
           (vm.transactionInfo.fee?.toStringWithSymbol() ?? "").isNotEmpty,
     ),
     TxDetailRowDefinition(
+      keyString: "standard_list_item_transaction_details_fee_rate_key",
+      title: S.current.transaction_details_fee_rate,
+      valueGetter: (vm) => vm.feeRateDisplayValue,
+      applicable: (vm) =>
+          vm.wallet.type == WalletType.bitcoin &&
+          !isLightning(vm.transactionInfo) &&
+          bitcoin?.getTransactionFeeRate(vm.transactionInfo) != null,
+    ),
+    TxDetailRowDefinition(
       keyString: "standard_list_item_transaction_confirmations_key",
       title: S.current.confirmations,
       valueGetter: (vm) => "${vm.transactionInfo.confirmations}/${vm.neededConfirmations}",
@@ -346,6 +355,17 @@ abstract class TransactionDetailsViewModelBase with Store {
   @computed
   String get feeAmount =>
       _appStore.amountParsingProxy.asDisplayStringWithSymbol(transactionInfo.fee!);
+
+  /// Actual paid fee rate in sat/vB for Bitcoin on-chain transactions,
+  /// derived from the total fee and the transaction's virtual size. Null
+  /// when the fee or vsize is unavailable (e.g. legacy cached records) or in
+  /// non-Bitcoin builds, in which case no rate must be displayed.
+  int? get feeRateSatPerVByte => bitcoin?.getTransactionFeeRate(transactionInfo);
+
+  String get feeRateDisplayValue {
+    final rate = feeRateSatPerVByte;
+    return rate != null ? "$rate sat/vB" : "";
+  }
 
   @computed
   String get transactionCopyAmount =>

--- a/res/values/strings_en.arb
+++ b/res/values/strings_en.arb
@@ -1279,6 +1279,7 @@
   "transaction_details_copied": "${title} copied to Clipboard",
   "transaction_details_date": "Date",
   "transaction_details_fee": "Fee",
+  "transaction_details_fee_rate": "Fee rate",
   "transaction_details_height": "Height",
   "transaction_details_recipient_address": "Recipient addresses",
   "transaction_details_source_address": "Source address",

--- a/tool/configure.dart
+++ b/tool/configure.dart
@@ -259,6 +259,7 @@ abstract class Bitcoin {
   Future<PendingTransaction> replaceByFee(Object wallet, String transactionHash, String fee);
   Future<String?> canReplaceByFee(Object wallet, Object tx);
   int getTransactionVSize(Object wallet, String txHex);
+  int? getTransactionFeeRate(Object transactionInfo);
   Future<bool> isChangeSufficientForFee(Object wallet, String txId, String newFee);
   int getFeeAmountForPriority(Object wallet, TransactionPriority priority, int inputsCount, int outputsCount, {int? size});
   int getEstimatedFeeWithFeeRate(Object wallet, int feeRate, int? amount,


### PR DESCRIPTION
Issue Number (if Applicable): Fixes CW-800

# Description

Persists Electrum transaction virtual size, exposes a null-safe sat/vB fee-rate calculation, and adds a fee-rate row to Bitcoin transaction details when both fee and vsize are available. Legacy history records without vsize remain readable.

# Validation

- UX/state review: no blocking findings
