### PR TITLE
fix: persist Linux Hive keys so transaction notes survive restart

### DIFF
--- a/lib/entities/get_encryption_key.dart
+++ b/lib/entities/get_encryption_key.dart
@@ -1,19 +1,55 @@
+import 'dart:io';
+
 import 'package:cake_wallet/core/secure_storage.dart';
+import 'package:cake_wallet/entities/hive_key_file.dart';
 import 'package:cw_core/cake_hive.dart';
+import 'package:cw_core/root_dir.dart';
+
+const legacyTransactionDescriptionsBoxKey = 'transactionDescriptionsBoxKey';
 
 Future<List<int>> getEncryptionKey(
     {required String forKey, required SecureStorage secureStorage}) async {
-  final stringifiedKey = await secureStorage.read(key: 'transactionDescriptionsBoxKey');
-  List<int> key;
+  String? stringifiedKey = await _readStoredKey(secureStorage, forKey);
 
+  if (stringifiedKey == null && forKey != legacyTransactionDescriptionsBoxKey) {
+    stringifiedKey = await _readStoredKey(secureStorage, legacyTransactionDescriptionsBoxKey);
+  }
+
+  if (stringifiedKey == null && Platform.isLinux) {
+    final appDir = await getAppDir();
+    stringifiedKey = await readHiveKeyFile(appDir, forKey);
+    if (stringifiedKey == null && forKey != legacyTransactionDescriptionsBoxKey) {
+      stringifiedKey = await readHiveKeyFile(appDir, legacyTransactionDescriptionsBoxKey);
+    }
+  }
+
+  final List<int> key;
   if (stringifiedKey == null) {
     key = CakeHive.generateSecureKey();
-    final keyStringified = key.join(',');
-    String storageKey = 'transactionDescriptionsBoxKey';
-    await secureStorage.write(key: storageKey, value: keyStringified);
+    stringifiedKey = key.join(',');
   } else {
     key = stringifiedKey.split(',').map((i) => int.parse(i)).toList();
   }
 
+  try {
+    await secureStorage.write(key: forKey, value: stringifiedKey);
+  } catch (_) {
+    if (!Platform.isLinux) {
+      rethrow;
+    }
+  }
+
+  if (Platform.isLinux) {
+    await writeHiveKeyFile(await getAppDir(), forKey, stringifiedKey);
+  }
+
   return key;
+}
+
+Future<String?> _readStoredKey(SecureStorage secureStorage, String key) async {
+  try {
+    return await secureStorage.read(key: key);
+  } catch (_) {
+    return null;
+  }
 }

--- a/lib/entities/hive_key_file.dart
+++ b/lib/entities/hive_key_file.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+const hiveKeyFileDirectoryName = '.hive_keys';
+
+File hiveKeyFile(Directory appDir, String name) =>
+    File(p.join(appDir.path, hiveKeyFileDirectoryName, name));
+
+Future<String?> readHiveKeyFile(Directory appDir, String name) async {
+  try {
+    final file = hiveKeyFile(appDir, name);
+    if (!await file.exists()) {
+      return null;
+    }
+    final value = (await file.readAsString()).trim();
+    return value.isEmpty ? null : value;
+  } catch (_) {
+    return null;
+  }
+}
+
+Future<void> writeHiveKeyFile(Directory appDir, String name, String value) async {
+  final file = hiveKeyFile(appDir, name);
+  await file.parent.create(recursive: true);
+  await file.writeAsString(value, flush: true);
+  if (!Platform.isWindows) {
+    await Process.run('chmod', ['600', file.path]);
+  }
+}

--- a/test/entities/hive_key_file_test.dart
+++ b/test/entities/hive_key_file_test.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:cake_wallet/entities/hive_key_file.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_key_file_test');
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('round-trips a hive key file and ignores missing files', () async {
+    expect(await readHiveKeyFile(tempDir, 'ordersBoxKey'), isNull);
+
+    await writeHiveKeyFile(tempDir, 'ordersBoxKey', '1,2,3,4');
+
+    expect(await readHiveKeyFile(tempDir, 'ordersBoxKey'), '1,2,3,4');
+    expect(hiveKeyFile(tempDir, 'ordersBoxKey').existsSync(), isTrue);
+  });
+}

--- a/tool/configure.dart
+++ b/tool/configure.dart
@@ -2099,7 +2099,8 @@ class DefaultSecureStorage extends SecureStorage {
   Future<void> write({required String key, required String? value}) async {
     // delete the value before writing on macOS because of a weird bug
     // https://github.com/mogol/flutter_secure_storage/issues/581
-    if (Platform.isMacOS) {
+    // Linux libsecret has a similar persist-across-restarts failure mode.
+    if (Platform.isMacOS || Platform.isLinux) {
       await _secureStorage.delete(key: key);
     }
     await _secureStorage.write(key: key, value: value);


### PR DESCRIPTION
## Summary
- On Linux, `flutter_secure_storage` often drops the Hive key for `TransactionDescriptions` between launches, so a new key is generated and existing notes cannot be decrypted.
- Persist that key in a `0600` file next to app data, and still try secure storage first.
- Honor the per-box `forKey` instead of always reading the notes key, with a fallback to the old shared key so existing boxes still open.

Fixes cake-tech/cake_wallet#3495

## Test plan
- [x] Linux: add a transaction note, quit the app fully, reopen, and confirm the note is still there
- [x] Linux: confirm `~/.config/cake_wallet/.hive_keys/` (or the active app dir) contains the key file with mode `600`
- [x] macOS / Windows / mobile: notes still persist as before
- [x] `flutter test test/entities/hive_key_file_test.dart`



