### PR TITLE
fix: localize settings labels, correct THB/TWD names, and fit receive QR on short windows

### DIFF
--- a/lib/entities/fiat_currency.dart
+++ b/lib/entities/fiat_currency.dart
@@ -115,9 +115,9 @@ class FiatCurrency extends EnumerableItem<String> with Serializable<String> impl
   static const sar = FiatCurrency(symbol: 'SAR', countryCode: "sau", fullName: "Saudi Riyal");
   static const sek = FiatCurrency(symbol: 'SEK', countryCode: "swe", fullName: "Swedish Krona");
   static const sgd = FiatCurrency(symbol: 'SGD', countryCode: "sgp", fullName: "Singapore Dollar");
-  static const thb =
-      FiatCurrency(symbol: 'THB', countryCode: "tha", fullName: "New Thaiwan Dollar");
-  static const twd = FiatCurrency(symbol: 'TWD', countryCode: "twn", fullName: "Thai Baht");
+  static const thb = FiatCurrency(symbol: 'THB', countryCode: "tha", fullName: "Thai Baht");
+  static const twd =
+      FiatCurrency(symbol: 'TWD', countryCode: "twn", fullName: "New Taiwan Dollar");
   static const uah = FiatCurrency(symbol: 'UAH', countryCode: "ukr", fullName: "Ukrainian Hryvnia");
   static const usd =
       FiatCurrency(symbol: 'USD', countryCode: "usa", fullName: "United States Dollar");

--- a/lib/entities/sync_status_display_mode.dart
+++ b/lib/entities/sync_status_display_mode.dart
@@ -1,21 +1,23 @@
+import 'package:cake_wallet/generated/i18n.dart';
+
 enum SyncStatusDisplayMode { eta, blocksRemaining }
 
 extension SyncStatusDisplayModeExtension on SyncStatusDisplayMode {
   String get title {
     switch (this) {
       case SyncStatusDisplayMode.eta:
-        return 'ETA';
+        return S.current.sync_status_display_mode_eta;
       case SyncStatusDisplayMode.blocksRemaining:
-        return 'Blocks Remaining';
+        return S.current.sync_status_display_mode_blocks;
     }
   }
 
   String get description {
     switch (this) {
       case SyncStatusDisplayMode.eta:
-        return 'Show estimated time remaining for sync completion';
+        return S.current.sync_status_display_mode_eta;
       case SyncStatusDisplayMode.blocksRemaining:
-        return 'Show number of blocks remaining to sync';
+        return S.current.sync_status_display_mode_blocks;
     }
   }
 

--- a/lib/new-ui/widgets/receive_page/receive_qr_code.dart
+++ b/lib/new-ui/widgets/receive_page/receive_qr_code.dart
@@ -29,10 +29,15 @@ class ReceiveQrCode extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final Size media = MediaQuery.sizeOf(context);
     final double targetY = largeQrMode ? largeQrModeBottomPadding + 50 : 0;
-    final double resolvedSize =
-        min(MediaQuery.of(context).size.width, MediaQuery.of(context).size.height) * 0.5;
-    final double resolvedScale = largeQrMode ? 1.7 : 1;
+    final double reservedVertical = largeQrMode ? 300 : 260;
+    final double byShortest = min(media.width, media.height) * 0.5;
+    final double byHeight = max(160.0, media.height - reservedVertical);
+    final double resolvedSize = min(byShortest, byHeight);
+    final double resolvedScale = largeQrMode
+        ? min(1.7, max(1.0, (media.height - 180) / resolvedSize))
+        : 1;
 
     return Stack(
       alignment: Alignment.topCenter,

--- a/lib/src/screens/settings/connection_sync_page.dart
+++ b/lib/src/screens/settings/connection_sync_page.dart
@@ -160,7 +160,7 @@ class ConnectionSyncPage extends BasePage {
                       ListItemSelector(
                           keyValue: "fiat_api",
                           label: S.of(context).fiat_api,
-                          options: [_connectionSyncViewModel.fiatApiMode.title],
+                          options: [_connectionSyncViewModel.fiatApiMode.toString()],
                           onTap: () async {
                             final items = FiatApiMode.all;
 
@@ -183,7 +183,7 @@ class ConnectionSyncPage extends BasePage {
                       ListItemSelector(
                           keyValue: "swap",
                           label: S.of(context).swap,
-                          options: [_connectionSyncViewModel.exchangeStatus.title],
+                          options: [_connectionSyncViewModel.exchangeStatus.toString()],
                           onTap: () async {
                             final items = ExchangeApiMode.all;
 

--- a/lib/src/screens/settings/display_settings_page.dart
+++ b/lib/src/screens/settings/display_settings_page.dart
@@ -67,8 +67,14 @@ class DisplaySettingsPage extends StatelessWidget {
                       onItemSelected: (ThemeMode themeMode) =>
                           _displaySettingsViewModel.setThemeMode(themeMode),
                       displayItem: (ThemeMode themeMode) {
-                        return themeMode.name[0].toUpperCase() +
-                            themeMode.name.substring(1).toLowerCase();
+                        switch (themeMode) {
+                          case ThemeMode.system:
+                            return S.of(context).use_device_theme;
+                          case ThemeMode.light:
+                            return S.of(context).light_theme;
+                          case ThemeMode.dark:
+                            return S.of(context).dark_theme;
+                        }
                       },
                     ),
                     useGenericColor: false,

--- a/lib/src/screens/settings/other_settings_page.dart
+++ b/lib/src/screens/settings/other_settings_page.dart
@@ -56,7 +56,10 @@ class OtherSettingsPage extends BasePage {
                 ? ListItemSelector(
                     keyValue: "fee_priority",
                     label: S.of(context).settings_fee_priority,
-                    options: [_otherSettingsViewModel.transactionPriority.title],
+                    options: [
+                      _otherSettingsViewModel
+                          .localizedPriorityTitle(_otherSettingsViewModel.transactionPriority)
+                    ],
                     onTap: () async {
                       final items = priorityForWalletType(_otherSettingsViewModel.walletType);
 
@@ -98,7 +101,10 @@ class OtherSettingsPage extends BasePage {
                 : ListItemSelector(
                     keyValue: "fee_priority",
                     label: S.of(context).settings_fee_priority,
-                    options: [_otherSettingsViewModel.transactionPriority.title],
+                    options: [
+                      _otherSettingsViewModel
+                          .localizedPriorityTitle(_otherSettingsViewModel.transactionPriority)
+                    ],
                     onTap: () async {
                       final selectedAtIndex =
                           priorityForWalletType(_otherSettingsViewModel.walletType).indexOf(

--- a/lib/view_model/settings/other_settings_view_model.dart
+++ b/lib/view_model/settings/other_settings_view_model.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:cake_wallet/bitcoin/bitcoin.dart';
 import 'package:cake_wallet/entities/auto_generate_subaddress_status.dart';
 import 'package:cake_wallet/entities/priority_for_wallet_type.dart';
+import 'package:cake_wallet/generated/i18n.dart';
 import 'package:cake_wallet/store/settings_store.dart';
 import 'package:cake_wallet/utils/package_info.dart';
 import 'package:cake_wallet/view_model/send/send_view_model.dart';
@@ -104,8 +105,30 @@ abstract class OtherSettingsViewModelBase with Store {
         WalletType.arbitrum,
       ].contains(_wallet.type));
 
+  String localizedPriorityTitle(TransactionPriority priority) {
+    switch (priority.title.toLowerCase()) {
+      case 'automatic':
+        return S.current.automatic;
+      case 'slow':
+        return S.current.transaction_priority_slow;
+      case 'medium':
+        return S.current.transaction_priority_medium;
+      case 'fast':
+        return S.current.transaction_priority_fast;
+      case 'fastest':
+        return S.current.transaction_priority_fastest;
+      case 'custom':
+        return S.current.custom;
+      case 'regular':
+        return S.current.transaction_priority_regular;
+      default:
+        return priority.title;
+    }
+  }
+
   String getDisplayPriority(dynamic priority) {
     final _priority = priority as TransactionPriority;
+    final localized = localizedPriorityTitle(_priority);
 
     if ([
       WalletType.bitcoin,
@@ -114,14 +137,16 @@ abstract class OtherSettingsViewModelBase with Store {
       WalletType.dogecoin,
     ].contains(_wallet.type)) {
       final rate = bitcoin!.getFeeRate(_wallet, _priority);
-      return bitcoin!.bitcoinTransactionPriorityWithLabel(_priority, rate);
+      final labeled = bitcoin!.bitcoinTransactionPriorityWithLabel(_priority, rate);
+      return labeled.replaceFirst(_priority.title, localized);
     }
 
-    return priority.toString();
+    return localized;
   }
 
   String getDisplayBitcoinPriority(dynamic priority, int customValue) {
     final _priority = priority as TransactionPriority;
+    final localized = localizedPriorityTitle(_priority);
 
     if ([
       WalletType.bitcoin,
@@ -130,10 +155,12 @@ abstract class OtherSettingsViewModelBase with Store {
       WalletType.dogecoin,
     ].contains(_wallet.type)) {
       final rate = bitcoin!.getFeeRate(_wallet, _priority);
-      return bitcoin!.bitcoinTransactionPriorityWithLabel(_priority, rate, customRate: customValue);
+      final labeled =
+          bitcoin!.bitcoinTransactionPriorityWithLabel(_priority, rate, customRate: customValue);
+      return labeled.replaceFirst(_priority.title, localized);
     }
 
-    return priority.toString();
+    return localized;
   }
 
   void onDisplayPrioritySelected(TransactionPriority priority) =>

--- a/test/entities/fiat_currency_test.dart
+++ b/test/entities/fiat_currency_test.dart
@@ -1,0 +1,14 @@
+import 'package:cake_wallet/entities/fiat_currency.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('THB and TWD use the correct full names and country flags', () {
+    expect(FiatCurrency.thb.symbol, 'THB');
+    expect(FiatCurrency.thb.fullName, 'Thai Baht');
+    expect(FiatCurrency.thb.countryCode, 'tha');
+
+    expect(FiatCurrency.twd.symbol, 'TWD');
+    expect(FiatCurrency.twd.fullName, 'New Taiwan Dollar');
+    expect(FiatCurrency.twd.countryCode, 'twn');
+  });
+}


### PR DESCRIPTION
## Summary
- Fix swapped THB / TWD fiat names (`Thai Baht` vs `New Taiwan Dollar`) and the `Thaiwan` typo.
- Show localized strings for fee priority, fiat/swap API mode, theme mode, and sync-status display. Settings rows were using hardcoded English `.title` values even though `toString()` / ARB keys already existed.
- Cap the receive QR size against window height so the code is not clipped on short Linux desktop windows.

Fixes cake-tech/cake_wallet#3373
Fixes cake-tech/cake_wallet#3367
Fixes cake-tech/cake_wallet#3368
Fixes cake-tech/cake_wallet#3343

## Test plan
- [x] Settings → Display → currency list: THB is Thai Baht with Thailand flag; TWD is New Taiwan Dollar with Taiwan flag
- [x] Switch app language to Italian
- [x] Settings → Other → fee priority shows Automatica/Lento/Media/Veloce (or the existing Italian ARB values), not English Slow/Medium/Fast
- [x] Settings → Connections → Fiat API / Swap summary shows Abilitato / Solo Tor / Disabilitato
- [x] Settings → Display → appearance chips show device/light/dark translations, not `System`/`Light`/`Dark`
- [x] Settings → Display → sync status options use the existing ETA / remaining-blocks strings
- [x] Receive screen on a short landscape window (Linux or resized desktop): full QR visible and scannable; address remains copyable/shareable

