### PR TITLE
fix: shrink the desktop balance card so history stays on screen

### DIFF
--- a/lib/new-ui/widgets/coins_page/cards/cards_view.dart
+++ b/lib/new-ui/widgets/coins_page/cards/cards_view.dart
@@ -8,6 +8,7 @@ import 'package:cake_wallet/generated/i18n.dart';
 import 'package:cake_wallet/new-ui/modal_navigator.dart';
 import 'package:cake_wallet/new-ui/pages/send_page.dart';
 import 'package:cake_wallet/routes.dart';
+import 'package:cake_wallet/utils/device_info.dart';
 import 'package:cake_wallet/utils/feature_flag.dart';
 import 'package:cake_wallet/utils/payment_request.dart';
 import 'package:cake_wallet/utils/responsive_layout_util.dart';
@@ -254,8 +255,13 @@ class _CardsViewState extends State<CardsView> {
     }
   }
 
-  double get effectiveCardWidth => min(MediaQuery.of(context).size.width * 0.878,
-      responsiveLayoutUtil.shouldRenderMobileUI ? 768 : 512);
+  double get effectiveCardWidth {
+    final screenWidth = MediaQuery.of(context).size.width;
+    if (DeviceInfo.instance.isDesktop) {
+      return min(screenWidth * 0.4, 320);
+    }
+    return min(screenWidth * 0.878, responsiveLayoutUtil.shouldRenderMobileUI ? 768 : 512);
+  }
 
   double _getBoxHeight(int numCards, double overlapAmount) {
     return


### PR DESCRIPTION
## Summary
- Portrait desktop windows were treated as mobile UI, so the balance card could grow to 768px and push transaction history off the page.
- Cap the desktop card at 320px (40% of width, whichever is smaller).

Fixes cake-tech/cake_wallet#3255

## Test plan
- [ ] Linux / macOS / Windows: dashboard card is credit-card sized and history is visible without scrolling past a giant card
- [ ] Phone / narrow window: card still uses the existing mobile width


Made with [Cursor](https://cursor.com)