### PR TITLE
docs: link README build instructions to platform guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,13 @@ We have excellent user guides, which are also open-source and open for contribut
 
 # Build Instructions
 
-More instructions to follow
+Platform-specific build instructions are available in `docs/builds/`:
 
-For instructions on how to build for Android: please view file `howto-build-android.md`
+- [Android](docs/builds/ANDROID.md)
+- [iOS](docs/builds/IOS.md)
+- [Linux](docs/builds/LINUX.md)
+- [macOS](docs/builds/MACOS.md)
+- [Windows](docs/builds/WINDOWS.md)
 
 # Contributing
 


### PR DESCRIPTION
## Summary
- Replace the placeholder README build section with links to the existing platform-specific build guides
- Remove the stale reference to `howto-build-android.md`, which is no longer present in the repository

Fixes #3559.

## Testing
- `git diff --check`