### PR TITLE
fix: drop the stale wallet list entry after a rename

### DIFF
--- a/cw_core/lib/wallet_service.dart
+++ b/cw_core/lib/wallet_service.dart
@@ -39,9 +39,22 @@ abstract class WalletService<N extends WalletCredentials, RFS extends WalletCred
     await copyWalletFilesTo(fromName: currentName, toName: newName, type: getType());
     await saveBackup(newName);
 
+    final typeDir = await pathForWalletTypeDir(type: getType());
     currentWalletInfo.id = WalletBase.idFor(newName, getType());
     currentWalletInfo.name = newName;
+    currentWalletInfo.dirPath = p.join(typeDir, newName);
+    currentWalletInfo.path = await pathForWallet(name: newName, type: getType());
     await currentWalletInfo.save();
+
+    final staleRows = await WalletInfo.selectList(
+      'name = ? AND type = ?',
+      [currentName, getType().index],
+    );
+    for (final stale in staleRows) {
+      if (stale.internalId != currentWalletInfo.internalId) {
+        await WalletInfo.delete(stale);
+      }
+    }
 
     final oldDir = Directory(p.join(await pathForWalletTypeDir(type: getType()), currentName));
     if (oldDir.existsSync()) {

--- a/lib/view_model/wallet_list/wallet_edit_view_model.dart
+++ b/lib/view_model/wallet_list/wallet_edit_view_model.dart
@@ -56,6 +56,11 @@ abstract class WalletEditViewModelBase with Store {
         newName,
         password: password,
       );
+      await _walletListViewModel.syncOpenedWalletAfterRename(
+        walletItem.type,
+        walletItem.name,
+        newName,
+      );
     }
 
     _walletListViewModel.updateList();

--- a/lib/view_model/wallet_list/wallet_list_view_model.dart
+++ b/lib/view_model/wallet_list/wallet_list_view_model.dart
@@ -7,9 +7,12 @@ import 'package:cake_wallet/entities/wallet_manager.dart';
 import 'package:mobx/mobx.dart';
 import 'package:cake_wallet/store/app_store.dart';
 import 'package:cake_wallet/view_model/wallet_list/wallet_list_item.dart';
+import 'package:cw_core/pathForWallet.dart';
+import 'package:cw_core/wallet_base.dart';
 import 'package:cw_core/wallet_info.dart';
 import 'package:cw_core/wallet_type.dart';
 import 'package:cake_wallet/wallet_types.g.dart';
+import 'package:path/path.dart' as p;
 
 part 'wallet_list_view_model.g.dart';
 
@@ -239,6 +242,20 @@ abstract class WalletListViewModelBase with Store {
         await reorderAccordingToWalletList();
         break;
     }
+  }
+
+  Future<void> syncOpenedWalletAfterRename(WalletType type, String oldName, String newName) async {
+    final wallet = _appStore.wallet;
+    if (wallet == null || wallet.type != type || wallet.name != oldName) {
+      return;
+    }
+
+    final typeDir = await pathForWalletTypeDir(type: type);
+    wallet.walletInfo.name = newName;
+    wallet.walletInfo.id = WalletBase.idFor(newName, type);
+    wallet.walletInfo.dirPath = p.join(typeDir, newName);
+    wallet.walletInfo.path = await pathForWallet(name: newName, type: type);
+    await wallet.walletInfo.save();
   }
 
   WalletListItem convertWalletInfoToWalletListItem(WalletInfo info) {


### PR DESCRIPTION
## Summary
- Renaming a wallet updated SQLite but left the open `WalletInfo` on the old name. The next save wrote that old row back, so the list showed both names.
- Tapping the old name created an empty snapshot directory and crashed with `FormatException`.
- Update paths on rename, delete leftover rows for the old name, and sync the open wallet's `WalletInfo`.

Fixes cake-tech/cake_wallet#3210

## Test plan
- [ ] In a single-seed group, rename the Bitcoin wallet
- [ ] Wallet list shows only the new name
- [ ] Tapping the renamed wallet opens it (no `FormatException`)
- [ ] Restart the app: still one Bitcoin wallet with the new name


Made with [Cursor](https://cursor.com)