### PR TITLE
Move `updateBleState` to connection page initialization

### DIFF
--- a/lib/src/screens/connect_device/connect_device_page.dart
+++ b/lib/src/screens/connect_device/connect_device_page.dart
@@ -120,6 +120,8 @@ class ConnectDevicePageBodyState extends State<ConnectDevicePageBody> {
       }
 
       if (widget.hardwareWalletVM.hasBluetooth) {
+        widget.hardwareWalletVM.updateBleState();
+
         _longWaitTimer = Timer(const Duration(seconds: 10), () {
           if (widget.hardwareWalletVM.isBleEnabled && bleDevices.isEmpty) {
             setState(() => longWait = true);

--- a/lib/view_model/hardware_wallet/ledger_view_model.dart
+++ b/lib/view_model/hardware_wallet/ledger_view_model.dart
@@ -42,8 +42,6 @@ abstract class LedgerViewModelBase extends HardwareWalletViewModel with Store {
         }
       });
 
-      updateBleState();
-
       if (!Platform.isIOS) {
         ledgerPlusUSB = sdk.LedgerInterface.usb();
       }

--- a/lib/view_model/hardware_wallet/trezor_connect_view_model.dart
+++ b/lib/view_model/hardware_wallet/trezor_connect_view_model.dart
@@ -39,7 +39,6 @@ abstract class TrezorConnectViewModelBase extends HardwareWalletViewModel with S
           _initBLE();
         }
       });
-      updateBleState();
 
       if (!Platform.isIOS) {
         trezorUSB = sdk.TrezorInterface.usb();


### PR DESCRIPTION
# Description

Refactored the code to move the `updateBleState` function call to the initialization of the connection page. This ensures that the BLE state is updated during the page's lifecycle, improving reliability and reducing potential errors.

# Pull Request - Checklist  

- [x] Initial Manual Tests Passed
- [x] Double check modified code and verify it with the feature/task requirements
- [x] Format code
- [x] Look for code duplication
- [x] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 