### PR TITLE
fix: fallback to public relays for Nostr profile resolution

### DIFF
--- a/lib/core/address_resolver/nostr/nostr_address_provider.dart
+++ b/lib/core/address_resolver/nostr/nostr_address_provider.dart
@@ -33,7 +33,7 @@ class NostrAddressProvider extends AddressLookupProvider {
       final profile = await NostrProfileHandler.queryProfile(query);
       if (profile == null) return [];
 
-      final data = await NostrProfileHandler.processRelays(profile, query);
+      final data = await NostrProfileHandler.processRelays(profile);
       if (data == null) return [];
 
       final result = <CryptoCurrency, String>{};

--- a/lib/core/address_resolver/nostr/nostr_api.dart
+++ b/lib/core/address_resolver/nostr/nostr_api.dart
@@ -6,46 +6,58 @@ import 'package:nostr_tools/nostr_tools.dart';
 import 'dart:async' show Completer, TimeoutException, runZonedGuarded;
 
 class NostrProfileHandler {
-  static final relayToDomainMap = {
-    'relay.snort.social': 'snort.social',
-  };
+  /// Well-known public relays, queried when the author's NIP-05 relay hints
+  /// are missing or none of them store the profile metadata event (kind 0).
+  /// Ordered by measured kind-0 coverage for a broad set of popular profiles.
+  static const fallbackRelays = <String>[
+    'wss://relay.nos.social',
+    'wss://nos.lol',
+    'wss://offchain.pub',
+    'wss://relay.damus.io',
+    'wss://relay.nostr.band',
+    'wss://purplepag.es',
+    'wss://relay.primal.net',
+  ];
 
   static final Nip05 _nip05 = Nip05();
 
   static Future<ProfilePointer?> queryProfile(String nip05Address) async {
     final profile = await _nip05.queryProfile(nip05Address);
-    if (profile?.pubkey != null && profile?.relays?.isNotEmpty == true) {
+    if (profile?.pubkey != null) {
       return profile;
     }
     return null;
   }
 
-  static Future<UserMetadata?> processRelays(
-    ProfilePointer profile,
-    String nip05Address,
-  ) async {
-    final userDomain = _extractDomain(nip05Address);
+  static Future<UserMetadata?> processRelays(ProfilePointer profile) async {
     const int metaKind = 0;
 
-    // Domain-matched relays first
-    for (final String relayUrl in profile.relays ?? []) {
-      final relayDomain =
-          relayToDomainMap[_getDomainFromRelayUrl(relayUrl)] ?? _getDomainFromRelayUrl(relayUrl);
+    // Author-declared relays first, then well-known public relays.
+    final seen = <String>{};
+    final relays = <String>[
+      ...?(profile.relays ?? const <String>[]),
+      ...fallbackRelays,
+    ].where((String relayUrl) => seen.add(relayUrl)).toList();
 
-      if (relayDomain == userDomain) {
-        final data = await _fetchInfoFromRelay(relayUrl, profile.pubkey, [metaKind]);
-        if (data != null) return data;
-      }
+    // Query in parallel and finish as soon as the first relay returns the
+    // metadata. _fetchInfoFromRelay swallows all errors and always completes,
+    // so the whole step is bounded by _relayTimeout.
+    final completer = Completer<UserMetadata?>();
+    var remaining = relays.length;
+
+    for (final relayUrl in relays) {
+      _fetchInfoFromRelay(relayUrl, profile.pubkey, [metaKind]).then((data) {
+        if (completer.isCompleted) return;
+        if (data != null) {
+          completer.complete(data);
+        } else {
+          remaining--;
+          if (remaining == 0) completer.complete(null);
+        }
+      });
     }
 
-    // Then try every remaining relay
-    for (final String relayUrl in profile.relays ?? []) {
-      final data = await _fetchInfoFromRelay(relayUrl, profile.pubkey, [metaKind]);
-      if (data != null) return data;
-    }
-
-    // Nothing found
-    return null;
+    return completer.future;
   }
 
   static const Duration _relayTimeout = Duration(seconds: 3);
@@ -113,15 +125,5 @@ class NostrProfileHandler {
       host: uri.host,
       port: uri.hasPort ? uri.port : 443,
     ).toString();
-  }
-
-  static String _extractDomain(String nip05) => nip05.split('@').last;
-
-  static String _getDomainFromRelayUrl(String url) {
-    try {
-      return Uri.parse(url).host;
-    } catch (_) {
-      return '';
-    }
   }
 }

--- a/test/core/address_resolver/nostr/nostr_api_test.dart
+++ b/test/core/address_resolver/nostr/nostr_api_test.dart
@@ -1,0 +1,24 @@
+import 'package:cake_wallet/core/address_resolver/nostr/nostr_api.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('NostrProfileHandler.fallbackRelays', () {
+    test('is non-empty and contains no duplicates', () {
+      expect(NostrProfileHandler.fallbackRelays, isNotEmpty);
+      expect(
+        NostrProfileHandler.fallbackRelays.toSet().length,
+        NostrProfileHandler.fallbackRelays.length,
+      );
+    });
+
+    test('leads with relays measured to cover popular profiles', () {
+      expect(
+        NostrProfileHandler.fallbackRelays.first,
+        'wss://relay.nos.social',
+      );
+      expect(NostrProfileHandler.fallbackRelays, contains('wss://nos.lol'));
+      expect(NostrProfileHandler.fallbackRelays, contains('wss://offchain.pub'));
+      expect(NostrProfileHandler.fallbackRelays, contains('wss://relay.primal.net'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Nostr (NIP-05) address resolution in the send screen now falls back to
well-known public relays when the author's NIP-05 relay hints are missing or
none of them serve the profile metadata (kind 0), and resolves as long as a
single relay has the profile.

- `queryProfile` no longer rejects NIP-05 profiles whose `nostr.json` has no
  `relays` map (e.g. `cakewallet@cakewallet.com` and `monero@monero.com` —
  both verified live to have a `names` entry and no `relays` entry, so they
  could never resolve before).
- Author relays are still tried first; fallbacks are queried in parallel and
  the first hit wins (bounded by the existing 3s relay timeout, replacing a
  sequential worst case of N×3s).
- Fallback set chosen from a measured sweep (kind-0 metadata coverage for 11
  popular profiles): `relay.nos.social` (fastest, 10/11), `nos.lol` (9/11),
  `offchain.pub` (7/11); `relay.primal.net` covers only Primal-app profiles,
  so it is last. Removed the obsolete domain-matching relay flow.

## Test plan

- New unit test for the fallback list:
  `test/core/address_resolver/nostr/nostr_api_test.dart` (all tests passed
  locally on flutter 3.47.2).
- Manual: paste `vik@monero.com` in the XMR send screen → should resolve to
  the Monero address in the profile.
- Note: the full `flutter test` / analyzer cannot run in a bare checkout
  (pubspec.yaml is generated; see `scripts/linux/app_config.sh`), so CI's
  Linux container (flutter 3.41.9) is authoritative for the rest of the
  suite.
