### PR TITLE
feat: Integrate PegaRoute swap provider

### DIFF
--- a/lib/core/trade_monitor.dart
+++ b/lib/core/trade_monitor.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:cake_wallet/exchange/provider/jupiter_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/near_Intents_exchange_provider.dart';
+import 'package:cake_wallet/exchange/provider/pegaroute_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/simpleswap_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/swapsxyz_exchange_provider.dart';
 import 'package:cake_wallet/exchange/trade.dart';
@@ -68,6 +69,8 @@ class TradeMonitor {
         return JupiterExchangeProvider();
       case ExchangeProviderDescription.nearIntents:
         return NearIntentsExchangeProvider();
+      case ExchangeProviderDescription.pegaRoute:
+        return PegaRouteExchangeProvider();
     }
     return null;
   }

--- a/lib/exchange/exchange_provider_description.dart
+++ b/lib/exchange/exchange_provider_description.dart
@@ -95,6 +95,11 @@ class ExchangeProviderDescription extends EnumerableItem<int> with Serializable<
       raw: 16,
       image: 'assets/new-ui/trade_providers/jupiter.svg',
       isCentralized: false);
+  static const pegaRoute = ExchangeProviderDescription(
+      title: 'PegaRoute',
+      raw: 17,
+      image: 'assets/new-ui/trade_providers/pegaroute.svg',
+      isCentralized: false);
 
   static ExchangeProviderDescription deserialize({required int raw}) {
     switch (raw) {
@@ -132,6 +137,8 @@ class ExchangeProviderDescription extends EnumerableItem<int> with Serializable<
         return nearIntents;
       case 16:
         return jupiter;
+      case 17:
+        return pegaRoute;
       default:
         throw Exception('Unexpected token: $raw for ExchangeProviderDescription deserialize');
     }

--- a/lib/exchange/provider/pegaroute_exchange_provider.dart
+++ b/lib/exchange/provider/pegaroute_exchange_provider.dart
@@ -1,0 +1,486 @@
+import "dart:convert";
+
+import "package:cake_wallet/.secrets.g.dart" as secrets;
+import "package:cake_wallet/exchange/exchange_provider_description.dart";
+import "package:cake_wallet/exchange/limits.dart";
+import "package:cake_wallet/exchange/provider/exchange_provider.dart";
+import "package:cake_wallet/exchange/trade.dart";
+import "package:cake_wallet/exchange/trade_not_found_exception.dart";
+import "package:cake_wallet/exchange/trade_request.dart";
+import "package:cake_wallet/exchange/trade_state.dart";
+import "package:cake_wallet/utils/exchange_provider_logger.dart";
+import "package:cw_core/crypto_currency.dart";
+import "package:cw_core/erc20_token.dart";
+import "package:cw_core/spl_token.dart";
+import "package:cw_core/utils/print_verbose.dart";
+import "package:cw_core/utils/proxy_wrapper.dart";
+
+class PegaRouteExchangeProvider extends ExchangeProvider {
+  PegaRouteExchangeProvider();
+
+  static const apiKey = secrets.pegaRouteApiKey;
+  static const apiBaseUrl = "api.pegaroute.com";
+  static const quotePath = "/quote";
+  static const swapPath = "/swap";
+
+  static final Map<String, String> _headers = {"X-API-Key": apiKey};
+
+  @override
+  String get title => "PegaRoute";
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  bool get isEnabled => true;
+
+  @override
+  bool get supportsFixedRate => false;
+
+  @override
+  ExchangeProviderDescription get description => ExchangeProviderDescription.pegaRoute;
+
+  @override
+  Future<bool> checkIsAvailable() async => true;
+
+  @override
+  Future<Limits?> fetchLimits({
+    required CryptoCurrency from,
+    required CryptoCurrency to,
+    required bool isFixedRateMode,
+  }) async {
+    final params = <String, String>{
+      "fromChain": _chainFor(from),
+      "fromToken": _tokenFor(from),
+      "toChain": _chainFor(to),
+      "toToken": _tokenFor(to),
+      "amount": "1",
+    };
+
+    final uri = Uri.https(apiBaseUrl, quotePath, params);
+    final response = await ProxyWrapper().get(clearnetUri: uri, headers: _headers);
+    final responseJSON = json.decode(response.body) as Map<String, dynamic>;
+
+    // All routes rejected the amount as too low; the error message may carry the minimum
+    if (response.statusCode == 400) {
+      final error = responseJSON["error"] as Map<String, dynamic>?;
+      final min = _extractAmount(error?["message"] as String? ?? "");
+      return Limits(min: min ?? 0, max: null);
+    }
+
+    if (response.statusCode != 200) {
+      throw Exception("Unexpected http status: ${response.statusCode}");
+    }
+
+    final routes = responseJSON["routes"] as List<dynamic>? ?? [];
+
+    double? min;
+    if (routes.isNotEmpty) {
+      min = _toDouble((routes.first as Map<String, dynamic>)["minAmount"]);
+    }
+
+    if (min == null) {
+      final warnings = responseJSON["warnings"] as List<dynamic>? ?? [];
+      for (final warning in warnings) {
+        final warningMap = warning as Map<String, dynamic>;
+        if (warningMap["code"] == "AMOUNT_TOO_LOW") {
+          min = _extractAmount(warningMap["message"] as String? ?? "");
+          if (min != null) break;
+        }
+      }
+    }
+
+    return Limits(min: min ?? 0, max: null);
+  }
+
+  @override
+  Future<double> fetchRate({
+    required CryptoCurrency from,
+    required CryptoCurrency to,
+    required double amount,
+    required bool isFixedRateMode,
+    required bool isReceiveAmount,
+  }) async {
+    try {
+      if (amount == 0) return 0.0;
+
+      // PegaRoute is float-only: quotes always take the source amount
+      final params = <String, String>{
+        "fromChain": _chainFor(from),
+        "fromToken": _tokenFor(from),
+        "toChain": _chainFor(to),
+        "toToken": _tokenFor(to),
+        "amount": amount.toString(),
+      };
+
+      final uri = Uri.https(apiBaseUrl, quotePath, params);
+      final response = await ProxyWrapper().get(clearnetUri: uri, headers: _headers);
+
+      final responseJSON = json.decode(response.body) as Map<String, dynamic>;
+
+      if (response.statusCode != 200) {
+        final error = responseJSON["error"] as Map<String, dynamic>?;
+        final message = error?["userMessage"] as String? ?? error?["message"] as String?;
+
+        ExchangeProviderLogger.logError(
+          provider: description,
+          function: "fetchRate",
+          error: Exception(message ?? "Unknown error"),
+          stackTrace: StackTrace.current,
+          requestData: {
+            "from": from.title,
+            "to": to.title,
+            "amount": amount,
+            "isFixedRateMode": isFixedRateMode,
+            "isReceiveAmount": isReceiveAmount,
+            "params": params,
+            "url": uri.toString(),
+          },
+        );
+
+        throw Exception(message);
+      }
+
+      final routes = responseJSON["routes"] as List<dynamic>? ?? [];
+      if (routes.isEmpty) return 0.0;
+
+      final expectedOutput = double.tryParse(
+            (routes.first as Map<String, dynamic>)["expectedOutput"]?.toString() ?? "",
+          ) ??
+          0.0;
+      final rate = expectedOutput / amount;
+
+      ExchangeProviderLogger.logSuccess(
+        provider: description,
+        function: "fetchRate",
+        requestData: {
+          "from": from.title,
+          "to": to.title,
+          "amount": amount,
+          "isFixedRateMode": isFixedRateMode,
+          "isReceiveAmount": isReceiveAmount,
+          "params": params,
+          "url": uri.toString(),
+        },
+        responseData: {
+          "rate": rate,
+          "statusCode": response.statusCode,
+          "responseJSON": responseJSON,
+        },
+      );
+
+      return rate;
+    } catch (e, s) {
+      ExchangeProviderLogger.logError(
+        provider: description,
+        function: "fetchRate",
+        error: e,
+        stackTrace: s,
+        requestData: {
+          "from": from.title,
+          "to": to.title,
+          "amount": amount,
+          "isFixedRateMode": isFixedRateMode,
+          "isReceiveAmount": isReceiveAmount,
+        },
+      );
+      printV(e.toString());
+      printV(s.toString());
+      return 0.0;
+    }
+  }
+
+  @override
+  Future<Trade> createTrade({
+    required TradeRequest request,
+    required bool isFixedRateMode,
+    required bool isSendAll,
+  }) async {
+    final quoteParams = <String, String>{
+      "fromChain": _chainFor(request.fromCurrency),
+      "fromToken": _tokenFor(request.fromCurrency),
+      "toChain": _chainFor(request.toCurrency),
+      "toToken": _tokenFor(request.toCurrency),
+      "amount": request.fromAmount,
+    };
+
+    final quoteUri = Uri.https(apiBaseUrl, quotePath, quoteParams);
+    final quoteResponse = await ProxyWrapper().get(clearnetUri: quoteUri, headers: _headers);
+    final quoteJSON = json.decode(quoteResponse.body) as Map<String, dynamic>;
+
+    if (quoteResponse.statusCode != 200) {
+      final error = quoteJSON["error"] as Map<String, dynamic>?;
+      final errorMessage = error?["userMessage"] as String? ??
+          error?["message"] as String? ??
+          "Unexpected http status: ${quoteResponse.statusCode}";
+
+      ExchangeProviderLogger.logError(
+        provider: description,
+        function: "createTrade",
+        error: Exception(errorMessage),
+        stackTrace: StackTrace.current,
+        requestData: {
+          "from": request.fromCurrency.title,
+          "to": request.toCurrency.title,
+          "fromAmount": request.fromAmount,
+          "toAddress": request.toAddress,
+          "refundAddress": request.refundAddress,
+          "isFixedRateMode": isFixedRateMode,
+          "isSendAll": isSendAll,
+          "params": quoteParams,
+          "url": quoteUri.toString(),
+        },
+      );
+
+      throw Exception(errorMessage);
+    }
+
+    final routes = quoteJSON["routes"] as List<dynamic>? ?? [];
+    if (routes.isEmpty) throw Exception("No routes available for this pair");
+
+    final route = routes.first as Map<String, dynamic>;
+    final quoteId = quoteJSON["quoteId"] as String?;
+
+    final body = <String, dynamic>{
+      "fromChain": _chainFor(request.fromCurrency),
+      "fromToken": _tokenFor(request.fromCurrency),
+      "toChain": _chainFor(request.toCurrency),
+      "toToken": _tokenFor(request.toCurrency),
+      "amount": request.fromAmount,
+      "destinationAddress": request.toAddress,
+      "senderAddress": request.refundAddress,
+      if (quoteId != null) "quoteId": quoteId,
+      if (route["provider"] != null) "routeProvider": route["provider"],
+    };
+
+    final uri = Uri.https(apiBaseUrl, swapPath);
+    final response = await ProxyWrapper().post(
+      clearnetUri: uri,
+      headers: {..._headers, "Content-Type": "application/json"},
+      body: json.encode(body),
+    );
+
+    if (response.statusCode != 202 && response.statusCode != 200) {
+      final responseJSON = json.decode(response.body) as Map<String, dynamic>;
+      final error = responseJSON["error"] as Map<String, dynamic>?;
+      final errorMessage = error?["userMessage"] as String? ??
+          error?["message"] as String? ??
+          "Unexpected http status: ${response.statusCode}";
+
+      ExchangeProviderLogger.logError(
+        provider: description,
+        function: "createTrade",
+        error: Exception(errorMessage),
+        stackTrace: StackTrace.current,
+        requestData: {
+          "from": request.fromCurrency.title,
+          "to": request.toCurrency.title,
+          "fromAmount": request.fromAmount,
+          "toAddress": request.toAddress,
+          "refundAddress": request.refundAddress,
+          "isFixedRateMode": isFixedRateMode,
+          "isSendAll": isSendAll,
+          "body": body,
+          "url": uri.toString(),
+        },
+      );
+
+      throw Exception(errorMessage);
+    }
+
+    final responseJSON = json.decode(response.body) as Map<String, dynamic>;
+    final id = responseJSON["transactionId"] as String;
+    // Current schema: execution (chain-family payload) + provider (reference/details);
+    // txParams is the legacy shape kept as fallback during their rollout.
+    final execution = responseJSON["execution"] as Map<String, dynamic>? ?? {};
+    final providerInfo = responseJSON["provider"] as Map<String, dynamic>? ?? {};
+    final txParams = responseJSON["txParams"] as Map<String, dynamic>? ?? {};
+    final inputAddress = execution["to"] as String? ?? txParams["to"] as String?;
+    final providerId =
+        providerInfo["referenceId"] as String? ?? txParams["providerReferenceId"] as String?;
+    final details = providerInfo["details"] as Map<String, dynamic>?;
+    final instaswapSwapLite = (details?["instaswapSwapLite"] ?? txParams["instaswapSwapLite"])
+        as Map<String, dynamic>?;
+    final expiresAtRaw = instaswapSwapLite?["expiresAt"] as String?;
+    final expiredAt = expiresAtRaw != null ? DateTime.tryParse(expiresAtRaw)?.toLocal() : null;
+    final receiveAmount = route["expectedOutput"]?.toString();
+
+    ExchangeProviderLogger.logSuccess(
+      provider: description,
+      function: "createTrade",
+      requestData: {
+        "from": request.fromCurrency.title,
+        "to": request.toCurrency.title,
+        "fromAmount": request.fromAmount,
+        "toAddress": request.toAddress,
+        "refundAddress": request.refundAddress,
+        "isFixedRateMode": isFixedRateMode,
+        "isSendAll": isSendAll,
+        "body": body,
+        "url": uri.toString(),
+      },
+      responseData: {
+        "id": id,
+        "inputAddress": inputAddress,
+        "providerId": providerId,
+        "receiveAmount": receiveAmount,
+        "statusCode": response.statusCode,
+        "responseJSON": responseJSON,
+      },
+    );
+
+    return Trade(
+      id: id,
+      from: request.fromCurrency,
+      to: request.toCurrency,
+      provider: description,
+      inputAddress: inputAddress,
+      refundAddress: request.refundAddress,
+      createdAt: DateTime.now(),
+      expiredAt: expiredAt,
+      amount: request.fromAmount,
+      receiveAmount: receiveAmount ?? request.toAmount,
+      state: TradeState.created,
+      payoutAddress: request.toAddress,
+      providerId: providerId,
+      isSendAll: isSendAll,
+    );
+  }
+
+  @override
+  Future<Trade> findTradeById({required String id}) async {
+    final uri = Uri.https(apiBaseUrl, "$swapPath/$id");
+    final response = await ProxyWrapper().get(clearnetUri: uri, headers: _headers);
+
+    if (response.statusCode == 404) throw TradeNotFoundException(id, provider: description);
+
+    if (response.statusCode != 200) {
+      throw Exception("Unexpected http status: ${response.statusCode}");
+    }
+
+    final responseJSON = json.decode(response.body) as Map<String, dynamic>;
+    final internalStatus =
+        responseJSON["internalStatus"] as String? ?? responseJSON["status"] as String? ?? "";
+    final input = responseJSON["input"] as Map<String, dynamic>? ?? {};
+    final output = responseJSON["output"] as Map<String, dynamic>? ?? {};
+
+    final from = _parseCurrency(input["chain"] as String?, input["token"] as String?);
+    final to = _parseCurrency(output["chain"] as String?, output["token"] as String?);
+
+    return Trade(
+      id: id,
+      from: from,
+      to: to,
+      provider: description,
+      inputAddress: input["address"] as String?,
+      amount: input["amount"]?.toString() ?? "",
+      state: _tradeState(internalStatus),
+      outputTransaction: output["txHash"] as String?,
+      receiveAmount: output["amount"]?.toString(),
+      payoutAddress: output["address"] as String?,
+    );
+  }
+
+  /// Registers the broadcasted deposit tx hash with PegaRoute
+  /// (required to start provider-side monitoring). Never throws.
+  static Future<bool> submitTxHash({required String id, required String txHash}) async {
+    try {
+      final uri = Uri.https(apiBaseUrl, "$swapPath/$id/txhash");
+      final response = await ProxyWrapper().post(
+        clearnetUri: uri,
+        headers: {..._headers, "Content-Type": "application/json"},
+        body: json.encode({"txHash": txHash}),
+      );
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        printV("submitTxHash failed: ${response.statusCode} ${response.body}");
+        ExchangeProviderLogger.logError(
+          provider: ExchangeProviderDescription.pegaRoute,
+          function: "submitTxHash",
+          error: Exception("Unexpected http status: ${response.statusCode}"),
+          stackTrace: StackTrace.current,
+          requestData: {"id": id, "txHash": txHash},
+        );
+        return false;
+      }
+
+      return true;
+    } catch (e, s) {
+      printV("submitTxHash error: $e");
+      ExchangeProviderLogger.logError(
+        provider: ExchangeProviderDescription.pegaRoute,
+        function: "submitTxHash",
+        error: e,
+        stackTrace: s,
+        requestData: {"id": id, "txHash": txHash},
+      );
+      return false;
+    }
+  }
+
+  // Cake currency tags that differ from PegaRoute chain ids (GET /chains)
+  static const _chainAliases = <String, String>{
+    "ARB": "ARBITRUM",
+    "AVAXC": "AVAX",
+    "POL": "POLYGON",
+    "TRX": "TRON",
+  };
+
+  String _chainFor(CryptoCurrency currency) {
+    final chain = (currency.tag ?? currency.title).toUpperCase();
+    return _chainAliases[chain] ?? chain;
+  }
+
+  String _tokenFor(CryptoCurrency currency) {
+    // ERC-20/SPL tokens are contract-qualified ('SYMBOL-<contract>');
+    // unsupported ids simply fail server-side with UNSUPPORTED_PAIR
+    if (currency is Erc20Token)
+      return "${currency.title.toUpperCase()}-${currency.contractAddress}";
+    if (currency is SPLToken) return "${currency.title.toUpperCase()}-${currency.mintAddress}";
+    return currency.title.toUpperCase();
+  }
+
+  CryptoCurrency? _parseCurrency(String? chain, String? token) {
+    if (token == null) return null;
+    final symbol = token.split("-").first;
+    final tag = chain != null && chain.toUpperCase() != symbol.toUpperCase() ? chain : null;
+    return CryptoCurrency.safeParseCurrencyFromString(symbol, tag: tag);
+  }
+
+  TradeState _tradeState(String internalStatus) {
+    switch (internalStatus) {
+      case "pending":
+        return TradeState.created;
+      case "submitted":
+        return TradeState.confirming;
+      case "executing":
+        return TradeState.exchanging;
+      case "confirming":
+        return TradeState.sending;
+      case "completed":
+        return TradeState.success;
+      case "failed":
+        return TradeState.failed;
+      case "refunded":
+        return TradeState.refunded;
+      default:
+        return TradeState.deserialize(raw: internalStatus);
+    }
+  }
+
+  double? _extractAmount(String message) {
+    final match = RegExp(r"\d+(?:\.\d+)?").firstMatch(message);
+    return match != null ? double.tryParse(match.group(0)!) : null;
+  }
+
+  static double? _toDouble(dynamic value) {
+    if (value is int) {
+      return value.toDouble();
+    } else if (value is double) {
+      return value;
+    } else if (value is String) {
+      return double.tryParse(value);
+    }
+    return null;
+  }
+}

--- a/lib/store/dashboard/trade_filter_store.dart
+++ b/lib/store/dashboard/trade_filter_store.dart
@@ -23,7 +23,8 @@ abstract class TradeFilterStoreBase with Store {
         displayXOSwap = true,
         displaySwapTrade = true,
         displaySwapXyz = true,
-        displayNearIntents = true;
+        displayNearIntents = true,
+        displayPegaRoute = true;
 
   @observable
   bool displayXMRTO;
@@ -68,6 +69,8 @@ abstract class TradeFilterStoreBase with Store {
   bool displaySwapXyz;
   @observable
   bool displayNearIntents;
+  @observable
+  bool displayPegaRoute;
 
   @computed
   int get enabledProvidersCount => [
@@ -83,7 +86,8 @@ abstract class TradeFilterStoreBase with Store {
         displayXOSwap,
         displaySwapTrade,
         displaySwapXyz,
-        displayNearIntents
+        displayNearIntents,
+        displayPegaRoute
       ].where((item) => item).length;
 
   @computed
@@ -100,7 +104,8 @@ abstract class TradeFilterStoreBase with Store {
       displayXOSwap &&
       displaySwapTrade &&
       displaySwapXyz &&
-      displayNearIntents;
+      displayNearIntents &&
+      displayPegaRoute;
 
   @action
   void toggleDisplayExchange(ExchangeProviderDescription provider) {
@@ -150,6 +155,9 @@ abstract class TradeFilterStoreBase with Store {
       case ExchangeProviderDescription.nearIntents:
         displayNearIntents = !displayNearIntents;
         break;
+      case ExchangeProviderDescription.pegaRoute:
+        displayPegaRoute = !displayPegaRoute;
+        break;
       case ExchangeProviderDescription.all:
         if (displayAllTrades) {
           displayChangeNow = false;
@@ -167,6 +175,7 @@ abstract class TradeFilterStoreBase with Store {
           displaySwapTrade = false;
           displaySwapXyz = false;
           displayNearIntents = false;
+          displayPegaRoute = false;
         } else {
           displayChangeNow = true;
           displaySideShift = true;
@@ -183,6 +192,7 @@ abstract class TradeFilterStoreBase with Store {
           displaySwapTrade = true;
           displaySwapXyz = true;
           displayNearIntents = true;
+          displayPegaRoute = true;
         }
         break;
     }
@@ -224,7 +234,9 @@ abstract class TradeFilterStoreBase with Store {
                     item.trade.provider == ExchangeProviderDescription.swapTrade) ||
                 (displaySwapXyz && item.trade.provider == ExchangeProviderDescription.swapsXyz) ||
                 (displayNearIntents &&
-                    item.trade.provider == ExchangeProviderDescription.nearIntents))
+                    item.trade.provider == ExchangeProviderDescription.nearIntents) ||
+                (displayPegaRoute &&
+                    item.trade.provider == ExchangeProviderDescription.pegaRoute))
             .toList()
         : _trades;
   }

--- a/lib/utils/exchange_provider_logger.dart
+++ b/lib/utils/exchange_provider_logger.dart
@@ -89,6 +89,7 @@ class ExchangeProviderLogEntry {
       ExchangeProviderDescription.swapsXyz,
       ExchangeProviderDescription.nearIntents,
       ExchangeProviderDescription.jupiter,
+      ExchangeProviderDescription.pegaRoute,
     ];
 
     return ExchangeProviderLogEntry(

--- a/lib/view_model/dashboard/dashboard_view_model.dart
+++ b/lib/view_model/dashboard/dashboard_view_model.dart
@@ -352,6 +352,11 @@ abstract class DashboardViewModelBase with Store {
           value: () => tradeFilterStore.displayNearIntents,
           onChanged: () =>
               tradeFilterStore.toggleDisplayExchange(ExchangeProviderDescription.nearIntents)),
+      SwapProviderFilterItem(
+          providerDescription: ExchangeProviderDescription.pegaRoute,
+          value: () => tradeFilterStore.displayPegaRoute,
+          onChanged: () =>
+              tradeFilterStore.toggleDisplayExchange(ExchangeProviderDescription.pegaRoute)),
     ];
   }
 

--- a/lib/view_model/exchange/exchange_trade_view_model.dart
+++ b/lib/view_model/exchange/exchange_trade_view_model.dart
@@ -11,6 +11,7 @@ import 'package:cake_wallet/exchange/provider/exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/exolix_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/jupiter_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/near_Intents_exchange_provider.dart';
+import 'package:cake_wallet/exchange/provider/pegaroute_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/swapsxyz_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/swaptrade_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/sideshift_exchange_provider.dart';
@@ -94,6 +95,9 @@ abstract class ExchangeTradeViewModelBase with Store {
         break;
       case ExchangeProviderDescription.nearIntents:
         _provider = NearIntentsExchangeProvider();
+        break;
+      case ExchangeProviderDescription.pegaRoute:
+        _provider = PegaRouteExchangeProvider();
         break;
     }
 

--- a/lib/view_model/exchange/exchange_view_model.dart
+++ b/lib/view_model/exchange/exchange_view_model.dart
@@ -32,6 +32,7 @@ import 'package:cake_wallet/exchange/provider/changenow_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/exolix_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/near_Intents_exchange_provider.dart';
+import 'package:cake_wallet/exchange/provider/pegaroute_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/stealth_ex_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/swapsxyz_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/swaptrade_exchange_provider.dart';
@@ -314,6 +315,7 @@ abstract class ExchangeViewModelBase extends WalletChangeListenerViewModel with 
         SwapsXyzExchangeProvider(),
         JupiterExchangeProvider(),
         NearIntentsExchangeProvider(),
+        PegaRouteExchangeProvider(),
         TrocadorExchangeProvider(
             useTorOnly: _useTorOnly, providerStates: _settingsStore.trocadorProviderStates),
       ];

--- a/lib/view_model/send/send_view_model.dart
+++ b/lib/view_model/send/send_view_model.dart
@@ -28,6 +28,7 @@ import 'package:cake_wallet/exchange/exchange_provider_description.dart';
 import 'package:cake_wallet/exchange/provider/exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/jupiter_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/near_Intents_exchange_provider.dart';
+import 'package:cake_wallet/exchange/provider/pegaroute_exchange_provider.dart';
 import 'package:cake_wallet/solana/solana.dart';
 import 'package:cake_wallet/exchange/provider/swapsxyz_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/thorchain_exchange.provider.dart';
@@ -1034,6 +1035,9 @@ abstract class SendViewModelBase extends WalletChangeListenerViewModel with Stor
         if (provider == ExchangeProviderDescription.swapsXyz) {
           registerSwapsXyzTransaction(_currentTrade!);
         }
+        if (provider == ExchangeProviderDescription.pegaRoute) {
+          registerPegaRouteTxHash(_currentTrade!);
+        }
       }
 
       await _updateSolanaTrade(signature: pendingTransaction!.id, isSuccess: true);
@@ -1706,6 +1710,32 @@ abstract class SendViewModelBase extends WalletChangeListenerViewModel with Stor
       }
     } catch (e) {
       printV('registerSwapsXyzTransaction error: $e');
+    }
+  }
+
+  Future<void> registerPegaRouteTxHash(Trade trade) async {
+    try {
+      final txHash =
+          pendingTransaction?.evmTxHashFromRawHex ?? pendingTransaction?.id ?? trade.txId ?? '';
+
+      if (txHash.isEmpty) {
+        printV('PegaRoute: txHash submission: skipped (txHash empty)');
+        return;
+      }
+
+      printV('PegaRoute: attempting to submit txHash: tradeId = ${trade.id}, txHash = $txHash');
+
+      final submitted = await PegaRouteExchangeProvider.submitTxHash(id: trade.id, txHash: txHash);
+
+      if (submitted) {
+        trade.txId = txHash;
+        await trade.save();
+        printV('PegaRoute: txHash submission: success');
+      } else {
+        printV('PegaRoute: txHash submission: failed');
+      }
+    } catch (e) {
+      printV('registerPegaRouteTxHash error: $e');
     }
   }
 

--- a/lib/view_model/trade_details_view_model.dart
+++ b/lib/view_model/trade_details_view_model.dart
@@ -8,6 +8,7 @@ import 'package:cake_wallet/exchange/provider/exolix_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/letsexchange_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/jupiter_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/near_Intents_exchange_provider.dart';
+import 'package:cake_wallet/exchange/provider/pegaroute_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/swapsxyz_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/swaptrade_exchange_provider.dart';
 import 'package:cake_wallet/exchange/provider/sideshift_exchange_provider.dart';
@@ -83,6 +84,9 @@ abstract class TradeDetailsViewModelBase with Store {
         break;
       case ExchangeProviderDescription.nearIntents:
         _provider = NearIntentsExchangeProvider();
+        break;
+      case ExchangeProviderDescription.pegaRoute:
+        _provider = PegaRouteExchangeProvider();
         break;
     }
 

--- a/res/pictures/trade_providers/pegaroute.svg
+++ b/res/pictures/trade_providers/pegaroute.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="40" height="40" rx="8" fill="#5B4CF5"/>
+<path d="M13 30V10H21.5C25.6421 10 29 13.3579 29 17.5C29 21.6421 25.6421 25 21.5 25H17.5V30H13ZM17.5 20.5H21.5C23.1569 20.5 24.5 19.1569 24.5 17.5C24.5 15.8431 23.1569 14.5 21.5 14.5H17.5V20.5Z" fill="white"/>
+</svg>

--- a/tool/utils/secret_key.dart
+++ b/tool/utils/secret_key.dart
@@ -94,6 +94,7 @@ class SecretKey {
     SecretKey('nearIntentsBearerToken', () => ''),
     SecretKey('nearIntentsAppFee', () => ''),
     SecretKey('nearIntentsAppFeeRecipient', () => ''),
+    SecretKey('pegaRouteApiKey', () => ''),
   ];
 
   static final evmChainsSecrets = [


### PR DESCRIPTION
## Summary

Integrates **PegaRoute** (pegaroute.com) as a new swap provider, with Monero support as the primary target. Mirrors the existing provider schema (same shape as the Near Intents PR #2742) — no refactors.

## Flow
- `GET /quote` → rate + limits (float-only; no reverse quotes; `min` from `route.minAmount`)
- `POST /swap` → `transactionId` + deposit address (`execution.to`; legacy `txParams.to` fallback kept for their rollout). XMR routes use a plain deposit-address flow — no on-chain memo (`execution.memo` is human instruction text and is deliberately not attached)
- `POST /swap/:id/txhash` after broadcast — required by PegaRoute to start monitoring; wired via the same post-commit hook pattern as Swaps.xyz in `SendViewModel` (also persists `trade.txId`)
- `GET /swap/:id` → status polling (TradeMonitor + trade pages); `internalStatus` maps onto existing `TradeState` values only, incl. explicit `refunded`

## Notes for review
- `ExchangeProviderDescription.pegaRoute` = raw **17** (append-only)
- API key via `secrets.pegaRouteApiKey` (new `SecretKey` entry; no keys in code)
- Affiliate/integrator fee is configured server-side on the integration record — client sends no fee params; quoted `expectedOutput` is already net
- `senderAddress` (required by their API) is wired from the trade refund address; it is also their refund identity
- Cake tag → PegaRoute chain-id aliases for ARB/AVAXC/POL/TRX; unsupported pairs fail server-side as `UNSUPPORTED_PAIR` (provider simply doesn't quote)
- Placeholder logo — awaiting the partner's SVG asset

## Verification
- `dart analyze`: zero errors
- Exercised live against their production API: quote (XMR→BTC), swap creation returning a real XMR deposit address + expiry, status poll round-trip, and txhash-submission error path (never throws)