### PR TITLE
fix: allow spending with LAN-only node

### DIFF
--- a/lib/reactions/check_connection.dart
+++ b/lib/reactions/check_connection.dart
@@ -28,20 +28,24 @@ void startCheckConnectionReaction(WalletBase wallet, SettingsStore settingsStore
     try {
       final connectivityResult = await (Connectivity().checkConnectivity());
 
+      int? chainId;
+      if (isEVMCompatibleChain(wallet.type)) {
+        chainId = evm!.getSelectedChainId(wallet);
+      }
+
+      final node = settingsStore.getCurrentNode(wallet.type, chainId: chainId);
+
       if (connectivityResult.contains(ConnectivityResult.none)) {
-        wallet.syncStatus = FailedSyncStatus();
-        return;
+        // Still try node even when OS says no network - it might be a LAN node.
+        if (!await node.requestNode()) {
+          wallet.syncStatus = FailedSyncStatus();
+          return;
+        }
       }
 
       if (wallet.type != WalletType.bitcoin &&
           (wallet.syncStatus is LostConnectionSyncStatus ||
               wallet.syncStatus is FailedSyncStatus)) {
-        int? chainId;
-        if (isEVMCompatibleChain(wallet.type)) {
-          chainId = evm!.getSelectedChainId(wallet);
-        }
-
-        final node = settingsStore.getCurrentNode(wallet.type, chainId: chainId);
         final alive = await node.requestNode();
 
         if (alive) {


### PR DESCRIPTION
# Description

On LANs that do not have internet but have a valid node we prevented users from spending.

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
