### PR TITLE
fix rive_common dependency

### DIFF
--- a/pubspec_overrides.yaml
+++ b/pubspec_overrides.yaml
@@ -1224,8 +1224,8 @@ dependency_overrides:
       ref: 2dbfe918a3d38340f378ab2734b1c97ebcb4ab26
   rive_common:
     git:
-      url: https://github.com/MrCyjaneK/rive_common
-      ref: 9457422fce3f1524437f6a1429200f048931a2fe
+      url: https://github.com/malik1004x/rive_common
+      ref: 34ef174e87dc4a29e728babfaad8dd9464b704ae
   riverpod:
     git:
       url: https://github.com/rrousselGit/riverpod


### PR DESCRIPTION
Issue Number (if Applicable): Fixes #

# Description

The current ref for the `rive_common` dependency is unable to be built for iOS, most likely due to a bug with the dependency pinning generator. This fixes the dependency by removing stale files (these files are not present in the current pub.dev version and are old versions of the iOS implementation left over from older releases of the package). 

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
