### PR TITLE
On Linux I get this glitch when trying to sign, this should fix it.

### DIFF
--- a/linux/com.cakewallet.CakeWallet.desktop
+++ b/linux/com.cakewallet.CakeWallet.desktop
@@ -6,4 +6,4 @@ Comment=A noncustodial multi-currency wallet
 Categories=Office;Finance;
 Terminal=false
 Icon=com.cakewallet.CakeWallet
-Exec=cake_wallet
+Exec=env NO_AT_BRIDGE=1 GTK_A11Y=none GTK_MODULES= cake_wallet

--- a/linux/main.cc
+++ b/linux/main.cc
@@ -1,6 +1,18 @@
 #include "my_application.h"
 
+#include <stdlib.h>
+
 int main(int argc, char** argv) {
+  // Flutter Linux can freeze for ~25s when a text field is focused (Sign /
+  // Verify, wallet password) if GTK talks to AT-SPI on the UI thread.
+  // Linux Mint sets GTK_MODULES=gail:atk-bridge, which loads that bridge.
+  // https://github.com/flutter/flutter/issues/153560
+  // https://github.com/cake-tech/cake_wallet/issues/2608
+  setenv("NO_AT_BRIDGE", "1", 1);
+  setenv("GTK_A11Y", "none", 1);
+  setenv("GTK_MODULES", "", 1);
+  setenv("GTK3_MODULES", "", 1);
+
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }


### PR DESCRIPTION
On Cake Wallet Linux 6.3.0 glitch.

When signing the app crashes, apparently it's something to do with flutter and Nvidia on specifically Linux. I tested this fix and it works, doesn't seem to cause any problems, I am using the version with the fix right now and nothing is obviously broken.

Here is the stupid AI blurb:

Text fields (Sign/Verify, wallet password) freeze on Linux Mint because Flutter talks to the AT-SPI accessibility bridge on the GTK thread.

Issue Number (if Applicable): Fixes #

# Description

Fix crash on Linux from signing

# Pull Request - Checklist  

- [ ] Initial Manual Tests Passed
- [ ] Double check modified code and verify it with the feature/task requirements
- [ ] Format code
- [ ] Look for code duplication
- [ ] Clear naming for variables and methods
- [ ] Manual tests in accessibility mode (TalkBack on Android) passed 
