### PR TITLE
fix: enter Lightning invoice amounts in sats

### DIFF
--- a/lib/new-ui/pages/receive_page.dart
+++ b/lib/new-ui/pages/receive_page.dart
@@ -73,6 +73,7 @@ class _NewReceivePageState extends State<NewReceivePage> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (widget.lightningMode) {
+        widget.addressListViewModel.setTokenCurrency(CryptoCurrency.btcln);
         widget.receiveOptionViewModel.selectReceiveOption(
           widget.receiveOptionViewModel.options
                   .firstWhereOrNull((item) => item.value.contains("Lightning")) ??

--- a/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
+++ b/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
@@ -88,7 +88,12 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
       );
 
   void setTokenCurrency(Currency curr) {
-    if (curr == wallet.currency || curr == CryptoCurrency.btcln) {
+    if (curr == CryptoCurrency.btcln) {
+      tokenCurrency = null;
+      selectedCurrency = CryptoCurrency.btcln;
+      return;
+    }
+    if (curr == wallet.currency) {
       tokenCurrency = null;
       selectedCurrency = wallet.currency;
       return;


### PR DESCRIPTION
## Summary
- LN receive remapped `btcln` to BTC, so the default `sats (LN)` display mode never applied and the amount field stayed in BTC.
- Keep Lightning selected as `btcln` and set that currency when opening receive in Lightning mode.

Fixes cake-tech/cake_wallet#3040

## Test plan
- [x] Settings amount display is the default `sats (LN)`
- [x] BTC wallet → Lightning receive → Set amount: field unit is `sats`, not `BTC`
- [x] On-chain BTC receive still follows the BTC / sats setting
- [ ] Switching the amount picker to fiat still works


